### PR TITLE
change is_nested function to use jacobian sign instead of looking for…

### DIFF
--- a/desc/configuration.py
+++ b/desc/configuration.py
@@ -696,7 +696,6 @@ class _Configuration(IOAble, ABC):
         self._Z_lmn = copy_coeffs(self.Z_lmn, old_modes_Z, self.Z_basis.modes)
         self._L_lmn = copy_coeffs(self.L_lmn, old_modes_L, self.L_basis.modes)
 
-
     def get_surface_at(self, rho=None, theta=None, zeta=None):
         """Return a representation for a given coordinate surface.
 
@@ -1279,7 +1278,7 @@ class _Configuration(IOAble, ABC):
         """
         data = self.compute(name="sqrt(g)", grid=grid)
 
-        return np.all(np.sign(data["sqrt(g)"][0]) == np.sign(data["sqrt(g)"]))
+        return jnp.all(jnp.sign(data["sqrt(g)"][0]) == jnp.sign(data["sqrt(g)"]))
 
     def to_sfl(
         self,

--- a/desc/configuration.py
+++ b/desc/configuration.py
@@ -5,7 +5,6 @@ import numbers
 
 from termcolor import colored
 from abc import ABC
-from shapely.geometry import LineString, MultiLineString
 from inspect import signature
 
 from desc.backend import jnp, jit, put, while_loop

--- a/desc/configuration.py
+++ b/desc/configuration.py
@@ -696,7 +696,6 @@ class _Configuration(IOAble, ABC):
         self._Z_lmn = copy_coeffs(self.Z_lmn, old_modes_Z, self.Z_basis.modes)
         self._L_lmn = copy_coeffs(self.L_lmn, old_modes_L, self.L_basis.modes)
 
-        self._make_labels()
 
     def get_surface_at(self, rho=None, theta=None, zeta=None):
         """Return a representation for a given coordinate surface.
@@ -1018,52 +1017,6 @@ class _Configuration(IOAble, ABC):
         """Spectral basis for lambda (FourierZernikeBasis)."""
         return self._L_basis
 
-    # FIXME: update this now that x is no longer a property of Configuration
-    def _make_labels(self):
-        R_label = ["R_{},{},{}".format(l, m, n) for l, m, n in self.R_basis.modes]
-        Z_label = ["Z_{},{},{}".format(l, m, n) for l, m, n in self.Z_basis.modes]
-        L_label = ["L_{},{},{}".format(l, m, n) for l, m, n in self.L_basis.modes]
-        return None
-
-    def get_xlabel_by_idx(self, idx):
-        """Find which mode corresponds to a given entry in x.
-
-        Parameters
-        ----------
-        idx : int or array-like of int
-            index into optimization vector x
-
-        Returns
-        -------
-        label : str or list of str
-            label for the coefficient at index idx, eg R_0,1,3 or L_4,3,0
-
-        """
-        self._make_labels()
-        idx = np.atleast_1d(idx)
-        labels = [self.xlabel.get(i, None) for i in idx]
-        return labels
-
-    def get_idx_by_xlabel(self, labels):
-        """Find which index of x corresponds to a given mode.
-
-        Parameters
-        ----------
-        label : str or list of str
-            label for the coefficient at index idx, eg R_0,1,3 or L_4,3,0
-
-        Returns
-        -------
-        idx : int or array-like of int
-            index into optimization vector x
-
-        """
-        self._make_labels()
-        if not isinstance(labels, (list, tuple)):
-            labels = [labels]
-        idx = [self.rev_xlabel.get(label, None) for label in labels]
-        return np.array(idx)
-
     def compute(self, name, grid=None, data=None, **kwargs):
         """Compute the quantity given by name on grid.
 
@@ -1303,24 +1256,20 @@ class _Configuration(IOAble, ABC):
 
         return jnp.vstack([rho, theta, phi]).T
 
-    def is_nested(self, nsurfs=10, ntheta=20, nzeta=None, Nt=45, Nr=20):
+    def is_nested(self, grid=None):
         """Check that an equilibrium has properly nested flux surfaces in a plane.
+
+            Does so by checking coordianate jacobian (sqrt(g)) sign.
+            If coordinate jacobian switches sign somewhere in the volume, this indicates that
+            it is zero at some point, meaning surfaces are touching and the equilibrium is not nested
+
+            NOTE: If grid resolution used is too low, or the solution is just barely unnested, this function may
+                fail to return the correct answer.
 
         Parameters
         ----------
-        nsurfs : int, optional
-            Number of flux surfaces to check (Default = 10).
-        ntheta : int, optional
-            Number of straight field-line poloidal contours to check (Default = 20).
-        nzeta : int, optional
-            Number of toroidal planes to check. By default checks the zeta=0
-            plane for axisymmetric equilibria and 5 planes evenly spaced in
-            zeta between 0 and 2pi/NFP for non-axisymmetric equilibria.
-            Otherwise uses nzeta planes linearly spaced in zeta between 0 and 2pi/NFP.
-        Nt : int, optional
-            Number of theta coordinates to use for the rho contours (Default = 45).
-        Nr : int, optional
-            Number of rho coordinates to use for the theta contours (Default = 20).
+        grid  :  Grid, optional
+            Grid on which to evaluate the coordinate jacobian and check for the sign. (Default to QuadratureGrid with eq's current grid resolutions)
 
         Returns
         -------
@@ -1328,53 +1277,9 @@ class _Configuration(IOAble, ABC):
             whether or not the surfaces are nested
 
         """
-        planes_nested_bools = []
-        if nzeta is None:
-            zetas = (
-                [0.0]
-                if self.N == 0
-                else np.linspace(0, 2 * np.pi / self.NFP, 5, endpoint=False)
-            )
-        else:
-            zetas = np.linspace(0, 2 * np.pi / self.NFP, nzeta, endpoint=False)
+        data = self.compute(name="sqrt(g)", grid=grid)
 
-        for zeta in zetas:
-            r_grid = LinearGrid(rho=nsurfs, theta=Nt, zeta=zeta, endpoint=True)
-            t_grid = LinearGrid(rho=Nr, theta=ntheta, zeta=zeta, endpoint=False)
-
-            r_coords = self.compute("R", r_grid)
-            t_coords = self.compute("lambda", t_grid)
-
-            v_nodes = t_grid.nodes
-            v_nodes[:, 1] = t_grid.nodes[:, 1] - t_coords["lambda"]
-            v_grid = Grid(v_nodes)
-            v_coords = self.compute("R", v_grid)
-
-            # rho contours
-            Rr = r_coords["R"].reshape(
-                (r_grid.num_rho, r_grid.num_theta, r_grid.num_zeta)
-            )[:, :, 0]
-            Zr = r_coords["Z"].reshape(
-                (r_grid.num_rho, r_grid.num_theta, r_grid.num_zeta)
-            )[:, :, 0]
-
-            # theta contours
-            Rv = v_coords["R"].reshape(
-                (t_grid.num_rho, t_grid.num_theta, t_grid.num_zeta)
-            )[:, :, 0]
-            Zv = v_coords["Z"].reshape(
-                (t_grid.num_rho, t_grid.num_theta, t_grid.num_zeta)
-            )[:, :, 0]
-
-            rline = MultiLineString(
-                [LineString(np.array([R, Z]).T) for R, Z in zip(Rr, Zr)]
-            )
-            vline = MultiLineString(
-                [LineString(np.array([R, Z]).T) for R, Z in zip(Rv.T, Zv.T)]
-            )
-
-            planes_nested_bools.append(rline.is_simple and vline.is_simple)
-        return np.all(planes_nested_bools)
+        return np.all(np.sign(data["sqrt(g)"][0]) == np.sign(data["sqrt(g)"]))
 
     def to_sfl(
         self,

--- a/desc/configuration.py
+++ b/desc/configuration.py
@@ -1254,7 +1254,7 @@ class _Configuration(IOAble, ABC):
 
         return jnp.vstack([rho, theta, phi]).T
 
-    def is_nested(self, grid=None):
+    def is_nested(self, grid=None, R_lmn=None, Z_lmn=None):
         """Check that an equilibrium has properly nested flux surfaces in a plane.
 
             Does so by checking coordianate jacobian (sqrt(g)) sign.
@@ -1275,6 +1275,11 @@ class _Configuration(IOAble, ABC):
             whether or not the surfaces are nested
 
         """
+        if R_lmn is None:
+            R_lmn = self.R_lmn
+        if Z_lmn is None:
+            Z_lmn = self.Z_lmn
+
         data = self.compute(name="sqrt(g)", grid=grid)
 
         return jnp.all(jnp.sign(data["sqrt(g)"][0]) == jnp.sign(data["sqrt(g)"]))

--- a/desc/io/input_reader.py
+++ b/desc/io/input_reader.py
@@ -1179,13 +1179,19 @@ class InputReader:
                 inputs_arr[i]["N"] = 0
                 inputs_arr[i]["N_grid"] = 0
                 inputs_arr[i]["pres_ratio"] = 0
-                inputs_arr[i]["bdry_ratio"] = 0
+                if bdry_steps != 0:
+                    inputs_arr[i]["bdry_ratio"] = 0
+                else:
+                    inputs_arr[i]["bdry_ratio"] = 1
             elif i < (res_steps + pres_steps):
                 inputs_arr[i]["N"] = 0
                 inputs_arr[i]["N_grid"] = 0
                 inputs_arr[i]["pres_ratio"] = (i - res_steps + 1) * pres_step
                 inputs_arr[i]["pert_order"] = 2
-                inputs_arr[i]["bdry_ratio"] = 0
+                if bdry_steps != 0:
+                    inputs_arr[i]["bdry_ratio"] = 0
+                else:
+                    inputs_arr[i]["bdry_ratio"] = 1
             else:
                 inputs_arr[i]["pert_order"] = 2
                 inputs_arr[i]["bdry_ratio"] = (

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -2,13 +2,11 @@ import numpy as np
 from abc import ABC, abstractmethod
 from inspect import getfullargspec
 
-import warnings
-from termcolor import colored
 from desc.backend import use_jax, jnp, jit
 from desc.utils import Timer
 from desc.io import IOAble
 from desc.derivatives import Derivative
-from desc.compute import arg_order, compute_jacobian
+from desc.compute import arg_order
 
 # XXX: could use `indicies` instead of `arg_order` in ObjectiveFunction loops
 

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -2,7 +2,8 @@ import numpy as np
 from abc import ABC, abstractmethod
 from inspect import getfullargspec
 
-
+import warnings
+from termcolor import colored
 from desc.backend import use_jax, jnp, jit
 from desc.utils import Timer
 from desc.io import IOAble
@@ -327,7 +328,14 @@ class ObjectiveFunction(IOAble):
             )
             nested = jnp.all(jnp.sign(data["sqrt(g)"][0]) == jnp.sign(data["sqrt(g)"]))
             if not nested:
-                print("Equilibrium is unnested! Stopping Optimization")
+                warnings.warn(
+                    colored(
+                        "WARNING: Flux surfaces are no longer nested, exiting early."
+                        + "Consider taking smaller perturbation/resolution steps "
+                        + "or reducing trust radius",
+                        "yellow",
+                    )
+                )
             return not nested
         else:
             return False

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -311,35 +311,6 @@ class ObjectiveFunction(IOAble):
             timer.disp("Total compilation time")
         self._compiled = True
 
-    def is_unnested(
-        self, x
-    ):  # assuming objective uses R_lmn, Z_lmn... not elegant at all
-        """Check if equilibrium is unnested, returning True if unnested and False if it is nested.
-
-        This function only works if the objective takes R_lmn and Z_lmn as arguments.
-        Otherwise, it returns False but does not actually check if the equilibrium is nested or not"""
-        kwargs = self.unpack_state(x)
-        if "R_lmn" in kwargs.keys() and "Z_lmn" in kwargs.keys():
-
-            data = compute_jacobian(
-                R_transform=self._objectives[0]._R_transform,
-                Z_transform=self._objectives[0]._Z_transform,
-                **kwargs
-            )
-            nested = jnp.all(jnp.sign(data["sqrt(g)"][0]) == jnp.sign(data["sqrt(g)"]))
-            if not nested:
-                warnings.warn(
-                    colored(
-                        "WARNING: Flux surfaces are no longer nested, exiting early."
-                        + "Consider taking smaller perturbation/resolution steps "
-                        + "or reducing trust radius",
-                        "yellow",
-                    )
-                )
-            return not nested
-        else:
-            return False
-
     @property
     def objectives(self):
         """list: List of objectives."""

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -313,16 +313,24 @@ class ObjectiveFunction(IOAble):
     def is_unnested(
         self, x
     ):  # assuming objective uses R_lmn, Z_lmn... not elegant at all
+        """Check if equilibrium is unnested, returning True if unnested and False if it is nested.
+
+        This function only works if the objective takes R_lmn and Z_lmn as arguments.
+        Otherwise, it returns False but does not actually check if the equilibrium is nested or not"""
         kwargs = self.unpack_state(x)
-        data = compute_jacobian(
-            R_transform=self._objectives[0]._R_transform,
-            Z_transform=self._objectives[0]._Z_transform,
-            **kwargs
-        )
-        nested = jnp.all(jnp.sign(data["sqrt(g)"][0]) == jnp.sign(data["sqrt(g)"]))
-        if not nested:
-            print("eq is unnested")
-        return not nested
+        if "R_lmn" in kwargs.keys() and "Z_lmn" in kwargs.keys():
+
+            data = compute_jacobian(
+                R_transform=self._objectives[0]._R_transform,
+                Z_transform=self._objectives[0]._Z_transform,
+                **kwargs
+            )
+            nested = jnp.all(jnp.sign(data["sqrt(g)"][0]) == jnp.sign(data["sqrt(g)"]))
+            if not nested:
+                print("Equilibrium is unnested! Stopping Optimization")
+            return not nested
+        else:
+            return False
 
     @property
     def objectives(self):

--- a/desc/optimize/optimizer.py
+++ b/desc/optimize/optimizer.py
@@ -26,6 +26,10 @@ class Optimizer(IOAble):
     Also offers several custom routines specifically designed for DESC, both scalar and
     least squares routines with and without jacobian/hessian information.
 
+    Note: surface nestedness is tracked during optimization iterations, and optimization exits early
+        if surfaces go unnested. However this is NOT tracked in the scipy.optimize.least_squares routines,
+        as those routines do not accept a custom callback function.
+
     Parameters
     ----------
     method : str
@@ -328,6 +332,10 @@ class Optimizer(IOAble):
             msg = [""]
 
             def callback(x_reduced):
+                # check for nestedness
+                is_unnested = is_unnested_wrapped(x_reduced)
+                if is_unnested:
+                    raise StopIteration
                 x = recover(x_reduced)
                 if len(allx) > 0:
                     dx = allx[-1] - x_reduced

--- a/desc/optimize/optimizer.py
+++ b/desc/optimize/optimizer.py
@@ -316,6 +316,11 @@ class Optimizer(IOAble):
             df = objective.jac(x)
             return df[:, unfixed_idx] @ Z
 
+        def is_unnested_wrapped(x_reduced):
+            x = recover(x_reduced)
+            nested = objective.is_unnested(x)
+            return nested
+
         if self.method in Optimizer._scipy_scalar_methods:
 
             allx = []
@@ -447,7 +452,7 @@ class Optimizer(IOAble):
                 gtol=gtol,
                 verbose=disp,
                 maxiter=maxiter,
-                callback=None,
+                callback=is_unnested_wrapped,
                 options=options,
             )
 
@@ -464,7 +469,7 @@ class Optimizer(IOAble):
                 gtol=gtol,
                 verbose=disp,
                 maxiter=maxiter,
-                callback=None,
+                callback=is_unnested_wrapped,
                 options=options,
             )
 

