### PR TITLE
self-consistent equilibrium attributes

### DIFF
--- a/desc/configuration.py
+++ b/desc/configuration.py
@@ -329,9 +329,6 @@ class _Configuration(IOAble, ABC):
         eq_NFP = self.NFP
         surf_NFP = self.surface.NFP if hasattr(self.surface, "NFP") else self.NFP
         axis_NFP = self._axis.NFP
-        print("eq:", eq_NFP)
-        print("surf:", surf_NFP)
-        print("axis:", axis_NFP)
 
         if not (eq_NFP == surf_NFP == axis_NFP):
             raise ValueError(

--- a/desc/configuration.py
+++ b/desc/configuration.py
@@ -693,7 +693,6 @@ class _Configuration(IOAble, ABC):
         if L_change and hasattr(self.iota, "change_resolution"):
             self.iota.change_resolution(L=max(L, self.iota.basis.L))
 
-        self.axis.change_resolution(self.N, NFP=self.NFP)
         self.surface.change_resolution(self.L, self.M, self.N, NFP=self.NFP)
 
         self._R_lmn = copy_coeffs(self.R_lmn, old_modes_R, self.R_basis.modes)

--- a/desc/configuration.py
+++ b/desc/configuration.py
@@ -207,7 +207,7 @@ class _Configuration(IOAble, ABC):
             spectral_indexing=self.spectral_indexing,
         )
 
-        # surface and axis
+        # surface
         if surface is None:
             self._surface = FourierRZToroidalSurface(NFP=self.NFP)
             self._bdry_mode = "lcfs"
@@ -246,6 +246,7 @@ class _Configuration(IOAble, ABC):
             raise TypeError("Got unknown surface type {}".format(surface))
         self._surface.change_resolution(self.L, self.M, self.N)
 
+        # magnetic axis
         if isinstance(axis, FourierRZCurve):
             self._axis = axis
         elif isinstance(axis, (np.ndarray, jnp.ndarray)):
@@ -276,6 +277,7 @@ class _Configuration(IOAble, ABC):
                     NFP=self.NFP,
                 )
             elif isinstance(self.surface, ZernikeRZToroidalSection):
