### PR TITLE
Fields

### DIFF
--- a/desc/backend.py
+++ b/desc/backend.py
@@ -65,6 +65,7 @@ if use_jax:
     while_loop = jax.lax.while_loop
     from jax.scipy.linalg import cho_factor, cho_solve, qr, solve_triangular
     from jax.scipy.special import gammaln
+    from jax.experimental.ode import odeint
 
     def put(arr, inds, vals):
         """Functional interface for array "fancy indexing"
@@ -94,6 +95,7 @@ else:
     jit = lambda func, *args, **kwargs: func
     from scipy.linalg import cho_factor, cho_solve, qr, solve_triangular
     from scipy.special import gammaln
+    from scipy.integrate import odeint
 
     def put(arr, inds, vals):
         """Functional interface for array "fancy indexing"

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -59,6 +59,9 @@ class MagneticField(IOAble, ABC):
 
         """
 
+    def __call__(self, coords, params=None, dR=0, dp=0, dZ=0):
+        return self.compute_magnetic_field(coords, params, dR, dp, dZ)
+
 
 class ScaledMagneticField(MagneticField):
     """Magnetic field scaled by a scalar value

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -10,6 +10,11 @@ from desc.derivatives import Derivative
 
 
 class MagneticField(IOAble, ABC):
+    """Base class for all magnetic fields
+
+    Subclasses must implement the "compute_magnetic_field" method
+
+    """
 
     _io_attrs_ = []
 
@@ -23,7 +28,7 @@ class MagneticField(IOAble, ABC):
         return self.__mul__(x)
 
     def __add__(self, x):
-        if isinstance(x, _MagneticField):
+        if isinstance(x, MagneticField):
             return SumMagneticField(self, x)
         else:
             return NotImplemented
@@ -55,12 +60,27 @@ class MagneticField(IOAble, ABC):
         """
 
 
-class ScaledMagneticField(_MagneticField):
+class ScaledMagneticField(MagneticField):
+    """Magnetic field scaled by a scalar value
+
+    ie B_new = scalar * B_old
+
+    Parameters
+    ----------
+    scalar : float, int
+        scaling factor for magnetic field
+    field : MagneticField
+        base field to be scaled
+        
+    """
+
+    _io_attrs = MagneticField._io_attrs_ + ["_field", "_scalar"]
+
     def __init__(self, scalar, field):
         assert np.isscalar(scalar), "scalar must actually be a scalar value"
         assert isinstance(
-            field, _MagneticField
-        ), "field should be a subclass of _MagneticField, got type {}".format(
+            field, MagneticField
+        ), "field should be a subclass of MagneticField, got type {}".format(
             type(field)
         )
         self._scalar = scalar
@@ -90,11 +110,21 @@ class ScaledMagneticField(_MagneticField):
         )
 
 
-class SumMagneticField(_MagneticField):
+class SumMagneticField(MagneticField):
+    """Sum of two or more magnetic field sources
+
+    Parameters
+    ----------
+    fields : MagneticField
+        two or more MagneticFields to add together
+    """
+
+    _io_attrs = MagneticField._io_attrs_ + ["_fields"]
+
     def __init__(self, *fields):
         assert all(
-            [isinstance(field, _MagneticField) for field in fields]
-        ), "fields should each be a subclass of _MagneticField, got {}".format(
+            [isinstance(field, MagneticField) for field in fields]
+        ), "fields should each be a subclass of MagneticField, got {}".format(
             [type(field) for field in fields]
         )
         self._fields = fields

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -13,6 +13,27 @@ class MagneticField(IOAble, ABC):
 
     _io_attrs_ = []
 
+    def __mul__(self, x):
+        if np.isscalar(x):
+            return ScaledMagneticField(x, self)
+        else:
+            return NotImplemented
+
+    def __rmul__(self, x):
+        return self.__mul__(x)
+
+    def __add__(self, x):
+        if isinstance(x, _MagneticField):
+            return SumMagneticField(self, x)
+        else:
+            return NotImplemented
+
+    def __neg__(self):
+        return ScaledMagneticField(-1, self)
+
+    def __sub__(self, x):
+        return self.__add__(-x)
+
     @abstractmethod
     def compute_magnetic_field(self, coords, params=None, dR=0, dp=0, dZ=0):
         """Compute magnetic field at a set of points

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -14,8 +14,24 @@ class MagneticField(IOAble, ABC):
     _io_attrs_ = []
 
     @abstractmethod