--- a/desc/optimize/optimizer.py
+++ b/desc/optimize/optimizer.py
@@ -330,6 +330,15 @@ class Optimizer(IOAble):
             if "Z_lmn" in kwargs.keys():
                 Z_lmn = kwargs["Z_lmn"]
             nested = eq.is_nested(R_lmn=R_lmn, Z_lmn=Z_lmn)
+            if not nested:
+                warnings.warn(
+                    colored(
+                        "WARNING: Flux surfaces are no longer nested, exiting early."
+                        + "Consider taking smaller perturbation/resolution steps "
+                        + "or reducing trust radius",
+                        "yellow",
+                    )
+                )
             return not nested
 
         if self.method in Optimizer._scipy_scalar_methods:

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -6,7 +6,7 @@ from netCDF4 import Dataset, stringtochar
 from scipy import optimize, interpolate, integrate
 
 from desc.backend import sign
-from desc.utils import Timer, area_difference
+from desc.utils import Timer
 from desc.grid import Grid, LinearGrid
 from desc.basis import DoubleFourierSeries
 from desc.transform import Transform
@@ -1093,54 +1093,6 @@ class VMECIO:
             root_fun, x0=theta_star, method="diagbroyden", options={"ftol": 1e-6}
         )
         return out.x
-
-    @classmethod
-    def area_difference_vmec(cls, equil, vmec_data, Nr=10, Nt=8, **kwargs):
-        """Compute average normalized area difference between VMEC and DESC equilibria.
-
-        Parameters
-        ----------
-        equil : Equilibrium
-            desc equilibrium to compare
-        vmec_data : dict
-            dictionary of vmec outputs
-        Nr : int, optional
-            number of radial surfaces to average over
-        Nt : int, optional
-            number of vartheta contours to compare
-
-        Returns
-        -------
-        area_rho : ndarray, shape(Nr, Nz)
-            normalized area difference of rho contours, computed as the symmetric
-            difference divided by the intersection
-        area_theta : ndarray, shape(Nt, Nz)
-            normalized area difference between vartheta contours, computed as the area
-            of the polygon created by closing the two vartheta contours divided by the
-            perimeter squared
-
-        """
-        # 1e-3 tolerance seems reasonable for testing, similar to comparison by eye
-        if isinstance(vmec_data, (str, os.PathLike)):
-            vmec_data = cls.read_vmec_output(vmec_data)
-
-        if equil.N == 0:
-            Nz = 1
-        else:
-            Nz = 6
-
-        coords = cls.compute_coord_surfaces(equil, vmec_data, Nr, Nt, **kwargs)
-
-        Rr1 = coords["Rr_desc"]
-        Zr1 = coords["Zr_desc"]
-        Rv1 = coords["Rv_desc"]
-        Zv1 = coords["Zv_desc"]
-        Rr2 = coords["Rr_vmec"]
-        Zr2 = coords["Zr_vmec"]
-        Rv2 = coords["Rv_vmec"]
-        Zv2 = coords["Zv_vmec"]
-        area_rho, area_theta = area_difference(Rr1, Rr2, Zr1, Zr2, Rv1, Rv2, Zv1, Zv2)
-        return area_rho, area_theta
 
     @classmethod
     def compute_coord_surfaces(cls, equil, vmec_data, Nr=10, Nt=8, **kwargs):

