### PR TITLE
Remove 'parent' and 'children' from Equilibrium

### DIFF
--- a/desc/configuration.py
+++ b/desc/configuration.py
@@ -381,10 +381,6 @@ class _Configuration(IOAble, ABC):
                 + f"{eq_NFP}, surface {surf_NFP}, and axis {axis_NFP}"
             )
 
-        # keep track of where it came from
-        self._parent = None
-        self._children = []
-
         self._R_lmn = np.zeros(self.R_basis.num_modes)
         self._Z_lmn = np.zeros(self.Z_basis.num_modes)
         self._L_lmn = np.zeros(self.L_basis.num_modes)
@@ -697,24 +693,12 @@ class _Configuration(IOAble, ABC):
         x_lmn = transform.fit(x)
         return x_lmn
 
-    @property
-    def parent(self):
-        """Pointer to the equilibrium this was derived from."""
-        return self.__dict__.setdefault("_parent", None)
-
-    @property
-    def children(self):
-        """List of configurations that were derived from this one."""
-        return self.__dict__.setdefault("_children", [])
-
     def copy(self, deepcopy=True):
         """Return a (deep)copy of this equilibrium."""
         if deepcopy:
             new = copy.deepcopy(self)
         else:
             new = copy.copy(self)
-        new._parent = self
-        self.children.append(new)
         return new
 
     def change_resolution(self, L=None, M=None, N=None, NFP=None, *args, **kwargs):

--- a/docs/notebooks/Spline_Basis.ipynb
+++ b/docs/notebooks/Spline_Basis.ipynb
@@ -658,33 +658,7 @@
     }
    },
    "source": [
-    "Note that this gives us back a new equilibrium, so that the original is saved for future study. The new equilibrium keeps track of where it came from though, and the old equilibrium knows about the new one:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "old == new:  True\n",
-      "new is child of old: False\n",
-      "old is parent of new: False\n"
-     ]
-    }
-   ],
-   "source": [
-    "# can keep track of which equilibria came from which\n",
-    "print(\"old == new: \", eq1 == eq)\n",
-    "print(\"new is child of old:\", eq1 in eq.children)\n",
-    "print(\"old is parent of new:\", eq1.parent is eq)"
+    "Note that this gives us back a new equilibrium, so that the original is saved for future study."
    ]
   },
   {
@@ -888,7 +862,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/hands_on.ipynb
+++ b/docs/notebooks/hands_on.ipynb
@@ -662,33 +662,7 @@
     }
    },
    "source": [
-    "Note that this gives us back a new equilibrium, so that the original is saved for future study. The new equilibrium keeps track of where it came from though, and the old equilibrium knows about the new one:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "old == new:  True\n",
-      "new is child of old: False\n",
-      "old is parent of new: False\n"
-     ]
-    }
-   ],
-   "source": [
-    "# can keep track of which equilibria came from which\n",
-    "print(\"old == new: \", eq1 == eq)\n",
-    "print(\"new is child of old:\", eq1 in eq.children)\n",
-    "print(\"old is parent of new:\", eq1.parent is eq)"
+    "Note that this gives us back a new equilibrium, so that the original is saved for future study."
    ]
   },
   {
@@ -1123,7 +1097,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- These attributes were updated every time an equilibrium was copied, to keep track of where it was copied from.
- However, they also serve as a big memory leak if an equilibrium is copied many times, such as in the continuation method
- These attributes were largely unused so removing them should have minimal effect (other than freeing up some memory)