### PR TITLE
Allow selecting profile when loading vmec equilibrium

### DIFF
--- a/desc/io/input_reader.py
+++ b/desc/io/input_reader.py
@@ -1318,7 +1318,7 @@ class InputReader:
         )
         # scale current profile
         if curr_tor is not None:
-            inputs["current"][:, 1] *= curr_tor / np.sum(inputs["current"][:, 1])
+            inputs["current"][:, 1] *= curr_tor / (np.sum(inputs["current"][:, 1]) or 1)
         # delete unused profile
         if iota_flag:
             del inputs["current"]

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -30,7 +30,7 @@ class VMECIO:
     """Performs input from VMEC netCDF files to DESC Equilibrium and vice-versa."""
 
     @classmethod
-    def load(cls, path, L=-1, M=-1, N=-1, spectral_indexing="fringe", profile="iota"):
+    def load(cls, path, L=-1, M=-1, N=-1, spectral_indexing="ansi", profile="iota"):
         """Load a VMEC netCDF file as an Equilibrium.
 
         Parameters
@@ -44,9 +44,9 @@ class VMECIO:
         N : int, optional
             Toroidal resolution. Default = NTOR from VMEC solution.
         spectral_indexing : str, optional
-            Type of Zernike indexing scheme to use. (Default = ``'fringe'``)
+            Type of Zernike indexing scheme to use. (Default = ``'ansi'``)
         profile : {"iota", "current"}
-            Which profile to use.
+             Which profile to use as the equilibrium constraint. (Default = ``'iota'``)
 
         Returns
         -------
@@ -112,6 +112,16 @@ class VMECIO:
             inputs["current"] = np.zeros((preset, 2))
             inputs["current"][:, 0] = np.arange(0, 2 * preset, 2)
             inputs["current"][:, 1] = file.variables["ac"][:]
+            # integrate current profile wrt s=rho^2
+            inputs["current"] = np.pad(
+                np.vstack(
+                    (
+                        inputs["current"][:, 0] + 2,
+                        inputs["current"][:, 1] * 2 / (inputs["current"][:, 0] + 2),
+                    )
+                ).T,
+                ((1, 0), (0, 0)),
+            )
             inputs["current"][:, 1] *= (
                 file.variables["ctor"][:] / (np.sum(inputs["current"][:, 1]) or 1),
             )

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -99,16 +99,25 @@ class VMECIO:
 
         # profiles
         preset = file.dimensions["preset"].size
+        pmass_type = "".join(file.variables["pmass_type"][:].astype(str)).strip()
+        if pmass_type != "power_series":
+            warnings.warn("Pressure is not a power series!")
         p0 = file.variables["presf"][0] / file.variables["am"][0]
         inputs["pressure"] = np.zeros((preset, 2))
         inputs["pressure"][:, 0] = np.arange(0, 2 * preset, 2)
         inputs["pressure"][:, 1] = file.variables["am"][:] * p0
         if profile == "iota":
+            piota_type = "".join(file.variables["piota_type"][:].astype(str)).strip()
+            if piota_type != "power_series":
+                warnings.warn("Iota is not a power series!")
             inputs["iota"] = np.zeros((preset, 2))
             inputs["iota"][:, 0] = np.arange(0, 2 * preset, 2)
             inputs["iota"][:, 1] = file.variables["ai"][:]
             inputs["current"] = None
         if profile == "current":
+            pcurr_type = "".join(file.variables["pcurr_type"][:].astype(str)).strip()
+            if pcurr_type != "power_series":
+                warnings.warn("Current is not a power series!")
             inputs["current"] = np.zeros((preset, 2))
             inputs["current"][:, 0] = np.arange(0, 2 * preset, 2)
             inputs["current"][:, 1] = file.variables["ac"][:]
@@ -122,6 +131,7 @@ class VMECIO:
                 ).T,
                 ((1, 0), (0, 0)),
             )
+            # scale total current to correct value
             inputs["current"][:, 1] *= (
                 file.variables["ctor"][:] / (np.sum(inputs["current"][:, 1]) or 1),
             )

--- a/tests/test_vmec.py
+++ b/tests/test_vmec.py
@@ -156,7 +156,11 @@ def test_load_then_save(TmpDir):
     input_path = "./tests/inputs/wout_SOLOVEV.nc"
     output_path = str(TmpDir.join("DESC_SOLOVEV.nc"))
 
-    eq = VMECIO.load(input_path)
+    eq = VMECIO.load(input_path, profile="current")
+    assert eq.iota is None
+    np.testing.assert_allclose(eq.current.params, 0)
+    eq = VMECIO.load(input_path, profile="iota")
+    assert eq.current is None
     VMECIO.save(eq, output_path)
 
     file1 = Dataset(input_path, mode="r")


### PR DESCRIPTION
Previously we always grab ``ai`` from the VMEC wout file, even if the VMEC equilibrium was solved with fixed current. Unfortunately, VMEC doesn't say in the ouput file whether it was a fixed iota or fixed current equilibrium so we can't easily detect it. Instead ``VMECIO.load`` now has an argument ``profile`` which can be set to ``"iota"`` or ``"current"`` to select the appropriate profile.