+                # FIXME: include m=0 l!=0 modes
                 self._axis = FourierRZCurve(
                     R_n=self.surface.R_lmn[
                         np.where(
@@ -295,16 +297,6 @@ class _Configuration(IOAble, ABC):
                 )
         else:
             raise TypeError("Got unknown axis type {}".format(axis))
-
-        # make sure field periods agree
-        eqNFP = self.NFP
-        surfNFP = self.surface.NFP if hasattr(self.surface, "NFP") else self.NFP
-        axNFP = self.axis.NFP
-        if not (eqNFP == surfNFP == axNFP):
-            raise ValueError(
-                "Unequal number of field periods for equilirium "
-                + f"{eqNFP}, surface {surfNFP}, and axis {axNFP}"
-            )
 
         # profiles
         if isinstance(pressure, Profile):
@@ -347,6 +339,16 @@ class _Configuration(IOAble, ABC):
             self.Z_lmn = kwargs.pop("Z_lmn")
         if "L_lmn" in kwargs:
             self.L_lmn = kwargs.pop("L_lmn")
+
+        # ensure number of field periods agree
+        eq_NFP = self.NFP
+        surf_NFP = self.surface.NFP if hasattr(self.surface, "NFP") else self.NFP
+        axis_NFP = self.axis.NFP
+        if not (eq_NFP == surf_NFP == axis_NFP):
+            raise ValueError(
+                "Unequal number of field periods for equilirium "
+                + f"{eq_NFP}, surface {surf_NFP}, and axis {axis_NFP}"
+            )
 
     # TODO: allow user to pass in arrays for surface, axis? or R_lmn etc?
     # TODO: make this kwargs instead?
@@ -413,8 +415,12 @@ class _Configuration(IOAble, ABC):
             if hasattr(self, "_surface"):
                 # use whatever surface is already assigned
                 if hasattr(self, "_axis"):
-                    axisR = np.array([self.axis.R_basis.modes[:, -1], self.axis.R_n]).T
-                    axisZ = np.array([self.axis.Z_basis.modes[:, -1], self.axis.Z_n]).T
+                    axisR = np.array(
+                        [self._axis.R_basis.modes[:, -1], self._axis.R_n]
+                    ).T
+                    axisZ = np.array(
+                        [self._axis.Z_basis.modes[:, -1], self._axis.Z_n]
+                    ).T
                 else:
                     axisR = None
                     axisZ = None
@@ -940,18 +946,29 @@ class _Configuration(IOAble, ABC):
     @property
     def axis(self):
         """Curve object representing the magnetic axis."""
-        # TODO: return the current axis by evaluating at rho=0
+        # value of Zernike polynomials at rho=0 for unique radial modes (+/-1)
+        sign_l = np.atleast_2d(((np.arange(0, self.L + 1, 2) / 2) % 2) * -2 + 1).T
+        # indices where m=0
+        idx0_R = np.where((self.R_basis.modes[:, 1] == 0))[0]
+        idx0_Z = np.where((self.Z_basis.modes[:, 1] == 0))[0]
+        # indices where l=0 & m=0
+        idx00_R = np.where((self.R_basis.modes[:, :2] == [0, 0]).all(axis=1))[0]
+        idx00_Z = np.where((self.Z_basis.modes[:, :2] == [0, 0]).all(axis=1))[0]
+        # this reshaping assumes the FourierZernike bases are sorted
+        self._axis = FourierRZCurve(
+            R_n=np.sum(
+                sign_l * np.reshape(self.R_lmn[idx0_R], (-1, idx00_R.size), order="F"),
+                axis=0,
+            ),
+            Z_n=np.sum(
+                sign_l * np.reshape(self.Z_lmn[idx0_Z], (-1, idx00_Z.size), order="F"),
+                axis=0,
+            ),
+            modes_R=self.R_basis.modes[idx00_R, 2],
+            modes_Z=self.Z_basis.modes[idx00_Z, 2],
+            NFP=self.NFP,
+        )
         return self._axis
-
-    @axis.setter
-    def axis(self, new):
-        if isinstance(new, FourierRZCurve):
-            new.change_resolution(self.N)
-            self._axis = new
-        else:
-            raise TypeError(
-                f"axis should be of type FourierRZCurve or a subclass, got {new}"
-            )
 
     @property
     def pressure(self):

--- a/desc/configuration.py
+++ b/desc/configuration.py
@@ -325,6 +325,20 @@ class _Configuration(IOAble, ABC):
         else:
             raise TypeError("Got unknown iota profile {}".format(iota))
 
+        # ensure number of field periods agree before setting guesses
+        eq_NFP = self.NFP
+        surf_NFP = self.surface.NFP if hasattr(self.surface, "NFP") else self.NFP
+        axis_NFP = self._axis.NFP
+        print("eq:", eq_NFP)
+        print("surf:", surf_NFP)
+        print("axis:", axis_NFP)
+
+        if not (eq_NFP == surf_NFP == axis_NFP):
+            raise ValueError(
+                "Unequal number of field periods for equilirium "
+                + f"{eq_NFP}, surface {surf_NFP}, and axis {axis_NFP}"
+            )
+
         # keep track of where it came from
         self._parent = None
         self._children = []
@@ -339,16 +353,6 @@ class _Configuration(IOAble, ABC):
             self.Z_lmn = kwargs.pop("Z_lmn")
         if "L_lmn" in kwargs:
             self.L_lmn = kwargs.pop("L_lmn")
-
-        # ensure number of field periods agree
-        eq_NFP = self.NFP
-        surf_NFP = self.surface.NFP if hasattr(self.surface, "NFP") else self.NFP
-        axis_NFP = self.axis.NFP
-        if not (eq_NFP == surf_NFP == axis_NFP):
-            raise ValueError(
-                "Unequal number of field periods for equilirium "
-                + f"{eq_NFP}, surface {surf_NFP}, and axis {axis_NFP}"
-            )
 
     # TODO: allow user to pass in arrays for surface, axis? or R_lmn etc?
     # TODO: make this kwargs instead?

--- a/desc/configuration.py
+++ b/desc/configuration.py
@@ -535,7 +535,7 @@ class _Configuration(IOAble, ABC):
     def _initial_guess_surface(
         self, x_basis, b_lmn, b_basis, axis=None, mode=None, coord=None
     ):
-        """Create an initial guess from the boundary coefficients and magnetic axis guess.
+        """Create an initial guess from boundary coefficients and a magnetic axis guess.
 
         Parameters
         ----------

--- a/desc/configuration.py
+++ b/desc/configuration.py
@@ -955,19 +955,21 @@ class _Configuration(IOAble, ABC):
         idx00_R = np.where((self.R_basis.modes[:, :2] == [0, 0]).all(axis=1))[0]
         idx00_Z = np.where((self.Z_basis.modes[:, :2] == [0, 0]).all(axis=1))[0]
         # this reshaping assumes the FourierZernike bases are sorted
-        self._axis = FourierRZCurve(
-            R_n=np.sum(
-                sign_l * np.reshape(self.R_lmn[idx0_R], (-1, idx00_R.size), order="F"),
-                axis=0,
-            ),
-            Z_n=np.sum(
+        R_n = np.sum(
+            sign_l * np.reshape(self.R_lmn[idx0_R], (-1, idx00_R.size), order="F"),
+            axis=0,
+        )
+        modes_R = self.R_basis.modes[idx00_R, 2]
+        if len(idx00_Z):
+            Z_n = np.sum(
                 sign_l * np.reshape(self.Z_lmn[idx0_Z], (-1, idx00_Z.size), order="F"),
                 axis=0,
-            ),
-            modes_R=self.R_basis.modes[idx00_R, 2],
-            modes_Z=self.Z_basis.modes[idx00_Z, 2],
-            NFP=self.NFP,
-        )
+            )
+            modes_Z = self.Z_basis.modes[idx00_Z, 2]
+        else:  # catch cases such as axisymmetry with stellarator symmetry
+            Z_n = 0
+            modes_Z = 0
+        self._axis = FourierRZCurve(R_n, Z_n, modes_R, modes_Z, NFP=self.NFP)
         return self._axis
 
     @property

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -33,10 +33,15 @@ class TestConstructor(unittest.TestCase):
         pressure = SplineProfile([1, 2, 3])
         iota = SplineProfile([2, 3, 4])
         surface = FourierRZToroidalSurface(NFP=2, sym=False)
-        axis = FourierRZCurve([-1, 10, 1], [1, 0, -1], NFP=2, sym=False)
-
+        axis = FourierRZCurve([-0.2, 10, 0.3], [0.3, 0, -0.2], NFP=2, sym=False)
         eq = Equilibrium(
-            pressure=pressure, iota=iota, surface=surface, axis=axis, N=1, sym=False
+            M=2,
+            pressure=pressure,
+            iota=iota,
+            surface=surface,
+            axis=axis,
+            N=1,
+            sym=False,
         )
 
         self.assertTrue(eq.pressure.eq(pressure))
@@ -45,10 +50,8 @@ class TestConstructor(unittest.TestCase):
         self.assertEqual(eq.NFP, 2)
         self.assertEqual(eq.axis.NFP, 2)
 
-        Rax, Zax = axis.get_coeffs([1, 0, -1])
-        Req, Zeq = eq.axis.get_coeffs([1, 0, -1])
-        np.testing.assert_allclose(Rax, Req)
-        np.testing.assert_allclose(Zax, Zeq)
+        np.testing.assert_allclose(axis.R_n, eq.Ra_n)
+        np.testing.assert_allclose(axis.Z_n, eq.Za_n)
 
         surface2 = ZernikeRZToroidalSection(spectral_indexing="ansi")
         eq2 = Equilibrium(surface=surface2)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -40,7 +40,6 @@ class TestConstructor(unittest.TestCase):
         self.assertTrue(eq.pressure.eq(pressure))
         self.assertTrue(eq.iota.eq(iota))
         self.assertTrue(eq.surface.eq(surface))
-        self.assertTrue(eq.axis.eq(axis))
         self.assertEqual(eq.spectral_indexing, "ansi")
         self.assertEqual(eq.NFP, 2)
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -332,23 +332,23 @@ class TestInitialGuess(unittest.TestCase):
         np.testing.assert_allclose(eq.Z_lmn, eq2.Z_lmn, atol=1e-8)
         np.testing.assert_allclose(eq.L_lmn, eq2.L_lmn, atol=1e-8)
 
-    def test_NFP_agree_error(self):
-
-        surface = FourierRZToroidalSurface(NFP=3)
+    def test_NFP_error(self):
+        """Check for ValueError when eq, axis, and surface NFPs do not agree."""
         axis = FourierRZCurve([-1, 10, 1], [1, 0, -1], NFP=2)
+        surface2 = FourierRZToroidalSurface(NFP=2)
+        surface3 = FourierRZToroidalSurface(NFP=3)
+
         # test axis and eq NFP not agreeing
         with pytest.raises(ValueError):
-            eq = Equilibrium(surface=surface, axis=axis, NFP=3)
+            eq = Equilibrium(surface=surface3, axis=axis, NFP=3)
 
-        surface2 = FourierRZToroidalSurface(NFP=2)
         # test axis and surface NFP not agreeing
         with pytest.raises(ValueError):
-            eq2 = Equilibrium(surface=surface2, axis=axis, NFP=3)
+            eq = Equilibrium(surface=surface2, axis=axis, NFP=3)
 
-        surface3 = FourierRZToroidalSurface(NFP=3)
         # test surface and eq NFP not agreeing
         with pytest.raises(ValueError):
-            eq3 = Equilibrium(surface=surface3, axis=axis, NFP=2)
+            eq = Equilibrium(surface=surface3, axis=axis, NFP=2)
 
 
 def test_guess_from_file(SOLOVEV):
@@ -391,20 +391,7 @@ class TestSurfaces(unittest.TestCase):
 
 
 def test_magnetic_axis(HELIOTRON):
-    """Tests that Configuration.axis returns the true axis location."""
-    eq = EquilibriaFamily.load(load_from=str(HELIOTRON["desc_h5_path"]))[-1]
-    axis = eq.axis
-    grid = LinearGrid(N=3 * eq.N_grid, NFP=eq.NFP, rho=np.array(0.0))
-
-    data = eq.compute("sqrt(g)", grid=grid)
-    coords = axis.compute_coordinates(grid=grid)
-
-    np.testing.assert_allclose(coords[:, 0], data["R"])
-    np.testing.assert_allclose(coords[:, 2], data["Z"])
-
-
-def test_NFP_warning(HELIOTRON):
-    """Tests that Configuration.axis returns the true axis location."""
+    """Test that Configuration.axis returns the true axis location."""
     eq = EquilibriaFamily.load(load_from=str(HELIOTRON["desc_h5_path"]))[-1]
     axis = eq.axis
     grid = LinearGrid(N=3 * eq.N_grid, NFP=eq.NFP, rho=np.array(0.0))

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -32,24 +32,35 @@ class TestConstructor(unittest.TestCase):
 
         pressure = SplineProfile([1, 2, 3])
         iota = SplineProfile([2, 3, 4])
-        surface = ZernikeRZToroidalSection(spectral_indexing="ansi")
-        axis = FourierRZCurve([-1, 10, 1], [1, 0, -1], NFP=2)
+        surface = FourierRZToroidalSurface(NFP=2, sym=False)
+        axis = FourierRZCurve([-1, 10, 1], [1, 0, -1], NFP=2, sym=False)
 
-        eq = Equilibrium(pressure=pressure, iota=iota, surface=surface, axis=axis)
+        eq = Equilibrium(
+            pressure=pressure, iota=iota, surface=surface, axis=axis, N=1, sym=False
+        )
 
         self.assertTrue(eq.pressure.eq(pressure))
         self.assertTrue(eq.iota.eq(iota))
-        self.assertTrue(eq.surface.eq(surface))
         self.assertEqual(eq.spectral_indexing, "ansi")
         self.assertEqual(eq.NFP, 2)
+        self.assertEqual(eq.axis.NFP, 2)
 
-        surface2 = FourierRZToroidalSurface(NFP=3)
+        Rax, Zax = axis.get_coeffs([1, 0, -1])
+        Req, Zeq = eq.axis.get_coeffs([1, 0, -1])
+        np.testing.assert_allclose(Rax, Req)
+        np.testing.assert_allclose(Zax, Zeq)
+
+        surface2 = ZernikeRZToroidalSection(spectral_indexing="ansi")
         eq2 = Equilibrium(surface=surface2)
-        self.assertEqual(eq2.NFP, 3)
-        self.assertEqual(eq2.axis.NFP, 3)
+        self.assertTrue(eq2.surface.eq(surface2))
 
-        eq3 = Equilibrium(surface=surface, axis=None)
-        np.testing.assert_allclose(eq3.axis.R_n, [10])
+        surface3 = FourierRZToroidalSurface(NFP=3)
+        eq3 = Equilibrium(surface=surface3)
+        self.assertEqual(eq3.NFP, 3)
+        self.assertEqual(eq3.axis.NFP, 3)
+
+        eq4 = Equilibrium(surface=surface2, axis=None)
+        np.testing.assert_allclose(eq4.axis.R_n, [10])
 
     def test_dict(self):
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import unittest
 from desc.equilibrium import Equilibrium, EquilibriaFamily
-from desc.grid import ConcentricGrid, QuadratureGrid
+from desc.grid import LinearGrid, ConcentricGrid, QuadratureGrid
 from desc.profiles import PowerSeriesProfile, SplineProfile
 from desc.geometry import (
     FourierRZCurve,
@@ -370,6 +370,19 @@ class TestSurfaces(unittest.TestCase):
             surf = eq.get_surface_at(rho=1, zeta=2)
         with pytest.raises(AssertionError):
             surf = eq.get_surface_at(rho=1.2)
+
+
+def test_magnetic_axis(HELIOTRON):
+    """Tests that Configuration.axis returns the true axis location."""
+    eq = EquilibriaFamily.load(load_from=str(HELIOTRON["desc_h5_path"]))[-1]
+    axis = eq.axis
+    grid = LinearGrid(N=3 * eq.N_grid, NFP=eq.NFP, rho=np.array(0.0))
+
+    data = eq.compute("sqrt(g)", grid=grid)
+    coords = axis.compute_coordinates(grid=grid)
+
+    np.testing.assert_allclose(coords[:, 0], data["R"])
+    np.testing.assert_allclose(coords[:, 2], data["Z"])
 
 
 def test_is_nested():

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -332,6 +332,24 @@ class TestInitialGuess(unittest.TestCase):
         np.testing.assert_allclose(eq.Z_lmn, eq2.Z_lmn, atol=1e-8)
         np.testing.assert_allclose(eq.L_lmn, eq2.L_lmn, atol=1e-8)
 
+    def test_NFP_agree_error(self):
+
+        surface = FourierRZToroidalSurface(NFP=3)
+        axis = FourierRZCurve([-1, 10, 1], [1, 0, -1], NFP=2)
+        # test axis and eq NFP not agreeing
+        with pytest.raises(ValueError):
+            eq = Equilibrium(surface=surface, axis=axis, NFP=3)
+
+        surface2 = FourierRZToroidalSurface(NFP=2)
+        # test axis and surface NFP not agreeing
+        with pytest.raises(ValueError):
+            eq2 = Equilibrium(surface=surface2, axis=axis, NFP=3)
+
+        surface3 = FourierRZToroidalSurface(NFP=3)
+        # test surface and eq NFP not agreeing
+        with pytest.raises(ValueError):
+            eq3 = Equilibrium(surface=surface3, axis=axis, NFP=2)
+
 
 def test_guess_from_file(SOLOVEV):
 
@@ -373,6 +391,19 @@ class TestSurfaces(unittest.TestCase):
 
 
 def test_magnetic_axis(HELIOTRON):
+    """Tests that Configuration.axis returns the true axis location."""
+    eq = EquilibriaFamily.load(load_from=str(HELIOTRON["desc_h5_path"]))[-1]
+    axis = eq.axis
+    grid = LinearGrid(N=3 * eq.N_grid, NFP=eq.NFP, rho=np.array(0.0))
+
+    data = eq.compute("sqrt(g)", grid=grid)
+    coords = axis.compute_coordinates(grid=grid)
+
+    np.testing.assert_allclose(coords[:, 0], data["R"])
+    np.testing.assert_allclose(coords[:, 2], data["Z"])
+
+
+def test_NFP_warning(HELIOTRON):
     """Tests that Configuration.axis returns the true axis location."""
     eq = EquilibriaFamily.load(load_from=str(HELIOTRON["desc_h5_path"]))[-1]
     axis = eq.axis


### PR DESCRIPTION
`Equilibrium.axis` and consequently `eq.Ra_n` & `eq.Za_n` were returning the axis shape from the initial guess, and never got updated after an equilibrium solve. This is now changed so that calling `eq.axis` always evaluates its position at rho=0 to be self-consistent with `eq.R_lmn` & `eq.Z_lmn`. 

Other notes: 
- The axis setter method was removed, since we shouldn't allow the user to assign an axis shape that is inconsistent with the rest of the flux surfaces. 
- Added a test that compares the axis shape to computing R & Z at rho=0. 

**Question:** Should we make a similar change to `Equilibrium.surface`? The same problem exists where the surface attribute could be inconsistent with the flux surfaces shapes (for example, after a boundary perturbation). 