### PR TITLE
Allow hdf5 to store None attributes correctly

### DIFF
--- a/desc/io/hdf5_io.py
+++ b/desc/io/hdf5_io.py
@@ -252,7 +252,7 @@ class hdf5Reader(hdf5IO, Reader):
                             RuntimeWarning,
                         )
                         continue
-                i += 1
+            i += 1
 
         return thelist
 

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -13,6 +13,7 @@ from desc.utils import equals
 from desc.grid import LinearGrid
 from desc.basis import FourierZernikeBasis
 from desc.transform import Transform
+from desc.equilibrium import Equilibrium
 
 
 def test_vmec_input(tmpdir_factory):
@@ -273,3 +274,12 @@ def test_copy():
         rtol=1e-10,
         atol=1e-10,
     )
+
+
+def test_save_none(tmpdir_factory):
+    tmpdir = tmpdir_factory.mktemp("none_test")
+    eq = Equilibrium()
+    eq._iota = None
+    eq.save(tmpdir + "none_test.h5")
+    eq1 = load(tmpdir + "none_test.h5")
+    assert eq1.iota is None

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -170,7 +170,28 @@ def test_writer_write_dict(writer_test_file):
     for key in thedict.keys():
         assert key in f.keys()
         assert key in g.keys()
+        assert f[key][()] == thedict[key]
+        assert g[key][()] == thedict[key]
     f.close()
+    reader = hdf5Reader(writer_test_file)
+
+    thedict1 = thedict.copy()
+    thedict1["subgroup"] = thedict
+    dict1 = reader.read_dict()
+    assert dict1 == thedict1
+
+
+def test_writer_write_list(writer_test_file):
+    thelist = ["1", 1, "2", 2, "3", 3]
+    writer = hdf5Writer(writer_test_file, "w")
+    writer.write_list(thelist)
+    with pytest.raises(SyntaxError):
+        writer.write_list(thelist, where="not a writable type")
+    writer.close()
+    reader = hdf5Reader(writer_test_file)
+
+    list1 = reader.read_list()
+    assert list1 == thelist
 
 
 def test_writer_write_obj(writer_test_file):

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -161,24 +161,19 @@ def test_writer_write_dict(writer_test_file):
     thedict = {"1": 1, "2": 2, "3": 3}
     writer = hdf5Writer(writer_test_file, "w")
     writer.write_dict(thedict)
-    writer.write_dict(thedict, where=writer.sub("subgroup"))
     with pytest.raises(SyntaxError):
         writer.write_dict(thedict, where="not a writable type")
     writer.close()
     f = h5py.File(writer_test_file, "r")
-    g = f["subgroup"]
     for key in thedict.keys():
         assert key in f.keys()
-        assert key in g.keys()
         assert f[key][()] == thedict[key]
-        assert g[key][()] == thedict[key]
     f.close()
     reader = hdf5Reader(writer_test_file)
 
-    thedict1 = thedict.copy()
-    thedict1["subgroup"] = thedict
     dict1 = reader.read_dict()
-    assert dict1 == thedict1
+    assert dict1 == thedict
+    reader.close()
 
 
 def test_writer_write_list(writer_test_file):
@@ -192,6 +187,7 @@ def test_writer_write_list(writer_test_file):
 
     list1 = reader.read_list()
     assert list1 == thelist
+    reader.close()
 
 
 def test_writer_write_obj(writer_test_file):


### PR DESCRIPTION
As discussed, this fixes the problem of ``None`` attributes not being stored correctly (since hdf5 doesn't have a null type). It just stores it as the string ``"None"`` and then parses it on the loading side. Also refactored the hdf5 reader to avoid some duplicated code.