### PR TITLE
Fix bug when changing resolution in continuation

### DIFF
--- a/desc/objective_funs.py
+++ b/desc/objective_funs.py
@@ -2,7 +2,7 @@ import numpy as np
 from abc import ABC, abstractmethod
 from termcolor import colored
 import warnings
-
+import copy
 from desc.backend import jnp, jit, use_jax
 from desc.utils import unpack_state, Timer
 from desc.io import IOAble
@@ -65,12 +65,12 @@ class ObjectiveFunction(IOAble, ABC):
         use_jit=True,
     ):
 
-        self.R_transform = R_transform.copy()
-        self.Z_transform = Z_transform.copy()
-        self.L_transform = L_transform.copy()
-        self.p_profile = p_profile.copy()
-        self.i_profile = i_profile.copy()
-        self.BC_constraint = BC_constraint.copy()
+        self.R_transform = copy.deepcopy(R_transform)
+        self.Z_transform = copy.deepcopy(Z_transform)
+        self.L_transform = copy.deepcopy(L_transform)
+        self.p_profile = copy.deepcopy(p_profile)
+        self.i_profile = copy.deepcopy(i_profile)
+        self.BC_constraint = copy.deepcopy(BC_constraint)
         self.use_jit = use_jit
         self._set_up()
 

--- a/desc/objective_funs.py
+++ b/desc/objective_funs.py
@@ -65,12 +65,12 @@ class ObjectiveFunction(IOAble, ABC):
         use_jit=True,
     ):
 
-        self.R_transform = R_transform
-        self.Z_transform = Z_transform
-        self.L_transform = L_transform
-        self.p_profile = p_profile
-        self.i_profile = i_profile
-        self.BC_constraint = BC_constraint
+        self.R_transform = R_transform.copy()
+        self.Z_transform = Z_transform.copy()
+        self.L_transform = L_transform.copy()
+        self.p_profile = p_profile.copy()
+        self.i_profile = i_profile.copy()
+        self.BC_constraint = BC_constraint.copy()
         self.use_jit = use_jit
         self._set_up()
 

--- a/tests/inputs/res_test
+++ b/tests/inputs/res_test
@@ -1,0 +1,48 @@
+# tests changing resolution in different ways during continuation method
+
+# global parameters
+sym =  1
+NFP =  5
+Psi = -2.13300000E+00
+
+# spectral resolution
+# first change just spectral, then just grid, then both
+L_rad  =  3, 4, 4, 4
+M_pol  =  2, 2, 2, 2,
+N_tor  =  0, 0, 0, 1
+M_grid =  3, 3, 5, 5
+N_grid =  0, 0, 0, 2
+
+# continuation parameters
+bdry_ratio = 0, 0, 0, 1
+pres_ratio = 0
+pert_order = 1
+
+# solver tolerances
+ftol = 1e-2
+xtol = 1e-6
+gtol = 1e-4
+nfev = 10
+
+# solver methods
+optimizer         = lsq-exact
+objective         = force
+spectral_indexing = ansi
+node_pattern      = jacobi
+
+# pressure and rotational transform profiles
+l:   0	p =   1.85596929e+05	i =   8.56047021e-01
+l:   2	p =  -3.71193859e+05	i =   3.88095412e-02
+l:   4	p =   1.85596929e+05	i =   6.86795128e-02
+
+# magnetic axis initial guess
+n:   0  R0 =  1.0E+1  Z0 =  0.0E+0
+
+# fixed-boundary surface shape
+m:   0  n:   0  R1 =  1.0E+1
+m:   1  n:   0  R1 = -1.0E+0
+m:   1  n:   1  R1 = -3.0E-1
+m:  -1  n:  -1  R1 =  3.0E-1
+m:  -1  n:   0  Z1 =  1.0E+0
+m:  -1  n:   1  Z1 = -3.0E-1
+m:   1  n:  -1  Z1 = -3.0E-1

--- a/tests/test_equilibrium.py
+++ b/tests/test_equilibrium.py
@@ -1,9 +1,11 @@
+import os
 import numpy as np
 from netCDF4 import Dataset
 import pytest
 from desc.equilibrium import Equilibrium, EquilibriaFamily
 from desc.grid import Grid, LinearGrid
 from desc.utils import area_difference
+from desc.__main__ import main
 
 
 def test_compute_volume(DSHAPE):
@@ -189,3 +191,17 @@ def test_to_sfl(plot_eq):
 
     np.testing.assert_allclose(rho_err, 0, atol=1e-5)
     np.testing.assert_allclose(theta_err, 0, atol=5e-10)
+
+
+@pytest.mark.slow
+def test_continuation_resolution(tmpdir_factory):
+    input_path = ".//tests//inputs//res_test"
+    output_dir = tmpdir_factory.mktemp("result")
+    desc_h5_path = output_dir.join("res_test_out.h5")
+
+    cwd = os.path.dirname(__file__)
+    exec_dir = os.path.join(cwd, "..")
+    input_filename = os.path.join(exec_dir, input_path)
+
+    args = ["-o", str(desc_h5_path), input_filename, "-vv"]
+    main(args)


### PR DESCRIPTION
- Changing only grid or only spectral resolution would lead to objectives getting copied and re-used instead of recreated, so the old compiled function with the wrong resolution was used, causing a shape error. 
- Seems to have been caused by transform objects living in both objectives and equilibria, so updating one also changed the other
- Making local copies of transforms in objectives seems to fix it for now.
- Kind of a kludge, but new objectives function API should eliminate this entirely by making transforms only properties of objectives.