### PR TITLE
Precompute derivatives for SplineProfile and SplineMagneticField

### DIFF
--- a/desc/interpolate.py
+++ b/desc/interpolate.py
@@ -129,7 +129,7 @@ def interp2d(
     fxy=None,
     **kwargs,
 ):
-    """Interpolate a 1d function
+    """Interpolate a 2d function
 
     Parameters
     ----------
@@ -182,6 +182,7 @@ def interp2d(
     """
 
     xq, yq, x, y, f = map(jnp.asarray, (xq, yq, x, y, f))
+    period, extrap = map(np.asarray, (period, extrap))
     if len(x) != f.shape[0] or x.ndim != 1:
         raise ValueError("x and f must be arrays of equal length")
     if len(y) != f.shape[1] or y.ndim != 1:
@@ -380,6 +381,7 @@ def interp3d(
         function value at query points
     """
     xq, yq, zq, x, y, z, f = map(jnp.asarray, (xq, yq, zq, x, y, z, f))
+    period, extrap = map(np.asarray, (period, extrap))
     if len(x) != f.shape[0] or x.ndim != 1:
         raise ValueError("x and f must be arrays of equal length")
     if len(y) != f.shape[1] or y.ndim != 1:
@@ -390,6 +392,7 @@ def interp3d(
     periodx, periody, periodz = np.broadcast_to(
         np.where(period == None, 0, period), (3,)
     )
+
     derivative_x, derivative_y, derivative_z = np.broadcast_to(
         np.where(derivative == None, 0, derivative), (3,)
     )

--- a/desc/profiles.py
+++ b/desc/profiles.py
@@ -7,7 +7,7 @@ import scipy.optimize
 from desc.backend import jnp, put, jit
 from desc.io import IOAble
 from desc.grid import Grid, LinearGrid, ConcentricGrid, QuadratureGrid
-from desc.interpolate import interp1d
+from desc.interpolate import interp1d, _approx_df
 from desc.transform import Transform
 from desc.basis import PowerSeries
 from desc.utils import copy_coeffs
@@ -399,7 +399,7 @@ class SplineProfile(Profile):
 
     """
 
-    _io_attrs_ = Profile._io_attrs_ + ["_knots", "_method"]
+    _io_attrs_ = Profile._io_attrs_ + ["_knots", "_method", "_Dx"]
 
     def __init__(self, values, knots=None, grid=None, method="cubic2", name=None):
 
@@ -412,6 +412,9 @@ class SplineProfile(Profile):
         self._knots = knots
         self._params = values
         self._method = method
+        self._Dx = _approx_df(
+            self._knots, np.eye(self._knots.size), self._method, axis=0
+        )
 
         if grid is None:
             grid = Grid(np.empty((0, 3)))
@@ -505,7 +508,8 @@ class SplineProfile(Profile):
             return jnp.zeros_like(xq)
         x = self._knots
         f = params
-        fq = interp1d(xq, x, f, method=self._method, derivative=dr, extrap=True)
+        df = self._Dx @ f
+        fq = interp1d(xq, x, f, method=self._method, derivative=dr, extrap=True, df=df)
         return fq
 
     def to_powerseries(self, order=6, xs=100, rcond=None, w=None):


### PR DESCRIPTION
- For fixed knot profiles, derivative operator can be precomputed
and then multiplied with funciton values to evaluate derivs.
- For fields, the values are fixed as well so full derivatives
can be precomputed.
- Speeds up field line tracing with splined fields by 30-40%
- Small difference in speed for profiles, since they're only 1D

Resolves #133