### PR TITLE
Fix bug for GPU users

### DIFF
--- a/desc/utils.py
+++ b/desc/utils.py
@@ -1,7 +1,6 @@
 import numpy as np
 import warnings
 from termcolor import colored
-from desc.backend import jnp
 
 # Helper Classes -------------------------------------------------------------
 
@@ -239,7 +238,7 @@ def equals(a, b):
         a == b
 
     """
-    if isinstance(a, (np.ndarray, jnp.ndarray)):
+    if hasattr(a, "shape") and hasattr(b, "shape"):
         return a.shape == b.shape and np.allclose(a, b)
     if isinstance(a, dict):
         if a.keys() != b.keys():


### PR DESCRIPTION
Recently some import statements were reordered and moved
around, causing the backend to be imported and set before
the input from the user was parsed, causing the device to
always be set to CPU and ignoring and user request to use GPU.

Import statements have now been fixed which should resolve the
issue.