### PR TITLE
VMECIO.save hotfix

### DIFF
--- a/desc/profiles.py
+++ b/desc/profiles.py
@@ -18,8 +18,8 @@ class Profile(IOAble, ABC):
     All profile classes inherit from this, and must implement
     the transform() and compute() methods.
 
-    The transform method should take an array of parameters and return the value
-    of the profile or its derivatives on the default grid that is assigned to Profile.grid.
+    The transform method should take an array of parameters and return the value of the
+    profile or its derivatives on the default grid that is assigned to Profile.grid.
     This allows the profile to be used in solving and optimizing an equilibrium.
 
     The compute method should take an array of nodes and an optional array of parameters
@@ -34,7 +34,7 @@ class Profile(IOAble, ABC):
 
     @property
     def name(self):
-        """Name of the profile"""
+        """Name of the profile."""
         return self._name
 
     @name.setter
@@ -44,32 +44,32 @@ class Profile(IOAble, ABC):
     @property
     @abstractmethod
     def grid(self):
-        """Default grid for computation"""
+        """Default grid for computation."""
 
     @grid.setter
     @abstractmethod
     def grid(self, new):
-        """Set default grid for computation"""
+        """Set default grid for computation."""
 
     @property
     @abstractmethod
     def params(self):
-        """Default parameters for computation"""
+        """Default parameters for computation."""
 
     @params.setter
     @abstractmethod
     def params(self, new):
-        """Set default params for computation"""
+        """Set default params for computation."""
 
     @abstractmethod
     def compute(self, params=None, grid=None, dr=0, dt=0, dz=0):
-        """compute values on specified nodes, default to using self.params"""
+        """Compute values on specified nodes, default to using self.params."""
 
     def __call__(self, grid=None, params=None, dr=0, dt=0, dz=0):
         return self.compute(params, grid, dr, dt, dz)
 
     def __repr__(self):
