### PR TITLE
Speed up VMECIO.save

### DIFF
--- a/desc/transform.py
+++ b/desc/transform.py
@@ -508,7 +508,11 @@ class Transform(IOAble):
         """
         if not self.built_pinv:
             self.build_pinv()
-        return jnp.matmul(self.matrices["pinv"], self.grid.weights * x)
+        if x.ndim > 1:
+            weights = self.grid.weights.reshape((-1, 1))
+        else:
+            weights = self.grid.weights
+        return jnp.matmul(self.matrices["pinv"], weights * x)
 
     def project(self, y):
         """Project vector y onto basis.

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -112,11 +112,7 @@ class VMECIO:
         eq.L_lmn = fourier_to_zernike(m, n, L_mn, eq.L_basis)
 
         # apply boundary conditions
-        BC = eq.surface.get_constraint(
-            eq.R_basis,
-            eq.Z_basis,
-            eq.L_basis,
-        )
+        BC = eq.surface.get_constraint(eq.R_basis, eq.Z_basis, eq.L_basis,)
         eq.x = BC.make_feasible(eq.x)
 
         return eq
@@ -513,6 +509,9 @@ class VMECIO:
         zmax_surf.units = "m"
         zmax_surf[:] = np.amax(np.abs(coords["Z"]))
 
+        half_grid = LinearGrid(M=2 * M_nyq + 1, N=2 * N_nyq + 1, NFP=NFP, rho=r_half)
+        jacobian_half_grid = eq.compute_jacobian(half_grid)
+
         # Jacobian
         timer.start("Jacobian")
         if verbose > 0:
@@ -529,13 +528,16 @@ class VMECIO:
             m = full_basis.modes[:, 1]
             n = full_basis.modes[:, 2]
         x_mn = np.zeros((surfs - 1, m.size))
-        for k in range(surfs - 1):
-            grid = LinearGrid(M=2 * M_nyq + 1, N=2 * N_nyq + 1, NFP=NFP, rho=r_half[k])
-            data = eq.compute_jacobian(grid)["g"]
-            if eq.sym:
-                x_mn[k, :] = cos_transform.fit(data)
-            else:
-                x_mn[k, :] = full_transform.fit(data)
+        data = (
+            jacobian_half_grid["g"]
+            .reshape(half_grid.M, half_grid.L, half_grid.N, order="F")
+            .transpose((1, 0, 2))
+            .reshape((half_grid.L, -1))
+        )
+        if eq.sym:
+            x_mn[:, :] = cos_transform.fit(data.T).T
+        else:
+            x_mn[:, :] = full_transform.fit(data.T).T
         xm, xn, s, c = ptolemy_identity_rev(m, n, x_mn)
         gmnc[0, :] = 0
         gmnc[1:, :] = c
@@ -545,6 +547,8 @@ class VMECIO:
         timer.stop("Jacobian")
         if verbose > 1:
             timer.disp("Jacobian")
+
+        B_field_half_grid = eq.compute_magnetic_field(half_grid)
 
         # |B|
         timer.start("|B|")
@@ -562,13 +566,16 @@ class VMECIO:
             m = full_basis.modes[:, 1]
             n = full_basis.modes[:, 2]
         x_mn = np.zeros((surfs - 1, m.size))
-        for k in range(surfs - 1):
-            grid = LinearGrid(M=2 * M_nyq + 1, N=2 * N_nyq + 1, NFP=NFP, rho=r_half[k])
-            data = eq.compute_magnetic_field(grid)["|B|"]
-            if eq.sym:
-                x_mn[k, :] = cos_transform.fit(data)
-            else:
-                x_mn[k, :] = full_transform.fit(data)
+        data = (
+            B_field_half_grid["|B|"]
+            .reshape(half_grid.M, half_grid.L, half_grid.N, order="F")
+            .transpose((1, 0, 2))
+            .reshape((half_grid.L, -1))
+        )
+        if eq.sym:
+            x_mn[:, :] = cos_transform.fit(data.T).T
+        else:
+            x_mn[:, :] = full_transform.fit(data.T).T
         xm, xn, s, c = ptolemy_identity_rev(m, n, x_mn)
         bmnc[0, :] = 0
         bmnc[1:, :] = c
@@ -599,13 +606,16 @@ class VMECIO:
             m = full_basis.modes[:, 1]
             n = full_basis.modes[:, 2]
         x_mn = np.zeros((surfs - 1, m.size))
