### PR TITLE
Add FixProfile base class

### DIFF
--- a/desc/objectives/linear_objectives.py
+++ b/desc/objectives/linear_objectives.py
@@ -465,7 +465,7 @@ class _FixProfile(_Objective, ABC):
         weight=1,
         profile=None,
         indices=True,
-        name=None,  # maybe make none? and the other ones use it
+        name="",
     ):
 
         self._profile = profile
@@ -519,11 +519,6 @@ class _FixProfile(_Objective, ABC):
         self._set_derivatives(use_jit=use_jit)
         self._built = True
 
-    @property
-    def target_arg(self):
-        """str: Name of argument corresponding to the target."""
-        return ""
-
 
 class FixPressure(_FixProfile):
     """Fixes pressure coefficients.
@@ -540,10 +535,11 @@ class FixPressure(_FixProfile):
         len(target) = len(weight) = len(modes)
     profile : Profile, optional
         Profile containing the radial modes to evaluate at.
-    modes : ndarray, optional
-        Basis modes numbers [l,m,n] of boundary modes to fix.
+    indices : ndarray or bool, optional
+        indices of the Profile.params array to fix.
+        (e.g. indices corresponding to modes for a PowerSeriesProfile or indices corresponding to knots for a SplineProfile).
         len(target) = len(weight) = len(modes).
-        If True/False uses all/none of the profile modes.
+        If True/False uses all/none of the Profile.params indices.
     name : str
         Name of the objective function.
 
@@ -627,10 +623,11 @@ class FixIota(_FixProfile):
         len(target) = len(weight) = len(modes)
     profile : Profile, optional
         Profile containing the radial modes to evaluate at.
-    modes : ndarray, optional
-        Basis modes numbers [l,m,n] of boundary modes to fix.
+    indices : ndarray or bool, optional
+        indices of the Profile.params array to fix.
+        (e.g. indices corresponding to modes for a PowerSeriesProfile or indices corresponding to knots for a SplineProfile).
         len(target) = len(weight) = len(modes).
-        If True/False uses all/none of the profile modes.
+        If True/False uses all/none of the Profile.params indices.
     name : str
         Name of the objective function.
 
@@ -681,7 +678,7 @@ class FixIota(_FixProfile):
 
         Parameters
         ----------
-        p_l : ndarray
+        i_l : ndarray
             parameters of the iota profile.
 
         Returns

--- a/desc/objectives/linear_objectives.py
+++ b/desc/objectives/linear_objectives.py
@@ -488,8 +488,6 @@ class _FixProfile(_Objective, ABC):
             Level of output.
 
         """
-        # what do I wanna do here... crud
-        # put this line in the subclass?
         if self._profile is None or self._profile.params.size != eq.L + 1:
             self._profile = profile
 

--- a/desc/objectives/linear_objectives.py
+++ b/desc/objectives/linear_objectives.py
@@ -1,6 +1,8 @@
 import numpy as np
 from termcolor import colored
 import warnings
+from abc import ABC, abstractmethod
+
 
 from desc.backend import jnp
 from desc.basis import zernike_radial_coeffs, zernike_radial
@@ -426,7 +428,137 @@ class FixLambdaGauge(_Objective):
         return self._shift_scale(f)
 
 