-    def compute_magnetic_field(self, grid, params, dR, dp, dZ):
-        """compute magnetic field on a grid in real (R, phi, Z) space"""
+    def compute_magnetic_field(self, grid, params=None, dR=0, dp=0, dZ=0):
+        """Compute magnetic field at a set of points
+
+        Parameters
+        ----------
+        coords : array-like shape(N,3) or Grid
+            cylindrical coordinates to evaluate field at [R,phi,Z]
+        params : tuple, optional
+            parameters to pass to scalar potential function
+        dR, dp, dZ : int, optional
+            order of derivative to take in R,phi,Z directions
+
+        Returns
+        -------
+        field : ndarray, shape(N,3)
+            magnetic field at specified points, in cylindrical form [BR, Bphi,BZ]
+
+        """
 
 
 class SplineMagneticField(MagneticField):
@@ -224,7 +240,7 @@ class ScalarPotentialField(MagneticField):
         self._potential = potential
         self._params = params
 
-    def compute_magnetic_field(self, coords, params=None):
+    def compute_magnetic_field(self, coords, params=None, dR=0, dp=0, dZ=0):
         """Compute magnetic field at a set of points
 
         Parameters
@@ -233,6 +249,8 @@ class ScalarPotentialField(MagneticField):
             cylindrical coordinates to evaluate field at [R,phi,Z]
         params : tuple, optional
             parameters to pass to scalar potential function
+        dR, dp, dZ : int, optional
+            order of derivative to take in R,phi,Z directions
 
         Returns
         -------
@@ -240,6 +258,10 @@ class ScalarPotentialField(MagneticField):
             magnetic field at specified points, in cylindrical form [BR, Bphi,BZ]
 
         """
+        if any([(dR != 0), (dp != 0), (dZ != 0)]):
+            raise NotImplementedError(
+                "Derivatives of scalar potential fields have not been implemented"
+            )
         if isinstance(coords, Grid):
             coords = coords.nodes
         if params is None:

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -106,7 +106,7 @@ class ScaledMagneticField(MagneticField):
 
         """
         return self._scalar * self._field.compute_magnetic_field(
-            grid, params=None, dR=0, dp=0, dZ=0
+            coords, params=None, dR=0, dp=0, dZ=0
         )
 
 
@@ -237,10 +237,10 @@ class SplineMagneticField(MagneticField):
 
         """
 
-        if isinstance(grid, Grid):
-            Rq, phiq, Zq = grid.nodes.T
+        if isinstance(coords, Grid):
+            Rq, phiq, Zq = coords.nodes.T
         else:
