### PR TITLE
Add retry steps to codecov upload

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,7 +13,7 @@ on:
 
 
 jobs:
-  build:
+  benchmark:
     if: ${{ github.event.label.name == 'run_benchmarks' && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
 

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -3,7 +3,7 @@ name: Black formatting
 on: [pull_request, workflow_dispatch]
 
 jobs:
-  black_format:
+  Black format:
     
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -3,7 +3,7 @@ name: Black formatting
 on: [pull_request, workflow_dispatch]
 
 jobs:
-  Black format:
+  black_format:
     
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/jax_tests.yml
+++ b/.github/workflows/jax_tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  jax_tests:
     if: ${{ github.event.label.name == 'test_jax' && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}  
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/jax_tests.yml
+++ b/.github/workflows/jax_tests.yml
@@ -1,4 +1,4 @@
-name: JAX version tests
+name: Dependency test - JAX
 
 on:
   pull_request:

--- a/.github/workflows/jax_tests.yml
+++ b/.github/workflows/jax_tests.yml
@@ -1,4 +1,4 @@
-name: Dependency test - JAX
+name: Dependency test JAX
 
 on:
   pull_request:

--- a/.github/workflows/mpl_tests.yml
+++ b/.github/workflows/mpl_tests.yml
@@ -1,4 +1,4 @@
-name: matplotlib version tests
+name: Dependecy test - Matplotlib
 
 on:
   pull_request:

--- a/.github/workflows/mpl_tests.yml
+++ b/.github/workflows/mpl_tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  mpl_tests:
     if: ${{ github.event.label.name == 'test_mpl' && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}  
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/mpl_tests.yml
+++ b/.github/workflows/mpl_tests.yml
@@ -1,4 +1,4 @@
-name: Dependecy test - Matplotlib
+name: Dependecy test Matplotlib
 
 on:
   pull_request:

--- a/.github/workflows/nbtests.yml
+++ b/.github/workflows/nbtests.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  Notebook tests:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/nbtests.yml
+++ b/.github/workflows/nbtests.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Notebook tests:
+  notebook_tests:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  Regression tests:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -46,15 +46,65 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: my-artifact
+          name: artifact-${{ matrix.python-version }}-${{ matrix.group }}
           path: |
             ./cov.xml
             ./mpl_results.html
+            ./prof.db	    
       - name: Upload coverage
+        continue-on-error: true
+        id : codecov1
         uses: codecov/codecov-action@v2
         with:
           name: codecov-umbrella # optional
           files: ./cov.xml
-          fail_ci_if_error: false # optional (default = false)
+          fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
-
+      - name: Upload coverage2
+        id : codecov2
+        continue-on-error: true
+        if: steps.codecov1.outcome=='failure'         # check the step outcome, retry 1st time
+        uses: codecov/codecov-action@v2
+        with:
+          name: codecov-umbrella # optional
+          files: ./cov.xml
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
+      - name: Upload coverage3
+        id : codecov3
+        continue-on-error: true
+        if: steps.codecov2.outcome=='failure'         # check the step outcome, retry 2nd time
+        uses: codecov/codecov-action@v2
+        with:
+          name: codecov-umbrella # optional
+          files: ./cov.xml
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
+      - name: Upload coverage4
+        id : codecov4
+        continue-on-error: true
+        if: steps.codecov3.outcome=='failure'         # check the step outcome, retry 3rd time
+        uses: codecov/codecov-action@v2
+        with:
+          name: codecov-umbrella # optional
+          files: ./cov.xml
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
+      - name: Upload coverage4
+        id : codecov4
+        continue-on-error: true
+        if: steps.codecov4.outcome=='failure'         # check the step outcome, retry 4th time
+        uses: codecov/codecov-action@v2
+        with:
+          name: codecov-umbrella # optional
+          files: ./cov.xml
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
+      - name: set the status                          # set the workflow status if command failed
+        if: always()
+        run: |
+          if ${{ steps.codecov1.outcome=='success' || steps.codecov2.outcome=='success' || steps.codecov3.outcome=='success' || steps.codecov4.outcome=='success' || steps.codecov5.outcome=='success' }}; then
+             echo fine
+          else
+             exit 1
+          fi

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -90,8 +90,8 @@ jobs:
           files: ./cov.xml
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
-      - name: Upload coverage4
-        id : codecov4
+      - name: Upload coverage5
+        id : codecov5
         continue-on-error: true
         if: steps.codecov4.outcome=='failure'         # check the step outcome, retry 4th time
         uses: codecov/codecov-action@v2

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Regression tests:
+  regression_tests:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -41,12 +41,12 @@ jobs:
         run: |
           pwd
           lscpu
-          python -m pytest -m regression --durations=0 --cov-report xml:cov.xml --cov-config=setup.cfg --cov=desc/ --mpl --mpl-results-path=mpl_results.html --mpl-generate-summary=html --splits 4 --group ${{ matrix.group }} --splitting-algorithm least_duration
+          python -m pytest -m regression --durations=0 --cov-report xml:cov.xml --cov-config=setup.cfg --cov=desc/ --mpl --mpl-results-path=mpl_results.html --mpl-generate-summary=html --splits 4 --group ${{ matrix.group }} --splitting-algorithm least_duration --db ./prof.db
       - name: save coverage file and plot comparison results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: artifact-${{ matrix.python-version }}-${{ matrix.group }}
+          name: regression_test_artifact-${{ matrix.python-version }}-${{ matrix.group }}
           path: |
             ./cov.xml
             ./mpl_results.html

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -46,16 +46,65 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: artifact-${{ matrix.python-version }}
+          name: artifact-${{ matrix.python-version }}-${{ matrix.group }}
           path: |
             ./cov.xml
             ./mpl_results.html
             ./prof.db
       - name: Upload coverage
+        continue-on-error: true
+        id : codecov1
         uses: codecov/codecov-action@v2
         with:
           name: codecov-umbrella # optional
           files: ./cov.xml
-          fail_ci_if_error: false # optional (default = false)
+          fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
-
+      - name: Upload coverage2
+        id : codecov2
+        continue-on-error: true
+        if: steps.codecov1.outcome=='failure'         # check the step outcome, retry 1st time
+        uses: codecov/codecov-action@v2
+        with:
+          name: codecov-umbrella # optional
+          files: ./cov.xml
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
+      - name: Upload coverage3
+        id : codecov3
+        continue-on-error: true
+        if: steps.codecov2.outcome=='failure'         # check the step outcome, retry 2nd time
+        uses: codecov/codecov-action@v2
+        with:
+          name: codecov-umbrella # optional
+          files: ./cov.xml
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
+      - name: Upload coverage4
+        id : codecov4
+        continue-on-error: true
+        if: steps.codecov3.outcome=='failure'         # check the step outcome, retry 3rd time
+        uses: codecov/codecov-action@v2
+        with:
+          name: codecov-umbrella # optional
+          files: ./cov.xml
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
+      - name: Upload coverage4
+        id : codecov4
+        continue-on-error: true
+        if: steps.codecov4.outcome=='failure'         # check the step outcome, retry 4th time
+        uses: codecov/codecov-action@v2
+        with:
+          name: codecov-umbrella # optional
+          files: ./cov.xml
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
+      - name: set the status                          # set the workflow status if command failed
+        if: always()
+        run: |
+          if ${{ steps.codecov1.outcome=='success' || steps.codecov2.outcome=='success' || steps.codecov3.outcome=='success' || steps.codecov4.outcome=='success' || steps.codecov5.outcome=='success' }}; then
+             echo fine
+          else
+             exit 1
+          fi

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  Unit tests:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Unit tests:
+  unit_tests:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -90,8 +90,8 @@ jobs:
           files: ./cov.xml
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
-      - name: Upload coverage4
-        id : codecov4
+      - name: Upload coverage5
+        id : codecov5
         continue-on-error: true
         if: steps.codecov4.outcome=='failure'         # check the step outcome, retry 4th time
         uses: codecov/codecov-action@v2

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -41,12 +41,12 @@ jobs:
         run: |
           pwd
           lscpu
-          python -m pytest -m unit --durations=0 --cov-report xml:cov.xml --cov-config=setup.cfg --cov=desc/ --mpl --mpl-results-path=mpl_results.html --mpl-generate-summary=html --splits 3 --group ${{ matrix.group }} --splitting-algorithm least_duration
+          python -m pytest -m unit --durations=0 --cov-report xml:cov.xml --cov-config=setup.cfg --cov=desc/ --mpl --mpl-results-path=mpl_results.html --mpl-generate-summary=html --splits 3 --group ${{ matrix.group }} --splitting-algorithm least_duration --db ./prof.db
       - name: save coverage file and plot comparison results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: artifact-${{ matrix.python-version }}-${{ matrix.group }}
+          name: unit_test_artifact-${{ matrix.python-version }}-${{ matrix.group }}
           path: |
             ./cov.xml
             ./mpl_results.html


### PR DESCRIPTION
- Should try uploading coverage up to 5 times for each action, and will fail the CI if all of the uploads fail.
- Renames artifacts to not overwrite them due to `pytest-split` groups-
- Renames workflows and job steps to be cleaner.