-        for k in range(surfs - 1):
-            grid = LinearGrid(M=2 * M_nyq + 1, N=2 * N_nyq + 1, NFP=NFP, rho=r_half[k])
-            data = eq.compute_magnetic_field(grid)["B^theta"]
-            if eq.sym:
-                x_mn[k, :] = cos_transform.fit(data)
-            else:
-                x_mn[k, :] = full_transform.fit(data)
+        data = (
+            B_field_half_grid["B^theta"]
+            .reshape(half_grid.M, half_grid.L, half_grid.N, order="F")
+            .transpose((1, 0, 2))
+            .reshape((half_grid.L, -1))
+        )
+        if eq.sym:
+            x_mn[:, :] = cos_transform.fit(data.T).T
+        else:
+            x_mn[:, :] = full_transform.fit(data.T).T
         xm, xn, s, c = ptolemy_identity_rev(m, n, x_mn)
         bsupumnc[0, :] = 0
         bsupumnc[1:, :] = c
@@ -636,13 +646,16 @@ class VMECIO:
             m = full_basis.modes[:, 1]
             n = full_basis.modes[:, 2]
         x_mn = np.zeros((surfs - 1, m.size))
-        for k in range(surfs - 1):
-            grid = LinearGrid(M=2 * M_nyq + 1, N=2 * N_nyq + 1, NFP=NFP, rho=r_half[k])
-            data = eq.compute_magnetic_field(grid)["B^zeta"]
-            if eq.sym:
-                x_mn[k, :] = cos_transform.fit(data)
-            else:
-                x_mn[k, :] = full_transform.fit(data)
+        data = (
+            B_field_half_grid["B^zeta"]
+            .reshape(half_grid.M, half_grid.L, half_grid.N, order="F")
+            .transpose((1, 0, 2))
+            .reshape((half_grid.L, -1))
+        )
+        if eq.sym:
+            x_mn[:, :] = cos_transform.fit(data.T).T
+        else:
+            x_mn[:, :] = full_transform.fit(data.T).T
         xm, xn, s, c = ptolemy_identity_rev(m, n, x_mn)
         bsupvmnc[0, :] = 0
         bsupvmnc[1:, :] = c
@@ -652,6 +665,9 @@ class VMECIO:
         timer.stop("B^zeta")
         if verbose > 1:
             timer.disp("B^zeta")
+
+        full_grid = LinearGrid(M=2 * M_nyq + 1, N=2 * N_nyq + 1, NFP=NFP, rho=r_full)
+        B_field_full_grid = eq.compute_magnetic_field(full_grid)
 
         # B_psi
         timer.start("B_psi")
@@ -673,14 +689,14 @@ class VMECIO:
             m = full_basis.modes[:, 1]
             n = full_basis.modes[:, 2]
         x_mn = np.zeros((surfs, m.size))
