### PR TITLE
fix bug where having iota specified in an input file along with vacuu…

### DIFF
--- a/desc/io/input_reader.py
+++ b/desc/io/input_reader.py
@@ -536,7 +536,10 @@ class InputReader:
 
         # remove unused profile
         if iota_flag:
-            del inputs["current"]
+            if inputs["objective"] != "vacuum":
+                del inputs["current"]
+            else:  # if vacuum objective from input file, use zero current
+                del inputs["iota"]
         else:
             del inputs["iota"]
 

--- a/desc/io/input_reader.py
+++ b/desc/io/input_reader.py
@@ -184,7 +184,8 @@ class InputReader:
         }
 
         iota_flag = False
-
+        pres_flag = False
+        curr_flag = False
         inputs["output_path"] = self.output_path
 
         if self.args is not None and self.args.quiet:
@@ -396,6 +397,7 @@ class InputReader:
             # profile coefficients
             match = re.search(r"\sp\s*=\s*" + num_form, command, re.IGNORECASE)
             if match:
+                pres_flag = True
                 p_l = [
                     float(x)
                     for x in re.findall(num_form, match.group(0))
@@ -429,6 +431,7 @@ class InputReader:
                 flag = True
             match = re.search(r"\sc\s*=\s*" + num_form, command, re.IGNORECASE)
             if match:
+                curr_flag = True
                 c_l = [
                     float(x)
                     for x in re.findall(num_form, match.group(0))
@@ -533,6 +536,8 @@ class InputReader:
             raise IOError(colored("M_pol is not assigned.", "red"))
         if np.sum(inputs["surface"]) == 0:
             raise IOError(colored("Fixed-boundary surface is not assigned.", "red"))
+        if curr_flag and iota_flag:
+            raise IOError(colored("Cannot specify both iota and current.", "red"))
 
         # remove unused profile
         if iota_flag:
@@ -542,6 +547,12 @@ class InputReader:
                 del inputs["iota"]
         else:
             del inputs["iota"]
+
+        if inputs["objective"] == "vacuum" and (pres_flag or iota_flag or curr_flag):
+            warnings.warn(
+                "Vacuum objective does not use any profiles, "
+                + "ignoring presssure, iota, and current"
+            )
 
         # sort axis array
         inputs["axis"] = inputs["axis"][inputs["axis"][:, 0].argsort()]

--- a/desc/objectives/linear_objectives.py
+++ b/desc/objectives/linear_objectives.py
@@ -778,7 +778,7 @@ class FixCurrent(_FixProfile):
         if eq.current is None:
             raise RuntimeError(
                 (
-                    "Attempt to fix toroidal current on an equilibrium no "
+                    "Attempting to fix toroidal current on an equilibrium with no "
                     + "current profile assigned"
                 )
             )

--- a/tests/inputs/HELIOTRON_vacuum
+++ b/tests/inputs/HELIOTRON_vacuum
@@ -26,6 +26,11 @@ objective         = vacuum
 spectral_indexing = ansi
 node_pattern      = jacobi
 
+# pressure and rotational transform/current profiles
+l:   0	p =   0    i = 0
+l:   2	p =   0    i = 0
+l:   4	p =   0    i = 0
+
 # magnetic axis initial guess
 n:   0  R0 =  1.0E+1  Z0 =  0.0E+0
 

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -139,6 +139,13 @@ class TestInputReader:
         #  and checksum compare a live conversion to it
         pass
 
+    @pytest.mark.unit
+    def test_vacuum_objective_with_iota_yields_current(self):
+        """Test that when a vacuum objective is given in an input file along with iota coefficients, a zero current profile is used instead."""
+        input_path = ".//tests//inputs//HELIOTRON_vacuum"
+        ir = InputReader(input_path)
+        assert "iota" not in ir.inputs[0].keys()
+
 
 class MockObject:
     """Example object for saving/loading tests."""

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -144,7 +144,8 @@ class TestInputReader:
         """Test that input file with vacuum objective  always uses zero current."""
         input_path = ".//tests//inputs//HELIOTRON_vacuum"
         # load an input file with vacuum obj but also an iota profile specified
-        ir = InputReader(input_path)
+        with pytest.warns(UserWarning):
+            ir = InputReader(input_path)
         # ensure that a current profile instead of an iota profile is used
         assert "iota" not in ir.inputs[0].keys()
         assert "current" in ir.inputs[0].keys()

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -141,10 +141,13 @@ class TestInputReader:
 
     @pytest.mark.unit
     def test_vacuum_objective_with_iota_yields_current(self):
-        """Test that when a vacuum objective is given in an input file along with iota coefficients, a zero current profile is used instead."""
+        """Test that input file with vacuum objective  always uses zero current."""
         input_path = ".//tests//inputs//HELIOTRON_vacuum"
+        # load an input file with vacuum obj but also an iota profile specified
         ir = InputReader(input_path)
+        # ensure that a current profile instead of an iota profile is used
         assert "iota" not in ir.inputs[0].keys()
+        assert "current" in ir.inputs[0].keys()
 
 
 class MockObject:

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -141,7 +141,7 @@ class TestInputReader:
 
     @pytest.mark.unit
     def test_vacuum_objective_with_iota_yields_current(self):
-        """Test that input file with vacuum objective  always uses zero current."""
+        """Test that input file with vacuum objective always uses zero current."""
         input_path = ".//tests//inputs//HELIOTRON_vacuum"
         # load an input file with vacuum obj but also an iota profile specified
         with pytest.warns(UserWarning):


### PR DESCRIPTION
…m objective results in error

If in an input file, `objective=vacuum` is specified but also iota profile coefficients are specified, the default behavior will be to set a zero current profile.

in PR #282 , the intended outcome was to have the above inputs minimize `CurrentDensity` with the iota profile as free parameters. To do this now, one must go through the scripting interface instead of the input file, and explicitly exclude FixIota() from the constraints like
```
constraints = (FixBoundaryR(fixed_boundary=True), FixBoundaryZ(fixed_boundary=True),LambdaGauge(),FixPsi())
objectives = CurrentDensity()
obj = ObjectiveFunction(objectives)
new_eq.solve(objective=obj,constraints=constraints);
```

I chose this resolution as making the input file with vacuum objective and iota profile yield the above result would have required more complicated logic inside of the `Equilibrium` and `EquilibriaFamily` classes