--- a/devtools/dev-requirements.txt
+++ b/devtools/dev-requirements.txt
@@ -22,6 +22,7 @@ pytest-mpl == 0.16.0
 pytest-benchmark
 markupsafe==2.0.1
 nbmake
+shapely >= 1.8.2
 
 #For building
 build

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ netcdf4 >= 1.5.4
 nvgpu
 psutil
 scipy >= 1.5.0
-shapely >= 1.8.2
 termcolor

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import unittest
 from desc.equilibrium import Equilibrium, EquilibriaFamily
-from desc.grid import ConcentricGrid
+from desc.grid import ConcentricGrid, QuadratureGrid
 from desc.profiles import PowerSeriesProfile, SplineProfile
 from desc.geometry import (
     FourierRZCurve,
@@ -370,3 +370,17 @@ class TestSurfaces(unittest.TestCase):
             surf = eq.get_surface_at(rho=1, zeta=2)
         with pytest.raises(AssertionError):
             surf = eq.get_surface_at(rho=1.2)
+
+
+def test_is_nested():
+
+    eq = Equilibrium()
+    grid = QuadratureGrid(L=10, M=10, N=0)
+    assert eq.is_nested(grid=grid)
+
+    eq.change_resolution(L=2, M=2)
+    eq.R_lmn[eq.R_basis.get_idx(L=1, M=1, N=0)] = 1
+    # make unnested by setting higher order mode to same amplitude as lower order mode
+    eq.R_lmn[eq.R_basis.get_idx(L=2, M=2, N=0)] = 1
+
+    assert eq.is_nested(grid=grid) == False

--- a/tests/test_equilibrium.py
+++ b/tests/test_equilibrium.py
@@ -3,9 +3,9 @@ import numpy as np
 from netCDF4 import Dataset
 import pytest
 
+from .utils import area_difference, compute_coords
 from desc.equilibrium import EquilibriaFamily, Equilibrium
 from desc.grid import Grid, LinearGrid
-from desc.utils import area_difference
 from desc.__main__ import main
 from desc.geometry import ZernikeRZToroidalSection
 from desc.objectives import (
@@ -90,68 +90,13 @@ def test_compute_flux_coords(SOLOVEV):
     np.testing.assert_allclose(nodes, flux_coords, rtol=1e-5, atol=1e-5)
 
 
-def _compute_coords(equil, check_all_zeta=False):
-
-    if equil.N == 0 and not check_all_zeta:
-        Nz = 1
-    else:
-        Nz = 6
-
-    Nr = 10
-    Nt = 8
-    num_theta = 1000
-    num_rho = 1000
-
-    # flux surfaces to plot
-    rr = np.linspace(0, 1, Nr)
-    rt = np.linspace(0, 2 * np.pi, num_theta)
-    rz = np.linspace(0, 2 * np.pi / equil.NFP, Nz, endpoint=False)
-    r_grid = LinearGrid(rho=rr, theta=rt, zeta=rz)
-
-    # straight field-line angles to plot
-    tr = np.linspace(0, 1, num_rho)
-    tt = np.linspace(0, 2 * np.pi, Nt, endpoint=False)
-    tz = np.linspace(0, 2 * np.pi / equil.NFP, Nz, endpoint=False)
-    t_grid = LinearGrid(rho=tr, theta=tt, zeta=tz)
-
-    # Note: theta* (also known as vartheta) is the poloidal straight field-line
-    # angle in PEST-like flux coordinates
-
-    # find theta angles corresponding to desired theta* angles
-    v_grid = Grid(equil.compute_theta_coords(t_grid.nodes))
-    r_coords = equil.compute("R", r_grid)
-    v_coords = equil.compute("Z", v_grid)
-
-    # rho contours
-    Rr1 = r_coords["R"].reshape(
-        (r_grid.num_theta, r_grid.num_rho, r_grid.num_zeta), order="F"
-    )
-    Rr1 = np.swapaxes(Rr1, 0, 1)
-    Zr1 = r_coords["Z"].reshape(
-        (r_grid.num_theta, r_grid.num_rho, r_grid.num_zeta), order="F"
-    )
-    Zr1 = np.swapaxes(Zr1, 0, 1)
-
-    # vartheta contours
-    Rv1 = v_coords["R"].reshape(
-        (t_grid.num_theta, t_grid.num_rho, t_grid.num_zeta), order="F"
-    )
-    Rv1 = np.swapaxes(Rv1, 0, 1)
-    Zv1 = v_coords["Z"].reshape(
-        (t_grid.num_theta, t_grid.num_rho, t_grid.num_zeta), order="F"
-    )
-    Zv1 = np.swapaxes(Zv1, 0, 1)
-
-    return Rr1, Zr1, Rv1, Zv1
-
-
 @pytest.mark.slow
 def test_to_sfl(SOLOVEV):
 
     eq = EquilibriaFamily.load(load_from=str(SOLOVEV["desc_h5_path"]))[-1]
 
-    Rr1, Zr1, Rv1, Zv1 = _compute_coords(eq)
-    Rr2, Zr2, Rv2, Zv2 = _compute_coords(eq.to_sfl())
+    Rr1, Zr1, Rv1, Zv1 = compute_coords(eq)
+    Rr2, Zr2, Rv2, Zv2 = compute_coords(eq.to_sfl())
     rho_err, theta_err = area_difference(Rr1, Rr2, Zr1, Zr2, Rv1, Rv2, Zv1, Zv2)
 
     np.testing.assert_allclose(rho_err, 0, atol=2.5e-5)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -107,6 +107,27 @@ def test_1d_optimization(SOLOVEV):
     np.testing.assert_allclose(eq.compute("V")["R0/a"], 2.5)
 
 
+def test_unnested_warning_optimization(SOLOVEV):
+    """Tests 1D optimization for target aspect ratio."""
+    optimizer = Optimizer("scipy-trust-exact")
+    eq = EquilibriaFamily.load(load_from=str(SOLOVEV["desc_h5_path"]))[-1]
+    eq.R_lmn[eq.R_basis.get_idx(L=1, M=1, N=0)] = 1
+    # make unnested by setting higher order mode to same amplitude as lower order mode
+    eq.R_lmn[eq.R_basis.get_idx(L=2, M=2, N=0)] = 1
+    objective = ObjectiveFunction(AspectRatio(target=2.5))
+    constraints = (
+        ForceBalance(),
+        FixBoundaryR(),
+        FixBoundaryZ(modes=eq.surface.Z_basis.modes[0:-1, :]),
+        FixPressure(),
+        FixIota(),
+        FixPsi(),
+    )
+    options = {"perturb_options": {"order": 1}}
+    with pytest.warns(Warning):
+        eq.optimize(objective, constraints, options=options)  # , optimizer=optimizer)
+
+
 def test_1d_optimization_old(SOLOVEV):
     """Tests 1D optimization for target aspect ratio."""
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -14,6 +14,7 @@ from desc.objectives import (
     FixPsi,
 )
 from desc.vmec_utils import vmec_boundary_subspace
+from desc.optimize import Optimizer
 from .utils import area_difference_vmec
 
 
@@ -87,7 +88,7 @@ def test_force_balance_grids():
 
 def test_1d_optimization(SOLOVEV):
     """Tests 1D optimization for target aspect ratio."""
-
+    optimizer = Optimizer("scipy-trust-exact")
     eq = EquilibriaFamily.load(load_from=str(SOLOVEV["desc_h5_path"]))[-1]
     objective = ObjectiveFunction(AspectRatio(target=2.5))
     constraints = (
@@ -99,7 +100,7 @@ def test_1d_optimization(SOLOVEV):
         FixPsi(),
     )
     options = {"perturb_options": {"order": 1}}
-    eq.optimize(objective, constraints, options=options)
+    eq.optimize(objective, constraints, options=options, optimizer=optimizer)
 
     np.testing.assert_allclose(eq.compute("V")["R0/a"], 2.5)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,6 +16,7 @@ from desc.objectives import (
 from desc.vmec_utils import vmec_boundary_subspace
 from desc.optimize import Optimizer
 from .utils import area_difference_vmec
+import pytest
 
 
 def test_SOLOVEV_vacuum(SOLOVEV_vac):
@@ -88,7 +89,7 @@ def test_force_balance_grids():
 
 def test_1d_optimization(SOLOVEV):
     """Tests 1D optimization for target aspect ratio."""
-    optimizer = Optimizer("scipy-trust-exact")
+    optimizer = Optimizer("lsq-exact")
     eq = EquilibriaFamily.load(load_from=str(SOLOVEV["desc_h5_path"]))[-1]
     objective = ObjectiveFunction(AspectRatio(target=2.5))
     constraints = (
@@ -100,7 +101,8 @@ def test_1d_optimization(SOLOVEV):
         FixPsi(),
     )
     options = {"perturb_options": {"order": 1}}
-    eq.optimize(objective, constraints, options=options, optimizer=optimizer)
+    with pytest.warns(UserWarning):
+        eq.optimize(objective, constraints, options=options)  # , optimizer=optimizer)
 
     np.testing.assert_allclose(eq.compute("V")["R0/a"], 2.5)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -13,8 +13,8 @@ from desc.objectives import (
     FixIota,
     FixPsi,
 )
-from desc.vmec import VMECIO
 from desc.vmec_utils import vmec_boundary_subspace
+from .utils import area_difference_vmec
 
 
 def test_SOLOVEV_vacuum(SOLOVEV_vac):
@@ -31,7 +31,7 @@ def test_SOLOVEV_results(SOLOVEV):
     """Tests that the SOLOVEV example gives the same result as VMEC."""
 
     eq = EquilibriaFamily.load(load_from=str(SOLOVEV["desc_h5_path"]))[-1]
-    rho_err, theta_err = VMECIO.area_difference_vmec(eq, SOLOVEV["vmec_nc_path"])
+    rho_err, theta_err = area_difference_vmec(eq, SOLOVEV["vmec_nc_path"])
 
     np.testing.assert_allclose(rho_err, 0, atol=1e-3)
     np.testing.assert_allclose(theta_err, 0, atol=1e-5)
@@ -41,7 +41,7 @@ def test_DSHAPE_results(DSHAPE):
     """Tests that the DSHAPE example gives the same result as VMEC."""
 
     eq = EquilibriaFamily.load(load_from=str(DSHAPE["desc_h5_path"]))[-1]
-    rho_err, theta_err = VMECIO.area_difference_vmec(eq, DSHAPE["vmec_nc_path"])
+    rho_err, theta_err = area_difference_vmec(eq, DSHAPE["vmec_nc_path"])
 
     np.testing.assert_allclose(rho_err, 0, atol=2e-3)
     np.testing.assert_allclose(theta_err, 0, atol=1e-5)
@@ -51,7 +51,7 @@ def test_HELIOTRON_results(HELIOTRON):
     """Tests that the HELIOTRON example gives the same result as VMEC."""
 
     eq = EquilibriaFamily.load(load_from=str(HELIOTRON["desc_h5_path"]))[-1]
-    rho_err, theta_err = VMECIO.area_difference_vmec(eq, HELIOTRON["vmec_nc_path"])
+    rho_err, theta_err = area_difference_vmec(eq, HELIOTRON["vmec_nc_path"])
 
     np.testing.assert_allclose(rho_err.mean(), 0, atol=1e-2)
     np.testing.assert_allclose(theta_err.mean(), 0, atol=2e-2)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -107,27 +107,6 @@ def test_1d_optimization(SOLOVEV):
     np.testing.assert_allclose(eq.compute("V")["R0/a"], 2.5)
 
 
-def test_unnested_warning_optimization(SOLOVEV):
-    """Tests 1D optimization for target aspect ratio."""
-    optimizer = Optimizer("scipy-trust-exact")
-    eq = EquilibriaFamily.load(load_from=str(SOLOVEV["desc_h5_path"]))[-1]
-    eq.R_lmn[eq.R_basis.get_idx(L=1, M=1, N=0)] = 1
-    # make unnested by setting higher order mode to same amplitude as lower order mode
-    eq.R_lmn[eq.R_basis.get_idx(L=2, M=2, N=0)] = 1
-    objective = ObjectiveFunction(AspectRatio(target=2.5))
-    constraints = (
-        ForceBalance(),
-        FixBoundaryR(),
-        FixBoundaryZ(modes=eq.surface.Z_basis.modes[0:-1, :]),
-        FixPressure(),
-        FixIota(),
-        FixPsi(),
-    )
-    options = {"perturb_options": {"order": 1}}
-    with pytest.warns(UserWarning):
-        eq.optimize(objective, constraints, options=options, optimizer=optimizer)
-
-
 def test_1d_optimization_old(SOLOVEV):
     """Tests 1D optimization for target aspect ratio."""
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -124,8 +124,8 @@ def test_unnested_warning_optimization(SOLOVEV):
         FixPsi(),
     )
     options = {"perturb_options": {"order": 1}}
-    with pytest.warns(Warning):
-        eq.optimize(objective, constraints, options=options)  # , optimizer=optimizer)
+    with pytest.warns(UserWarning):
+        eq.optimize(objective, constraints, options=options, optimizer=optimizer)
 
 
 def test_1d_optimization_old(SOLOVEV):

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -4,7 +4,7 @@ import pytest
 from desc.io import InputReader
 from desc.profiles import PowerSeriesProfile
 from desc.equilibrium import Equilibrium
-from tests.test_equilibrium import _compute_coords, area_difference
+from .utils import compute_coords, area_difference
 
 
 class TestProfiles(unittest.TestCase):
@@ -22,8 +22,8 @@ class TestProfiles(unittest.TestCase):
         eq1.solve()
         eq2.solve()
 
-        Rr1, Zr1, Rv1, Zv1 = _compute_coords(eq1, check_all_zeta=True)
-        Rr2, Zr2, Rv2, Zv2 = _compute_coords(eq2, check_all_zeta=True)
+        Rr1, Zr1, Rv1, Zv1 = compute_coords(eq1, check_all_zeta=True)
+        Rr2, Zr2, Rv2, Zv2 = compute_coords(eq2, check_all_zeta=True)
         rho_err, theta_err = area_difference(Rr1, Rr2, Zr1, Zr2, Rv1, Rv2, Zv1, Zv2)
         np.testing.assert_allclose(rho_err, 0, atol=1e-7)
         np.testing.assert_allclose(theta_err, 0, atol=2e-11)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,174 @@
+import os
+import numpy as np
+from shapely.geometry import Polygon
+from desc.vmec import VMECIO
+from desc.grid import Grid, LinearGrid
+
+
+def compute_coords(equil, check_all_zeta=False):
+
+    if equil.N == 0 and not check_all_zeta:
+        Nz = 1
+    else:
+        Nz = 6
+
+    Nr = 10
+    Nt = 8
+    num_theta = 1000
+    num_rho = 1000
+
+    # flux surfaces to plot
+    rr = np.linspace(0, 1, Nr)
+    rt = np.linspace(0, 2 * np.pi, num_theta)
+    rz = np.linspace(0, 2 * np.pi / equil.NFP, Nz, endpoint=False)
+    r_grid = LinearGrid(rho=rr, theta=rt, zeta=rz)
+
+    # straight field-line angles to plot
+    tr = np.linspace(0, 1, num_rho)
+    tt = np.linspace(0, 2 * np.pi, Nt, endpoint=False)
+    tz = np.linspace(0, 2 * np.pi / equil.NFP, Nz, endpoint=False)
+    t_grid = LinearGrid(rho=tr, theta=tt, zeta=tz)
+
+    # Note: theta* (also known as vartheta) is the poloidal straight field-line
+    # angle in PEST-like flux coordinates
+
+    # find theta angles corresponding to desired theta* angles
+    v_grid = Grid(equil.compute_theta_coords(t_grid.nodes))
+    r_coords = equil.compute("R", r_grid)
+    v_coords = equil.compute("Z", v_grid)
+
+    # rho contours
+    Rr1 = r_coords["R"].reshape(
+        (r_grid.num_theta, r_grid.num_rho, r_grid.num_zeta), order="F"
+    )
+    Rr1 = np.swapaxes(Rr1, 0, 1)
+    Zr1 = r_coords["Z"].reshape(
+        (r_grid.num_theta, r_grid.num_rho, r_grid.num_zeta), order="F"
+    )
+    Zr1 = np.swapaxes(Zr1, 0, 1)
+
+    # vartheta contours
+    Rv1 = v_coords["R"].reshape(
+        (t_grid.num_theta, t_grid.num_rho, t_grid.num_zeta), order="F"
+    )
+    Rv1 = np.swapaxes(Rv1, 0, 1)
+    Zv1 = v_coords["Z"].reshape(
+        (t_grid.num_theta, t_grid.num_rho, t_grid.num_zeta), order="F"
+    )
+    Zv1 = np.swapaxes(Zv1, 0, 1)
+
+    return Rr1, Zr1, Rv1, Zv1
+
+
+def area_difference(Rr1, Rr2, Zr1, Zr2, Rv1, Rv2, Zv1, Zv2):
+    """Compute area difference between coordinate curves
+
+    Parameters
+    ----------
+    args : ndarray
+        R and Z coordinates of constant rho (r) or vartheta (v) contours.
+        Arrays should be indexed as [rho,theta,zeta]
+
+    Returns
+    -------
+    area_rho : ndarray, shape(Nr, Nz)
+        normalized area difference of rho contours, computed as the symmetric
+        difference divided by the intersection
+    area_theta : ndarray, shape(Nt, Nz)
+        normalized area difference between vartheta contours, computed as the area
+        of the polygon created by closing the two vartheta contours divided by the
+        perimeter squared
+    """
+    assert Rr1.shape == Rr2.shape == Zr1.shape == Zr2.shape
+    assert Rv1.shape == Rv2.shape == Zv1.shape == Zv2.shape
+
+    poly_r1 = np.array(
+        [
+            [Polygon(np.array([R, Z]).T) for R, Z in zip(Rr1[:, :, i], Zr1[:, :, i])]
+            for i in range(Rr1.shape[2])
+        ]
+    )
+    poly_r2 = np.array(
+        [
+            [Polygon(np.array([R, Z]).T) for R, Z in zip(Rr2[:, :, i], Zr2[:, :, i])]
+            for i in range(Rr2.shape[2])
+        ]
+    )
+    poly_v = np.array(
+        [
+            [
+                Polygon(np.array([R, Z]).T)
+                for R, Z in zip(
+                    np.hstack([Rv1[:, :, i].T, Rv2[::-1, :, i].T]),
+                    np.hstack([Zv1[:, :, i].T, Zv2[::-1, :, i].T]),
+                )
+            ]
+            for i in range(Rv1.shape[2])
+        ]
+    )
+
+    diff_rho = np.array(
+        [
+            poly1.symmetric_difference(poly2).area
+            for poly1, poly2 in zip(poly_r1.flat, poly_r2.flat)
+        ]
+    ).reshape((Rr1.shape[2], Rr1.shape[0]))
+    intersect_rho = np.array(
+        [
+            poly1.intersection(poly2).area
+            for poly1, poly2 in zip(poly_r1.flat, poly_r2.flat)
+        ]
+    ).reshape((Rr1.shape[2], Rr1.shape[0]))
+    area_rho = np.where(diff_rho > 0, diff_rho / intersect_rho, 0)
+    area_theta = np.array(
+        [poly.area / (poly.length) ** 2 for poly in poly_v.flat]
+    ).reshape((Rv1.shape[1], Rv1.shape[2]))
+    return area_rho, area_theta
+
+
+def area_difference_vmec(equil, vmec_data, Nr=10, Nt=8, **kwargs):
+    """Compute average normalized area difference between VMEC and DESC equilibria.
+
+    Parameters
+    ----------
+    equil : Equilibrium
+        desc equilibrium to compare
+    vmec_data : dict
+        dictionary of vmec outputs
+    Nr : int, optional
+        number of radial surfaces to average over
+    Nt : int, optional
+        number of vartheta contours to compare
+
+    Returns
+    -------
+    area_rho : ndarray, shape(Nr, Nz)
+        normalized area difference of rho contours, computed as the symmetric
+        difference divided by the intersection
+    area_theta : ndarray, shape(Nt, Nz)
+        normalized area difference between vartheta contours, computed as the area
+        of the polygon created by closing the two vartheta contours divided by the
+        perimeter squared
+
+    """
+    # 1e-3 tolerance seems reasonable for testing, similar to comparison by eye
+    if isinstance(vmec_data, (str, os.PathLike)):
+        vmec_data = VMECIO.read_vmec_output(vmec_data)
+
+    if equil.N == 0:
+        Nz = 1
+    else:
+        Nz = 6
+
+    coords = VMECIO.compute_coord_surfaces(equil, vmec_data, Nr, Nt, **kwargs)
+
+    Rr1 = coords["Rr_desc"]
+    Zr1 = coords["Zr_desc"]
+    Rv1 = coords["Rv_desc"]
+    Zv1 = coords["Zv_desc"]
+    Rr2 = coords["Rr_vmec"]
+    Zr2 = coords["Zr_vmec"]
+    Rv2 = coords["Rv_vmec"]
+    Zv2 = coords["Zv_vmec"]
+    area_rho, area_theta = area_difference(Rr1, Rr2, Zr1, Zr2, Rv1, Rv2, Zv1, Zv2)
+    return area_rho, area_theta


### PR DESCRIPTION
… geometric intersection

Changes:

 - `is_nested` method of `Configuration` now checks for nestedness by checking that the jacobian does not switch sign anywhere in the volume, using a quadrature grid with the current grid resolution, instead of the old method of checking for geometric intersection using a certain number of surfaces
   - Can also accept `R_lmn` and `Z_lmn` as arguments to use, to check coefficients other than the equilibrium's own coefficients for nestedness
 - move `shapely` dependency from requirements to dev_requirements