-            Rq, phiq, Zq = grid.T
+            Rq, phiq, Zq = coords.T
 
         BRq = interp3d(
             Rq,

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -1,0 +1,254 @@
+import numpy as np
+from abc import ABC, abstractmethod
+from netCDF4 import Dataset
+
+from desc.backend import jnp
+from desc.io import IOAble
+from desc.grid import Grid
+from desc.interpolate import interp3d
+from desc.derivatives import Derivative
+
+
+class MagneticField(IOAble, ABC):
+
+    _io_attrs_ = []
+
+    @abstractmethod
+    def compute_magnetic_field(self, grid, params, dR, dp, dZ):
+        """compute magnetic field on a grid in real (R, phi, Z) space"""
+
+
+class SplineMagneticField(MagneticField):
+    """Magnetic field from precomputed values on a grid
+
+    Parameters
+    ----------
+    R : array-like, size(NR)
+        R coordinates where field is specified
+    phi : array-like, size(Nphi)
+        phi coordinates where field is specified
+    Z : array-like, size(NZ)
+        Z coordinates where field is specified
+    BR : array-like, shape(NR,Nphi,NZ)
+        radial magnetic field on grid
+    Bphi : array-like, shape(NR,Nphi,NZ)
+        toroidal magnetic field on grid
+    BZ : array-like, shape(NR,Nphi,NZ)
+        vertical magnetic field on grid
+    method : str
+        interpolation method
+    extrap : bool
+        whether to extrapolate beyond the domain of known field values or return nan
+    period : float
+        period in the toroidal direction (usually 2pi/NFP)
+
+    """
+
+    _io_attrs_ = [
+        "_R",
+        "_phi",
+        "_Z",
+        "_BR",
+        "_Bphi",
+        "_BZ",
+        "_method",
+        "_extrap",
+        "_period",
+    ]
+
+    def __init__(self, R, phi, Z, BR, Bphi, BZ, method="cubic", extrap=False, period=0):
+
+        R, phi, Z = np.atleast_1d(R), np.atleast_1d(phi), np.atleast_1d(Z)
+        assert R.ndim == 1
+        assert phi.ndim == 1
+        assert Z.ndim == 1
+        BR, Bphi, BZ = np.atleast_3d(BR), np.atleast_3d(Bphi), np.atleast_3d(BZ)
+        assert BR.shape == Bphi.shape == BZ.shape == (R.size, phi.size, Z.size)
+
+        self._R = R
+        self._phi = phi
+        self._Z = Z
+        self._BR = BR
+        self._Bphi = Bphi
+        self._BZ = BZ
+
+        self._method = method
+        self._extrap = extrap
+        self._period = period
+
+        # TODO: precompute derivative matrices
+
+    def compute_magnetic_field(self, grid, params=None, dR=0, dp=0, dZ=0):
+        """Compute magnetic field at a set of points
+
+        Parameters
+        ----------
+        coords : array-like shape(N,3) or Grid
+            cylindrical coordinates to evaluate field at [R,phi,Z]
+        params : tuple, optional
+            parameters to pass to scalar potential function
+        dR, dp, dZ : int, optional
+            order of derivative to take in R,phi,Z directions
+
+        Returns
+        -------
+        field : ndarray, shape(N,3)
+            magnetic field at specified points, in cylindrical form [BR, Bphi,BZ]
+
+        """
+
+        if isinstance(grid, Grid):
+            Rq, phiq, Zq = grid.nodes.T
+        else:
+            Rq, phiq, Zq = grid.T
+
+        BRq = interp3d(
+            Rq,
+            phiq,
+            Zq,
+            self._R,
+            self._phi,
+            self._Z,
+            self._BR,
+            self._method,
+            (dR, dp, dZ),
+            self._extrap,
+            self._period,
+        )
+        Bphiq = interp3d(
+            Rq,
+            phiq,
+            Zq,
+            self._R,
+            self._phi,
+            self._Z,
+            self._Bphi,
+            self._method,
+            (dR, dp, dZ),
+            self._extrap,
+            self._period,
+        )
+        BZq = interp3d(
+            Rq,
+            phiq,
+            Zq,
+            self._R,
+            self._phi,
+            self._Z,
+            self._BZ,
+            self._method,
+            (dR, dp, dZ),
+            self._extrap,
+            self._period,
+        )
+
+        return jnp.array([BRq, Bphiq, BZq]).T
+
+    @classmethod
+    def from_mgrid(
+        cls, mgrid_file, extcur=1, method="cubic", extrap=False, period=None
+    ):
+        """Create a SplineMagneticField from an "mgrid" file from MAKEGRID
+
+        Parameters
+        ----------
+        mgrid_file : str or path-like
+            path to mgrid file in netCDF format
+        extcur : array-like
+            currents for each subset of the field
+        method : str
+            interpolation method
+        extrap : bool
+            whether to extrapolate beyond the domain of known field values or return nan
+        period : float
+            period in the toroidal direction (usually 2pi/NFP)
+
+        """
+        mgrid = Dataset(mgrid_file, "r")
+        ir = int(mgrid["ir"][()])
+        jz = int(mgrid["jz"][()])
+        kp = int(mgrid["kp"][()])
+        nfp = mgrid["nfp"][()].data
+        nextcur = int(mgrid["nextcur"][()])
+        rMin = mgrid["rmin"][()]
+        rMax = mgrid["rmax"][()]
+        zMin = mgrid["zmin"][()]
+        zMax = mgrid["zmax"][()]
+
+        br = np.zeros([kp, jz, ir])
+        bp = np.zeros([kp, jz, ir])
+        bz = np.zeros([kp, jz, ir])
+        extcur = np.broadcast_to(extcur, nextcur)
+        for i in range(nextcur):
+
+            # apply scaling by currents given in VMEC input file
+            scale = extcur[i]
+
+            # sum up contributions from different coils
+            coil_id = "%03d" % (i + 1,)
+            br[:, :, :] += scale * mgrid["br_" + coil_id][()]
+            bp[:, :, :] += scale * mgrid["bp_" + coil_id][()]
+            bz[:, :, :] += scale * mgrid["bz_" + coil_id][()]
+        mgrid.close()
+
+        # shift axes to correct order
+        br = np.moveaxis(br, (0, 1, 2), (1, 2, 0))
+        bp = np.moveaxis(bp, (0, 1, 2), (1, 2, 0))
+        bz = np.moveaxis(bz, (0, 1, 2), (1, 2, 0))
+
+        # re-compute grid knots in radial and vertical direction
+        Rgrid = np.linspace(rMin, rMax, ir)
+        Zgrid = np.linspace(zMin, zMax, jz)
+        pgrid = 2.0 * np.pi / (nfp * kp) * np.arange(kp)
+        if period is None:
+            period = 2 * np.pi / (nfp)
+
+        return cls(Rgrid, pgrid, Zgrid, br, bp, bz, method, extrap, period)
+
+
+class ScalarPotentialField(MagneticField):
+    """Magnetic field due to a scalar magnetic potential in cylindrical coordinates
+
+    Parameters
+    ----------
+    potential : callable
+        function to compute the scalar potential. Should have a signature of
+        the form potential(R,phi,Z,*params) -> ndarray.
+        R,phi,Z are arrays of cylindrical coordinates.
+    params : tuple, optional
+        default parameters to pass to potential function
+
+    """
+
+    def __init__(self, potential, params=()):
+        self._potential = potential
+        self._params = params
+
+    def compute_magnetic_field(self, coords, params=None):
+        """Compute magnetic field at a set of points
+
+        Parameters
+        ----------
+        coords : array-like shape(N,3) or Grid
+            cylindrical coordinates to evaluate field at [R,phi,Z]
+        params : tuple, optional
+            parameters to pass to scalar potential function
+
+        Returns
+        -------
+        field : ndarray, shape(N,3)
+            magnetic field at specified points, in cylindrical form [BR, Bphi,BZ]
+
+        """
+        if isinstance(coords, Grid):
+            coords = coords.nodes
+        if params is None:
+            params = self._params
+        r, p, z = coords.T
+        funR = lambda x: self._potential(x, p, z, *params)
+        funP = lambda x: self._potential(r, x, z, *params)
+        funZ = lambda x: self._potential(r, p, x, *params)
+        br = Derivative.compute_jvp(funR, 0, (jnp.ones_like(r),), r)
+        bp = Derivative.compute_jvp(funP, 0, (jnp.ones_like(p),), p)
+        bz = Derivative.compute_jvp(funZ, 0, (jnp.ones_like(z),), z)
+        return jnp.array([br, bp / r, bz]).T

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -1,0 +1,113 @@
+import numpy as np
+import unittest
+import pytest
+
+from desc.backend import jnp
+from desc.magnetic_fields import (
+    ToroidalMagneticField,
+    VerticalMagneticField,
+    PoloidalMagneticField,
+    SplineMagneticField,
+    ScalarPotentialField,
+    field_line_integrate,
+)
+
+
+def phi_lm(R, phi, Z, a, m):
+    CNm0 = (R ** m - R ** -m) / (2 * m)
+    Nm1 = CNm0 * Z
+    CDm0 = (R ** m + R ** -m) / 2
+    c1 = -m * (m - 1)
+    c2 = (m + 1) * (m - 2)
+    c3 = m * (m + 1)
+    c4 = -(m + 2) * (m - 1)
+    CDm1 = (c1 * R ** (m + 2) + c2 * R ** (m) + c3 * R ** (-m + 2) + c4 * R ** (-m)) / (
+        8 * m * (m ** 2 - 1)
+    )
+    Dm2 = CDm0 * Z ** 2 / 2 + CDm1
+    return phi + a * Dm2 * jnp.sin(m * phi) + a * Nm1 * jnp.cos(m * phi)
+
+
+a = -1.489
+m = 5
+args = (a, m)
+
+
+class TestMagneticFields(unittest.TestCase):
+    def test_basic_fields(self):
+
+        tfield = ToroidalMagneticField(2, 1)
+        vfield = VerticalMagneticField(1)
+        pfield = PoloidalMagneticField(2, 1, 2)
+        np.testing.assert_allclose(tfield([1, 0, 0]), [[0, 2, 0]])
+        np.testing.assert_allclose((4 * tfield)([2, 0, 0]), [[0, 4, 0]])
+        np.testing.assert_allclose((tfield + vfield)([1, 0, 0]), [[0, 2, 1]])
+        np.testing.assert_allclose(
+            (tfield + vfield - pfield)([1, 0, 0.1]), [[0.4, 2, 1]]
+        )
+
+    def test_field_derivatives(self):
+
+        tfield = ToroidalMagneticField(2, 1)
+        vfield = VerticalMagneticField(1)
+        pfield = PoloidalMagneticField(2, 1, 2)
+        np.testing.assert_allclose(tfield([1, 0, 0], dR=1), [[0, -2, 0]])
+        np.testing.assert_allclose(tfield([1, 0, 0], dp=1), [[0, 0, 0]])
+        np.testing.assert_allclose(tfield([1, 0, 0], dZ=1), [[0, 0, 0]])
+        np.testing.assert_allclose(vfield([1, 0, 0], dR=1), [[0, 0, 0]])
+        np.testing.assert_allclose(vfield([1, 0, 0], dp=1), [[0, 0, 0]])
+        np.testing.assert_allclose(vfield([1, 0, 0], dZ=1), [[0, 0, 0]])
+        with pytest.raises(NotImplementedError):
+            pfield([1, 0, 0], dR=1)
+        with pytest.raises(NotImplementedError):
+            pfield([1, 0, 0], dp=1)
+        with pytest.raises(NotImplementedError):
+            pfield([1, 0, 0], dZ=1)
+
+    def test_scalar_field(self):
+
+        field = ScalarPotentialField(phi_lm, args)
+        np.testing.assert_allclose(
+            field.compute_magnetic_field([1.0, 0, 0]), [[0, 1, 0]]
+        )
+        np.testing.assert_allclose(
+            field.compute_magnetic_field([1.0, np.pi / 4, 0]), [[0, 1, 0]]
+        )
+        with pytest.raises(NotImplementedError):
+            field([1, 0, 0], dR=1)
+        with pytest.raises(NotImplementedError):
+            field([1, 0, 0], dp=1)
+        with pytest.raises(NotImplementedError):
+            field([1, 0, 0], dZ=1)
+
+    def test_spline_field(self):
+
+        field1 = ScalarPotentialField(phi_lm, args)
+        R = np.linspace(0.5, 1.5, 20)
+        Z = np.linspace(-1.5, 1.5, 20)
+        p = np.linspace(0, 2 * np.pi / 5, 40)
+        field2 = SplineMagneticField.from_field(field1, R, p, Z, period=2 * np.pi / 5)
+
+        np.testing.assert_allclose(
+            field1([1.0, 1.0, 1.0]), field2([1.0, 1.0, 1.0]), rtol=1e-2, atol=1e-2
+        )
+
+        extcur = [4700.0, 1000.0]
+        mgrid = "tests/inputs/mgrid_test.nc"
+        field3 = SplineMagneticField.from_mgrid(mgrid, extcur)
+
+        np.testing.assert_allclose(
+            field3([0.70, 0, 0]), [[0, -0.671, 0.0858]], rtol=1e-3, atol=1e-8
+        )
+
+    def test_field_line_integrate(self):
+
+        # q=4, field line should rotate 1/4 turn after 1 toroidal transit
+        # from outboard midplane to top center
+        field = ToroidalMagneticField(2, 10) + PoloidalMagneticField(2, 10, 0.25)
+        r0 = [10.001]
+        z0 = [0.0]
+        phis = [0, 2 * np.pi]
+        r, z = field_line_integrate(r0, z0, phis, field)
+        np.testing.assert_allclose(r[-1], 10, rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(z[-1], 0.001, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
Adds classes for representing various types of magnetic fields
- Base class for all magnetic field types defining the `compute_magnetic_field` API and methods for combining fields
- SplineMagneticField for dealing with mgrid files and splining expensive to compute fields
- ScalarPotentialField for vacuum fields that can be written as B=grad(Phi)
- basic field types for testing, such as toroidal, poloidal, vertical
- field line integration function for tracing field lines in R,phi,Z, using JAX for differentiability

Resolves #91 #106 