-        """string form of the object"""
+        """String form of the object."""
         return (
             type(self).__name__
             + " at "
@@ -79,7 +79,7 @@ class Profile(IOAble, ABC):
 
 
 class PowerSeriesProfile(Profile):
-    """Profile represented by a monic power series
+    """Profile represented by a monic power series.
 
     f(x) = a[0] + a[1]*x + a[2]*x**2 + ...
 
@@ -161,12 +161,12 @@ class PowerSeriesProfile(Profile):
 
     @property
     def basis(self):
-        """Spectral basis for power series"""
+        """Spectral basis for power series."""
         return self._basis
 
     @property
     def grid(self):
-        """Default grid for computation"""
+        """Default grid for computation."""
         return self._grid
 
     @grid.setter
@@ -184,7 +184,7 @@ class PowerSeriesProfile(Profile):
 
     @property
     def params(self):
-        """Parameter values"""
+        """Parameter values."""
         return self._params
 
     @params.setter
@@ -193,11 +193,12 @@ class PowerSeriesProfile(Profile):
             self._params = jnp.asarray(new)
         else:
             raise ValueError(
-                f"params should have the same size as the basis, got {len(new)} for basis with {self._basis.num_modes} modes"
+                f"params should have the same size as the basis, "
+                + "got {len(new)} for basis with {self._basis.num_modes} modes"
             )
 
     def get_params(self, l):
-        """Get power series coefficients for given mode number(s)"""
+        """Get power series coefficients for given mode number(s)."""
         l = np.atleast_1d(l).astype(int)
         a = np.zeros_like(l).astype(float)
 
@@ -207,7 +208,7 @@ class PowerSeriesProfile(Profile):
         return a
 
     def set_params(self, l, a=None):
-        """set specific power series coefficients"""
+        """Set specific power series coefficients."""
         l, a = np.atleast_1d(l), np.atleast_1d(a)
         a = np.broadcast_to(a, l.shape)
         for ll, aa in zip(l, a):
@@ -216,18 +217,18 @@ class PowerSeriesProfile(Profile):
                 self.params[idx] = aa
 
     def get_idx(self, l):
-        """get index into params array for given mode number(s)"""
+        """Get index into params array for given mode number(s)."""
         return self.basis.get_idx(L=l)
 
     def change_resolution(self, L):
-        """set a new maximum mode number"""
+        """Set a new maximum mode number."""
         modes_old = self.basis.modes
         self.basis.change_resolution(L)
         self._transform = self._get_transform(self.grid)
         self.params = copy_coeffs(self.params, modes_old, self.basis.modes)
 
     def compute(self, params=None, grid=None, dr=0, dt=0, dz=0):
-        """Compute values of profile at specified nodes
+        """Compute values of profile at specified nodes.
 
         Parameters
         ----------
@@ -251,8 +252,10 @@ class PowerSeriesProfile(Profile):
         return transform.transform(params, dr=dr, dt=dt, dz=dz)
 
     @classmethod
-    def from_values(cls, x, y, order=6, rcond=None, w=None, grid=None, name=""):
-        """Fit a PowerSeriesProfile from point data
+    def from_values(
+        cls, x, y, order=6, rcond=None, w=None, grid=None, sym="auto", name=""
+    ):
+        """Fit a PowerSeriesProfile from point data.
 
         Parameters
         ----------
@@ -272,6 +275,8 @@ class PowerSeriesProfile(Profile):
             uncertainties, use 1/sigma (not 1/sigma**2).
         grid : Grid
             default grid to use for computing values using transform method
+        sym : bool
+            Whether the basis should only contain even powers (T) or all powers (F).
         name : str
             name of the profile
 
@@ -282,10 +287,10 @@ class PowerSeriesProfile(Profile):
 
         """
         params = np.polyfit(x, y, order, rcond=rcond, w=w, full=False)[::-1]
-        return cls(params, grid=grid, name=name)
+        return cls(params, grid=grid, sym=sym, name=name)
 
     def to_powerseries(self, order=6, xs=100, rcond=None, w=None):
-        """Convert this profile to a PowerSeriesProfile
+        """Convert this profile to a PowerSeriesProfile.
 
         Parameters
         ----------
@@ -320,7 +325,7 @@ class PowerSeriesProfile(Profile):
         return PowerSeriesProfile(params, modes, self.grid, self.name)
 
     def to_spline(self, knots=20, method="cubic2"):
-        """Convert this profile to a SplineProfile
+        """Convert this profile to a SplineProfile.
 
         Parameters
         ----------
@@ -392,7 +397,7 @@ class PowerSeriesProfile(Profile):
 
 
 class SplineProfile(Profile):
-    """Profile represented by a piecewise cubic spline
+    """Profile represented by a piecewise cubic spline.
 
 
     Parameters
@@ -445,7 +450,7 @@ class SplineProfile(Profile):
 
     @property
     def grid(self):
-        """Default grid for computation"""
+        """Default grid for computation."""
         return self._grid
 
     @grid.setter
@@ -470,7 +475,8 @@ class SplineProfile(Profile):
             self._params = jnp.asarray(new)
         else:
             raise ValueError(
-                f"params should have the same size as the knots, got {len(new)} values for {len(self._knots)} knots"
+                f"params should have the same size as the knots, "
+                + "got {len(new)} values for {len(self._knots)} knots"
             )
 
     @property
@@ -484,7 +490,8 @@ class SplineProfile(Profile):
             self._params = jnp.asarray(new)
         else:
             raise ValueError(
-                f"params should have the same size as the knots, got {len(new)} values for {len(self._knots)} knots"
+                f"params should have the same size as the knots, "
+                + "got {len(new)} values for {len(self._knots)} knots"
             )
 
     def _get_xq(self, grid):
@@ -500,7 +507,7 @@ class SplineProfile(Profile):
         return grid[:, 0]
 
     def compute(self, params=None, grid=None, dr=0, dt=0, dz=0):
-        """Compute values of profile at specified nodes
+        """Compute values of profile at specified nodes.
 
         Parameters
         ----------
@@ -530,7 +537,7 @@ class SplineProfile(Profile):
         return fq
 
     def to_powerseries(self, order=6, xs=100, rcond=None, w=None):
-        """Convert this profile to a PowerSeriesProfile
+        """Convert this profile to a PowerSeriesProfile.
 
         Parameters
         ----------
@@ -563,7 +570,7 @@ class SplineProfile(Profile):
         return p
 
     def to_spline(self, knots=20, method="cubic2"):
-        """Convert this profile to a SplineProfile
+        """Convert this profile to a SplineProfile.
 
         Parameters
         ----------

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -322,7 +322,7 @@ class VMECIO:
         am[:] = np.zeros((file.dimensions["preset"].size,))
         # only using up to 10th order to avoid poor conditioning
         am[:11] = PowerSeriesProfile.from_values(
-            s_full, eq.pressure(r_full), order=10
+            s_full, eq.pressure(r_full), order=10, sym=False
         ).params
 
         ai = file.createVariable("ai", np.float64, ("preset",))
@@ -330,7 +330,7 @@ class VMECIO:
         ai[:] = np.zeros((file.dimensions["preset"].size,))
         # only using up to 10th order to avoid poor conditioning
         ai[:11] = PowerSeriesProfile.from_values(
-            s_full, eq.iota(r_full), order=10
+            s_full, eq.iota(r_full), order=10, sym=False
         ).params
 
         ac = file.createVariable("ac", np.float64, ("preset",))
@@ -441,7 +441,7 @@ class VMECIO:
         if not eq.sym:
             zaxis_cc = file.createVariable("zaxis_cc", np.float64, ("n_tor",))
             zaxis_cc.long_name = "cos(n*p) component of magnetic axis Z coordinate"
-            zaxis_cc[1:] = Z0_n[N:]
+            zaxis_cc[:] = Z0_n[N:]
 
         # R
         timer.start("R")
@@ -509,9 +509,10 @@ class VMECIO:
 
         grid = LinearGrid(M=M_nyq, N=N_nyq, NFP=NFP)
         coords = eq.compute("R", grid)
+        sin_basis = DoubleFourierSeries(M=M_nyq, N=N_nyq, NFP=NFP, sym="sin")
+        cos_basis = DoubleFourierSeries(M=M_nyq, N=N_nyq, NFP=NFP, sym="cos")
+        full_basis = DoubleFourierSeries(M=M_nyq, N=N_nyq, NFP=NFP, sym=None)
         if eq.sym:
-            sin_basis = DoubleFourierSeries(M=M_nyq, N=N_nyq, NFP=NFP, sym="sin")
-            cos_basis = DoubleFourierSeries(M=M_nyq, N=N_nyq, NFP=NFP, sym="cos")
             sin_transform = Transform(
                 grid=grid, basis=sin_basis, build=False, build_pinv=True
             )
@@ -519,7 +520,6 @@ class VMECIO:
                 grid=grid, basis=cos_basis, build=False, build_pinv=True
             )
         else:
-            full_basis = DoubleFourierSeries(M=M_nyq, N=N_nyq, NFP=NFP, sym=None)
             full_transform = Transform(
                 grid=grid, basis=full_basis, build=False, build_pinv=True
             )

--- a/tests/test_vmec.py
+++ b/tests/test_vmec.py
@@ -172,7 +172,7 @@ def test_vmec_save_asym(TmpDir):
     """Tests that saving a non-symmetric equilibrium runs without errors."""
 
     output_path = str(TmpDir.join("output.nc"))
-    eq = Equilibrium(sym=False)
+    eq = Equilibrium(L=2, M=2, N=2, NFP=3, pressure=np.array([[2, 0]]), sym=False)
     VMECIO.save(eq, output_path)
 
 

--- a/tests/test_vmec.py
+++ b/tests/test_vmec.py
@@ -168,6 +168,14 @@ def test_load_then_save(TmpDir):
     file2.close()
 
 
+def test_vmec_save_asym(TmpDir):
+    """Tests that saving a non-symmetric equilibrium runs without errors."""
+
+    output_path = str(TmpDir.join("output.nc"))
+    eq = Equilibrium(sym=False)
+    VMECIO.save(eq, output_path)
+
+
 @pytest.mark.slow
 def test_vmec_save(DSHAPE, TmpDir):
     """Tests that saving in NetCDF format agrees with VMEC."""


### PR DESCRIPTION
A user reported that `VMECIO.save()` was not working, and there were two separate bugs:
1. `PowerSeriesProfile.from_values()` was returning even profiles by default for vacuum values, but the VMEC output requires all the profile coefficients. 
2. There was a typo in setting the magnetic axis Z coordinate coefficients, for cases without stellarator symmetry. 
This PR fixes these bugs and adds a simple test that involves both cases. 