-        for k in range(surfs):
-            grid = LinearGrid(M=2 * M_nyq + 1, N=2 * N_nyq + 1, NFP=NFP, rho=r_full[k])
-            data = eq.compute_magnetic_field(grid)["B_rho"] / (2 * r_full[k])
-            # B_rho -> B_psi conversion: d(rho)/d(s) = 1/(2*rho)
-            if eq.sym:
-                x_mn[k, :] = sin_transform.fit(data)
-            else:
-                x_mn[k, :] = full_transform.fit(data)
+        data = B_field_full_grid["B_rho"].reshape(
+            full_grid.M, full_grid.L, full_grid.N, order="F"
+        ).transpose((1, 0, 2)).reshape((full_grid.L, -1)) / (2 * r_full[:, np.newaxis])
+        # B_rho -> B_psi conversion: d(rho)/d(s) = 1/(2*rho)
+        if eq.sym:
+            x_mn[:, :] = sin_transform.fit(data.T).T
+        else:
+            x_mn[:, :] = full_transform.fit(data.T).T
         xm, xn, s, c = ptolemy_identity_rev(m, n, x_mn)
         bsubsmns[:, :] = s
         bsubsmns[0, :] = (  # linear extrapolation for coefficient at the magnetic axis
@@ -716,13 +732,16 @@ class VMECIO:
             m = full_basis.modes[:, 1]
             n = full_basis.modes[:, 2]
         x_mn = np.zeros((surfs - 1, m.size))
-        for k in range(surfs - 1):
-            grid = LinearGrid(M=2 * M_nyq + 1, N=2 * N_nyq + 1, NFP=NFP, rho=r_half[k])
-            data = eq.compute_magnetic_field(grid)["B_theta"]
-            if eq.sym:
-                x_mn[k, :] = cos_transform.fit(data)
-            else:
-                x_mn[k, :] = full_transform.fit(data)
+        data = (
+            B_field_half_grid["B_theta"]
+            .reshape(half_grid.M, half_grid.L, half_grid.N, order="F")
+            .transpose((1, 0, 2))
+            .reshape((half_grid.L, -1))
+        )
+        if eq.sym:
+            x_mn[:, :] = cos_transform.fit(data.T).T
+        else:
+            x_mn[:, :] = full_transform.fit(data.T).T
         xm, xn, s, c = ptolemy_identity_rev(m, n, x_mn)
         bsubumnc[0, :] = 0
         bsubumnc[1:, :] = c
@@ -753,13 +772,16 @@ class VMECIO:
             m = full_basis.modes[:, 1]
             n = full_basis.modes[:, 2]
         x_mn = np.zeros((surfs - 1, m.size))
-        for k in range(surfs - 1):
-            grid = LinearGrid(M=2 * M_nyq + 1, N=2 * N_nyq + 1, NFP=NFP, rho=r_half[k])
-            data = eq.compute_magnetic_field(grid)["B_zeta"]
-            if eq.sym:
-                x_mn[k, :] = cos_transform.fit(data)
-            else:
-                x_mn[k, :] = full_transform.fit(data)
+        data = (
+            B_field_half_grid["B_zeta"]
+            .reshape(half_grid.M, half_grid.L, half_grid.N, order="F")
+            .transpose((1, 0, 2))
+            .reshape((half_grid.L, -1))
+        )
+        if eq.sym:
+            x_mn[:, :] = cos_transform.fit(data.T).T
+        else:
+            x_mn[:, :] = full_transform.fit(data.T).T
         xm, xn, s, c = ptolemy_identity_rev(m, n, x_mn)
         bsubvmnc[0, :] = 0
         bsubvmnc[1:, :] = c
@@ -769,6 +791,9 @@ class VMECIO:
         timer.stop("B_zeta")
         if verbose > 1:
             timer.disp("B_zeta")
+
+        jacobian_full_grid = eq.compute_jacobian(full_grid)
+        current_full_grid = eq.compute_current_density(full_grid)
 
         # J^theta * sqrt(g)
         timer.start("J^theta")
@@ -792,16 +817,16 @@ class VMECIO:
             m = full_basis.modes[:, 1]
             n = full_basis.modes[:, 2]
         x_mn = np.zeros((surfs, m.size))
-        for k in range(surfs):
-            grid = LinearGrid(M=2 * M_nyq + 1, N=2 * N_nyq + 1, NFP=NFP, rho=r_full[k])
-            data = (
-                eq.compute_current_density(grid)["J^theta"]
-                * eq.compute_jacobian(grid)["g"]
-            )
-            if eq.sym:
-                x_mn[k, :] = cos_transform.fit(data)
-            else:
-                x_mn[k, :] = full_transform.fit(data)
+        data = (
+            (current_full_grid["J^theta"] * jacobian_full_grid["g"])
+            .reshape(full_grid.M, full_grid.L, full_grid.N, order="F")
+            .transpose((1, 0, 2))
+            .reshape((full_grid.L, -1))
+        )
+        if eq.sym:
+            x_mn[:, :] = cos_transform.fit(data.T).T
+        else:
+            x_mn[:, :] = full_transform.fit(data.T).T
         xm, xn, s, c = ptolemy_identity_rev(m, n, x_mn)
         currumnc[:, :] = c
         currumnc[0, :] = (  # linear extrapolation for coefficient at the magnetic axis
@@ -839,16 +864,16 @@ class VMECIO:
             m = full_basis.modes[:, 1]
             n = full_basis.modes[:, 2]
         x_mn = np.zeros((surfs, m.size))
-        for k in range(surfs):
-            grid = LinearGrid(M=2 * M_nyq + 1, N=2 * N_nyq + 1, NFP=NFP, rho=r_full[k])
-            data = (
-                eq.compute_current_density(grid)["J^zeta"]
-                * eq.compute_jacobian(grid)["g"]
-            )
-            if eq.sym:
-                x_mn[k, :] = cos_transform.fit(data)
-            else:
-                x_mn[k, :] = full_transform.fit(data)
+        data = (
+            (current_full_grid["J^zeta"] * jacobian_full_grid["g"])
+            .reshape(full_grid.M, full_grid.L, full_grid.N, order="F")
+            .transpose((1, 0, 2))
+            .reshape((full_grid.L, -1))
+        )
+        if eq.sym:
+            x_mn[:, :] = cos_transform.fit(data.T).T
+        else:
+            x_mn[:, :] = full_transform.fit(data.T).T
         xm, xn, s, c = ptolemy_identity_rev(m, n, x_mn)
         currvmnc[:, :] = c
         currvmnc[0, :] = (  # linear extrapolation for coefficient at the magnetic axis


### PR DESCRIPTION
- Now computes things on larger grids rather than smaller grids
in a loop to take advantage of jax/numpy vectorization
- Only compute field/current once rather than separately
for each component
- test case runs ~10x faster now