### PR TITLE
Fix rounding error when building high res grids

### DIFF
--- a/desc/grid.py
+++ b/desc/grid.py
@@ -705,10 +705,9 @@ class ConcentricGrid(Grid):
         dt = []
 
         for iring in range(L // 2 + 1, 0, -1):
-            dtheta = (
-                2 * np.pi / (2 * M + np.ceil((M / L) * (5 - 4 * iring)).astype(int))
-            )
-            theta = np.arange(0, 2 * np.pi, dtheta)
+            ntheta = 2 * M + np.ceil((M / L) * (5 - 4 * iring)).astype(int)
+            dtheta = 2 * np.pi / ntheta
+            theta = np.linspace(0, 2 * np.pi, ntheta, endpoint=False)
             if rotation in {None, False}:
                 if self.sym:
                     # this is emperically chosen, could be something different, just
@@ -737,7 +736,7 @@ class ConcentricGrid(Grid):
         dimzern = r.size
 
         dz = 2 * np.pi / (NFP * (2 * N + 1))
-        z = np.arange(0, 2 * np.pi / NFP, dz)
+        z = np.linspace(0, 2 * np.pi / NFP, 2 * N + 1, endpoint=False)
 
         r = np.tile(r, 2 * N + 1)
         t = np.tile(t, 2 * N + 1)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -224,6 +224,10 @@ class TestGrid(unittest.TestCase):
 
         np.testing.assert_allclose(grid_quad.nodes, quadrature_nodes, atol=1e-8)
 
+    def test_concentric_grid_high_res(self):
+        # need to make sure this builds without crashing, as in GH issue #207
+        grid = ConcentricGrid(L=32, M=28, N=30)
+
     def test_quad_grid_volume_integration(self):
 
         r = 1


### PR DESCRIPTION
Replace use of ``np.arange`` with ``np.linspace`` to avoid rounding errors with floating points spacing.

Resolves #207 