-class FixPressure(_Objective):
+class _FixProfile(
+    _Objective,
+):  # should it be an ABC?
+    """Fixes profile coefficients (or values, for SplineProfile).
+
+    Parameters
+    ----------
+    eq : Equilibrium, optional
+        Equilibrium that will be optimized to satisfy the Objective.
+    target : tuple, float, ndarray, optional
+        Target value(s) of the objective.
+        len(target) = len(weight) = len(modes). If None, uses Profile.params.
+        e.g. for PowerSeriesProfile these are profile coefficients, and for SplineProfile they are values at knots.
+    weight : float, ndarray, optional
+        Weighting to apply to the Objective, relative to other Objectives.
+        len(target) = len(weight) = len(modes)
+    profile : Profile, optional
+        Profile containing the radial modes to evaluate at.
+    indices : ndarray or Bool, optional
+        indices of the Profile.params array to fix.
+        (e.g. indices corresponding to modes for a PowerSeriesProfile or indices corresponding to knots for a SplineProfile).
+        len(target) = len(weight) = len(modes).
+        If True/False uses all/none of the Profile.params indices.
+    name : str
+        Name of the objective function.
+
+    """
+
+    _scalar = False
+    _linear = True
+    _fixed = True
+
+    def __init__(
+        self,
+        eq=None,
+        target=None,
+        weight=1,
+        profile=None,
+        indices=True,
+        name=None,  # maybe make none? and the other ones use it
+    ):
+
+        self._profile = profile
+        self._indices = indices
+        super().__init__(eq=eq, target=target, weight=weight, name=name)
+        self._print_value_fmt = None
+
+    def build(self, eq, use_jit=True, verbose=1):
+        """Build constant arrays.
+
+        Parameters
+        ----------
+        eq : Equilibrium, optional
+            Equilibrium that will be optimized to satisfy the Objective.
+        use_jit : bool, optional
+            Whether to just-in-time compile the objective and derivatives.
+        verbose : int, optional
+            Level of output.
+
+        """
+        # what do I wanna do here... crud
+        # put this line in the subclass?
+        if self._profile is None or self._profile.params.size != eq.L + 1:
+            if self.name == "fixed-pressure":
+                self._profile = eq.pressure
+            elif self.name == "fixed-iota":
+                self._profile = eq.iota
+            # elif self.name == "fixed-current":
+            #     self._profile = eq.current
+            else:
+                raise NotImplementedError(
+                    f"Fixing profile for {self.name} is not implemented."
+                )
+
+        # find indices to fix
+        if self._indices is False or self._indices is None:  # no indices to fix
+            indices = np.array([[]], dtype=int)
+            self._idx = np.array([], dtype=int)
+            idx = self._idx
+        elif self._indices is True:  # all indices of Profile.params
+            self._idx = np.arange(np.size(self._profile.params))
+            print(self._idx)
+            print(self._profile)
+            print(self._profile.params)
+            indices = self._idx
+            idx = self._idx
+        else:  # specified indices
+            self._idx = np.atleast_1d(
+                self._indices
+            )  # should _idx be 1d or 2d? I think 1D
+            idx = self._idx
+
+        self._dim_f = self._idx.size
+        # use given targets and weights if specified
+        if self.target.size == indices.shape[0]:
+            self.target = self._target[idx]
+        if self.weight.size == indices.shape[0]:
+            self.weight = self._weight[idx]
+        # use profile parameters as target if needed
+        if None in self.target or self.target.size != self.dim_f:
+            self.target = self._profile.params[self._idx]
+
+        self._check_dimensions()
+        self._set_dimensions(eq)
+        self._set_derivatives(use_jit=use_jit)
+        self._built = True
+
+    def compute(self, params, **kwargs):
+        """Compute fixed profile errors.
+
+        Parameters
+        ----------
+        params : ndarray
+            parameters of the Profile.param.
+
+        Returns
+        -------
+        f : ndarray
+            Fixed profile errors.
+
+        """
+        fixed_params = params[self._idx]
+        return self._shift_scale(fixed_params)
+
+    @property
+    def target_arg(self):
+        """str: Name of argument corresponding to the target."""
+        return None  # or do ABC
+
+
+class FixPressure(_FixProfile):
     """Fixes pressure coefficients.
 
     Parameters
@@ -460,147 +592,19 @@ class FixPressure(_Objective):
         target=None,
         weight=1,
         profile=None,
-        modes=True,
+        indices=True,
         name="fixed-pressure",
     ):
 
-        self._profile = profile
-        self._modes = modes
-        super().__init__(eq=eq, target=target, weight=weight, name=name)
+        super().__init__(
+            eq=eq,
+            target=target,
+            weight=weight,
+            profile=profile,
+            indices=indices,
+            name=name,
+        )
         self._print_value_fmt = "Fixed-pressure profile error: {:10.3e} (Pa)"
-
-    def build(self, eq, use_jit=True, verbose=1):
-        """Build constant arrays.
-
-        Parameters
-        ----------
-        eq : Equilibrium, optional
-            Equilibrium that will be optimized to satisfy the Objective.
-        use_jit : bool, optional
-            Whether to just-in-time compile the objective and derivatives.
-        verbose : int, optional
-            Level of output.
-
-        """
-        if self._profile is None or self._profile.params.size != eq.L + 1:
-            self._profile = eq.pressure
-
-        if isinstance(self._profile, PowerSeriesProfile):
-            # find indices of pressure modes to fix
-            if self._modes is False or self._modes is None:  # no modes
-                modes = np.array([[]], dtype=int)
-                self._idx = np.array([], dtype=int)
-                idx = self._idx
-            elif self._modes is True:  # all modes in profile
-                modes = self._profile.basis.modes
-                self._idx = np.arange(self._profile.basis.num_modes)
-                idx = self._idx
-            else:  # specified modes
-                modes = np.atleast_2d(self._modes)
-                dtype = {
-                    "names": ["f{}".format(i) for i in range(3)],
-                    "formats": 3 * [modes.dtype],
-                }
-                _, self._idx, idx = np.intersect1d(
-                    self._profile.basis.modes.astype(modes.dtype).view(dtype),
-                    modes.view(dtype),
-                    return_indices=True,
-                )
-                if self._idx.size < modes.shape[0]:
-                    warnings.warn(
-                        colored(
-                            "Some of the given modes are not in the pressure profile, "
-                            + "these modes will not be fixed.",
-                            "yellow",
-                        )
-                    )
-
-            self._dim_f = self._idx.size
-            # use given targets and weights if specified
-            if self.target.size == modes.shape[0]:
-                self.target = self._target[idx]
-            if self.weight.size == modes.shape[0]:
-                self.weight = self._weight[idx]
-            # use profile parameters as target if needed
-            if None in self.target or self.target.size != self.dim_f:
-                self.target = self._profile.params[self._idx]
-
-        elif isinstance(self._profile, SplineProfile):
-            # for spline profile, params = values of the profile at the knot locations
-            # and the passed-in modes are actually the desired values at the knot locations
-
-            # find indices of pressure values to fix
-            if self._modes is False or self._modes is None:  # no values
-                values = np.array([[]], dtype=int)
-                self._idx = np.array([], dtype=int)
-                idx = self._idx
-            elif self._modes is True:  # all values/knot locations in profile
-                values = self._profile.params
-                self._idx = np.arange(len(self._profile.params))
-                idx = self._idx
-            else:  # specified values
-                # FIXME: not tested and also not sure of what we want to do here
-                # we want to be able to I assume fix profile values at certain knot
-                # locations but not others (like keep core fixed vary edge etc)
-                # in this setup, _modes would be the knot locations we want fixed?
-                # I think it would just be that but I am not completely sure
-                # might only make sense if target is also supplied?
-                raise NotImplementedError(
-                    f"Specifying specific values for SplineProfile is not implemented yet."
-                )
-                knots = np.atleast_2d(self._modes)
-                dtype = {
-                    "names": ["f{}".format(i) for i in range(3)],
-                    "formats": 3 * [values.dtype],
-                }
-                _, self._idx, idx = np.intersect1d(
-                    self._profile._knots.astype(knots.dtype).view(dtype),
-                    values.view(dtype),
-                    return_indices=True,
-                )
-                if self._idx.size < knots.shape[0]:
-                    warnings.warn(
-                        colored(
-                            "Some of the given knots are not in the pressure profile, "
-                            + "these modes will not be fixed.",
-                            "yellow",
-                        )
-                    )
-
-            self._dim_f = self._idx.size
-            # use given targets and weights if specified
-            if self.target.size == values.shape[0]:
-                self.target = self._target[idx]
-            if self.weight.size == values.shape[0]:
-                self.weight = self._weight[idx]
-            # use profile parameters as target if needed
-            if None in self.target or self.target.size != self.dim_f:
-                self.target = self._profile.params[self._idx]
-        else:
-            raise NotImplementedError(
-                f"Given pressure profile type for {self._profile} is not implemented yet."
-            )
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
-
-    def compute(self, p_l, **kwargs):
-        """Compute fixed-pressure profile errors.
-
-        Parameters
-        ----------
-        p_l : ndarray
-            Spectral coefficients of p(rho) -- pressure profile.
-
-        Returns
-        -------
-        f : ndarray
-            Pressure profile errors (Pa).
-
-        """
-        p = p_l[self._idx]
-        return self._shift_scale(p)
 
     @property
     def target_arg(self):
@@ -608,7 +612,7 @@ class FixPressure(_Objective):
         return "p_l"
 
 
-class FixIota(_Objective):
+class FixIota(_FixProfile):
     """Fixes rotational transform coefficients.
 
     Parameters
