### PR TITLE
Fix parsing of dev-requirements in setup.py

### DIFF
--- a/devtools/dev-requirements.txt
+++ b/devtools/dev-requirements.txt
@@ -12,6 +12,7 @@ sphinx_copybutton
 black == 21.7b0
 click == 8.0.4
 flake8 >= 4.0.1
+pylint >= 2.12.2
 
 #For testing and benchmarking
 pytest >= 5.0.0

--- a/devtools/requirements.txt
+++ b/devtools/requirements.txt
@@ -1,9 +1,0 @@
-black == 21.7b0
-click == 8.0.4
-codecov
-flake8 >= 4.0.1
-pylint >= 2.12.2
-pytest >= 5.0.0
-pytest-benchmark
-pytest-cov >= 2.6.0
-pytest-mpl

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as f:
 
 with open(os.path.join(here, "devtools/dev-requirements.txt"), encoding="utf-8") as f:
     dev_requirements = f.read().splitlines()
+dev_requirements = [foo for foo in dev_requirements if not (foo.startswith("#") or foo.startswith("-r"))]
 
 setup(
     name="desc-opt",


### PR DESCRIPTION
setup.py doesn't properly handle comments in requirements files, so this strips those from the list passed into the setup function.
Also removed devtools/requirements.txt since this was just a subset of dev-requirements