@@ -642,147 +646,19 @@ class FixIota(_Objective):
         target=None,
         weight=1,
         profile=None,
-        modes=True,
+        indices=True,
         name="fixed-iota",
     ):
 
-        self._profile = profile
-        self._modes = modes
-        super().__init__(eq=eq, target=target, weight=weight, name=name)
+        super().__init__(
+            eq=eq,
+            target=target,
+            weight=weight,
+            profile=profile,
+            indices=indices,
+            name=name,
+        )
         self._print_value_fmt = "Fixed-iota profile error: {:10.3e}"
-
-    def build(self, eq, use_jit=True, verbose=1):
-        """Build constant arrays.
-
-        Parameters
-        ----------
-        eq : Equilibrium, optional
-            Equilibrium that will be optimized to satisfy the Objective.
-        use_jit : bool, optional
-            Whether to just-in-time compile the objective and derivatives.
-        verbose : int, optional
-            Level of output.
-
-        """
-        if self._profile is None or self._profile.params.size != eq.L + 1:
-            self._profile = eq.iota
-
-        if isinstance(self._profile, PowerSeriesProfile):
-            # find inidies of iota modes to fix
-            if self._modes is False or self._modes is None:  # no modes
-                modes = np.array([[]], dtype=int)
-                self._idx = np.array([], dtype=int)
-                idx = self._idx
-            elif self._modes is True:  # all modes in profile
-                modes = self._profile.basis.modes
-                self._idx = np.arange(self._profile.basis.num_modes)
-                idx = self._idx
-            else:  # specified modes
-                modes = np.atleast_2d(self._modes)
-                dtype = {
-                    "names": ["f{}".format(i) for i in range(3)],
-                    "formats": 3 * [modes.dtype],
-                }
-                _, self._idx, idx = np.intersect1d(
-                    self._profile.basis.modes.astype(modes.dtype).view(dtype),
-                    modes.view(dtype),
-                    return_indices=True,
-                )
-                if self._idx.size < modes.shape[0]:
-                    warnings.warn(
-                        colored(
-                            "Some of the given modes are not in the iota profile, "
-                            + "these modes will not be fixed.",
-                            "yellow",
-                        )
-                    )
-
-            self._dim_f = self._idx.size
-
-            # use given targets and weights if specified
-            if self.target.size == modes.shape[0]:
-                self.target = self._target[idx]
-            if self.weight.size == modes.shape[0]:
-                self.weight = self._weight[idx]
-            # use profile parameters as target if needed
-            if None in self.target or self.target.size != self.dim_f:
-                self.target = self._profile.params[self._idx]
-
-        elif isinstance(self._profile, SplineProfile):
-            # FIXME: same things as in FixedPressure
-
-            # find indices of pressure values to fix
-            if self._modes is False or self._modes is None:  # no values
-                values = np.array([[]], dtype=int)
-                self._idx = np.array([], dtype=int)
-                idx = self._idx
-            elif self._modes is True:  # all values in profile
-                values = self._profile.params
-                self._idx = np.arange(len(self._profile.params))
-                idx = self._idx
-            else:  # specified values
-                # FIXME: not tested and also not sure of what we want to do here
-                # we want to be able to I assume fix profile values at certain knot
-                # locations but not others (like keep core fixed vary edge etc)
-                # in this setup, _modes would be the knot locations we want fixed?
-                # I think it would just be that but I am not completely sure
-                # might only make sense if target is also supplied?
-                raise NotImplementedError(
-                    f"Specifying specific values for SplineProfile is not implemented yet."
-                )
-                knots = np.atleast_2d(self._modes)
-                dtype = {
-                    "names": ["f{}".format(i) for i in range(3)],
-                    "formats": 3 * [values.dtype],
-                }
-                _, self._idx, idx = np.intersect1d(
-                    self._profile._knots.astype(knots.dtype).view(dtype),
-                    values.view(dtype),
-                    return_indices=True,
-                )
-                if self._idx.size < knots.shape[0]:
-                    warnings.warn(
-                        colored(
-                            "Some of the given knots are not in the pressure profile, "
-                            + "these modes will not be fixed.",
-                            "yellow",
-                        )
-                    )
-
-            self._dim_f = self._idx.size
-            # use given targets and weights if specified
-            if self.target.size == values.shape[0]:
-                self.target = self._target[idx]
-            if self.weight.size == values.shape[0]:
-                self.weight = self._weight[idx]
-            # use profile parameters as target if needed
-            if None in self.target or self.target.size != self.dim_f:
-                self.target = self._profile.params[self._idx]
-        else:
-            raise NotImplementedError(
-                f"Given pressure profile type for {self._profile} is not implemented yet."
-            )
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
-
-    def compute(self, i_l, **kwargs):
-        """Compute fixed-iota profile errors.
-
-        Parameters
-        ----------
-        i_l : ndarray
-            Spectral coefficients of iota(rho) -- rotational transform profile.
-
-        Returns
-        -------
-        f : ndarray
-            Rotational transform profile errors.
-
-        """
-        i = i_l[self._idx]
-        return self._shift_scale(i)
 
     @property
     def target_arg(self):


### PR DESCRIPTION
Refactors ``FixPressure`` and ``FixIota`` (and ``FixCurrent`` eventually) to move the basic build method to a base class, to avoid duplicated code.