### PR TITLE
Add jit method to objectives

### DIFF
--- a/desc/objectives/_equilibrium.py
+++ b/desc/objectives/_equilibrium.py
@@ -125,10 +125,7 @@ class ForceBalance(_Objective):
         if verbose > 1:
             timer.disp("Precomputing transforms")
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, R_lmn, Z_lmn, L_lmn, p_l, i_l, c_l, Psi, **kwargs):
         """Compute MHD force balance errors.
@@ -284,10 +281,7 @@ class RadialForceBalance(_Objective):
         if verbose > 1:
             timer.disp("Precomputing transforms")
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, R_lmn, Z_lmn, L_lmn, p_l, i_l, c_l, Psi, **kwargs):
         """Compute radial MHD force balance errors.
@@ -440,10 +434,7 @@ class HelicalForceBalance(_Objective):
         if verbose > 1:
             timer.disp("Precomputing transforms")
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, R_lmn, Z_lmn, L_lmn, p_l, i_l, c_l, Psi, **kwargs):
         """Compute helical MHD force balance errors.
@@ -607,10 +598,7 @@ class Energy(_Objective):
         if verbose > 1:
             timer.disp("Precomputing transforms")
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, R_lmn, Z_lmn, L_lmn, p_l, i_l, c_l, Psi, **kwargs):
         """Compute MHD energy.
@@ -773,10 +761,7 @@ class CurrentDensity(_Objective):
         if verbose > 1:
             timer.disp("Precomputing transforms")
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, R_lmn, Z_lmn, L_lmn, i_l, c_l, Psi, **kwargs):
         """Compute toroidal current density.

--- a/desc/objectives/_generic.py
+++ b/desc/objectives/_generic.py
@@ -127,11 +127,8 @@ class GenericObjective(_Objective):
                 else:
                     self.inputs[arg] = None
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
         self._args = args
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, **kwargs):
         """Compute the quantity.
@@ -228,10 +225,7 @@ class ToroidalCurrent(_Objective):
         if verbose > 1:
             timer.disp("Precomputing transforms")
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, R_lmn, Z_lmn, L_lmn, i_l, c_l, Psi, **kwargs):
         """Compute toroidal current.

--- a/desc/objectives/_geometry.py
+++ b/desc/objectives/_geometry.py
@@ -73,10 +73,7 @@ class Volume(_Objective):
         if verbose > 1:
             timer.disp("Precomputing transforms")
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, R_lmn, Z_lmn, **kwargs):
         """Compute plasma volume.
@@ -163,10 +160,7 @@ class AspectRatio(_Objective):
         if verbose > 1:
             timer.disp("Precomputing transforms")
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, R_lmn, Z_lmn, **kwargs):
         """Compute aspect ratio.

--- a/desc/objectives/_qs.py
+++ b/desc/objectives/_qs.py
@@ -156,10 +156,7 @@ class QuasisymmetryBoozer(_Objective):
 
         self._dim_f = np.sum(self._idx)
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, R_lmn, Z_lmn, L_lmn, i_l, c_l, Psi, **kwargs):
         """Compute quasi-symmetry Boozer harmonics error.
@@ -320,10 +317,7 @@ class QuasisymmetryTwoTerm(_Objective):
         if verbose > 1:
             timer.disp("Precomputing transforms")
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, R_lmn, Z_lmn, L_lmn, i_l, c_l, Psi, **kwargs):
         """Compute quasi-symmetry two-term errors.
@@ -474,10 +468,7 @@ class QuasisymmetryTripleProduct(_Objective):
         if verbose > 1:
             timer.disp("Precomputing transforms")
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, R_lmn, Z_lmn, L_lmn, i_l, c_l, Psi, **kwargs):
         """Compute quasi-symmetry triple product errors.

--- a/desc/objectives/_stability.py
+++ b/desc/objectives/_stability.py
@@ -112,10 +112,7 @@ class MercierStability(_Objective):
         if verbose > 1:
             timer.disp("Precomputing transforms")
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, R_lmn, Z_lmn, L_lmn, p_l, i_l, c_l, Psi, **kwargs):
         """Compute the Mercier stability criterion.
@@ -259,10 +256,7 @@ class MagneticWell(_Objective):
         if verbose > 1:
             timer.disp("Precomputing transforms")
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, R_lmn, Z_lmn, L_lmn, p_l, i_l, c_l, Psi, **kwargs):
         """Compute a magnetic well parameter.

--- a/desc/objectives/linear_objectives.py
+++ b/desc/objectives/linear_objectives.py
@@ -66,11 +66,7 @@ class FixBoundaryR(_Objective):
         self._surface_label = surface_label
         super().__init__(eq=eq, target=target, weight=weight, name=name)
         self._print_value_fmt = "R boundary error: {:10.3e} (m)"
-
-        if self._fixed_boundary:
-            self.compute = self._compute_R
-        else:
-            self.compute = self._compute_Rb
+        self._args = ["R_lmn"] if self._fixed_boundary else ["Rb_lmn"]
 
     def build(self, eq, use_jit=True, verbose=1):
         """Build constant arrays.
@@ -142,14 +138,8 @@ class FixBoundaryR(_Objective):
 
     def compute(self, *args, **kwargs):
         """Compute deviation from desired boundary."""
-        pass
-
-    def _compute_R(self, R_lmn, **kwargs):
-        Rb = jnp.dot(self._A, R_lmn)
-        return self._shift_scale(Rb)
-
-    def _compute_Rb(self, Rb_lmn, **kwargs):
-        Rb = jnp.dot(self._A, Rb_lmn)
+        x = kwargs.get(self.args[0], args[0])
+        Rb = jnp.dot(self._A, x)
         return self._shift_scale(Rb)
 
     @property
@@ -204,11 +194,7 @@ class FixBoundaryZ(_Objective):
         self._surface_label = surface_label
         super().__init__(eq=eq, target=target, weight=weight, name=name)
         self._print_value_fmt = "Z boundary error: {:10.3e} (m)"
-
-        if self._fixed_boundary:
-            self.compute = self._compute_Z
-        else:
-            self.compute = self._compute_Zb
+        self._args = ["Z_lmn"] if self._fixed_boundary else ["Zb_lmn"]
 
     def build(self, eq, use_jit=True, verbose=1):
         """Build constant arrays.
@@ -279,14 +265,8 @@ class FixBoundaryZ(_Objective):
 
     def compute(self, *args, **kwargs):
         """Compute deviation from desired boundary."""
-        pass
-
-    def _compute_Z(self, Z_lmn, **kwargs):
-        Zb = jnp.dot(self._A, Z_lmn)
-        return self._shift_scale(Zb)
-
-    def _compute_Zb(self, Zb_lmn, **kwargs):
-        Zb = jnp.dot(self._A, Zb_lmn)
+        x = kwargs.get(self.args[0], args[0])
+        Zb = jnp.dot(self._A, x)
         return self._shift_scale(Zb)
 
     @property

--- a/desc/objectives/linear_objectives.py
+++ b/desc/objectives/linear_objectives.py
@@ -138,10 +138,7 @@ class FixBoundaryR(_Objective):
         if None in self.target or self.target.size != self.dim_f:
             self.target = eq.surface.R_lmn[idx]
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, *args, **kwargs):
         """Compute deviation from desired boundary."""
@@ -278,10 +275,7 @@ class FixBoundaryZ(_Objective):
         if None in self.target or self.target.size != self.dim_f:
             self.target = eq.surface.Z_lmn[idx]
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, *args, **kwargs):
         """Compute deviation from desired boundary."""
@@ -410,10 +404,7 @@ class FixLambdaGauge(_Objective):
 
         self._dim_f = self._A.shape[0]
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, L_lmn, **kwargs):
         """Compute lambda gauge symmetry errors.
@@ -521,10 +512,7 @@ class _FixProfile(_Objective, ABC):
         if None in self.target or self.target.size != self.dim_f:
             self.target = self._profile.params[self._idx]
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
 
 class FixPressure(_FixProfile):
@@ -847,10 +835,7 @@ class FixPsi(_Objective):
         if None in self.target:
             self.target = eq.Psi
 
-        self._check_dimensions()
-        self._set_dimensions(eq)
-        self._set_derivatives(use_jit=use_jit)
-        self._built = True
+        super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
     def compute(self, Psi, **kwargs):
         """Compute fixed-Psi error.

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -577,7 +577,7 @@ class _Objective(IOAble, ABC):
 
         """
         self.target = np.atleast_1d(getattr(eq, self.target_arg, self.target))
-        if self.use_jit:
+        if self._use_jit:
             self.jit()
 
     @abstractmethod

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -532,20 +532,11 @@ class _Objective(IOAble, ABC):
         if "CompiledFunction" in str(type(self.compute_scalar)):
             del self.compute_scalar
         self.compute_scalar = jit(self.compute_scalar)
-        redo_derivs = False
+        del self._derivatives
+        self._set_derivatives()
         for mode, val in self._derivatives.items():
             for arg, deriv in val.items():
-                if "CompiledFunction" in str(type(self._derivatives[mode][arg])):
-                    redo_derivs = True
-                    break
-            if redo_derivs:
-                break
-        if redo_derivs:
-            del self._derivatives
-            self._set_derivatives()
-            for mode, val in self._derivatives.items():
-                for arg, deriv in val.items():
-                    self._derivatives[mode][arg] = jit(self._derivatives[mode][arg])
+                self._derivatives[mode][arg] = jit(self._derivatives[mode][arg])
 
     def _check_dimensions(self):
         """Check that len(target) = len(weight) = dim_f."""

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -458,7 +458,7 @@ class _Objective(IOAble, ABC):
 
     """
 
-    _io_attrs_ = ["_target", "_weight", "_name"]
+    _io_attrs_ = ["_target", "_weight", "_name", "_args"]
 
     def __init__(self, eq=None, target=0, weight=1, name=None):
 
@@ -468,7 +468,7 @@ class _Objective(IOAble, ABC):
         self._name = name
         self._use_jit = None
         self._built = False
-
+        self._args = [arg for arg in getfullargspec(self.compute)[0] if arg != "self"]
         if eq is not None:
             self.build(eq)
 
@@ -492,7 +492,6 @@ class _Objective(IOAble, ABC):
     def _set_derivatives(self):
         """Set up derivatives of the objective wrt each argument."""
         self._derivatives = {"jac": {}, "grad": {}, "hess": {}}
-        self._args = [arg for arg in getfullargspec(self.compute)[0] if arg != "self"]
 
         for arg in arg_order:
             if arg in self.args:  # derivative wrt arg

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -23,6 +23,7 @@ from desc.objectives import (
     ToroidalCurrent,
     Volume,
 )
+from desc.objectives.objective_funs import _Objective
 from desc.profiles import PowerSeriesProfile
 
 
@@ -187,3 +188,29 @@ def test_derivative_modes():
     H1 = obj1.hess(x)
     H2 = obj2.hess(x)
     np.testing.assert_allclose(np.diag(H1), np.diag(H2), atol=1e-10)
+
+
+@pytest.mark.unit
+def test_rejit():
+    """Test that updating attributes and recompiling correctly updates."""
+
+    class DummyObjective(_Objective):
+        def __init__(self, y, eq=None, target=0, weight=1, name="dummy"):
+            self.y = y
+            super().__init__(eq=eq, target=target, weight=weight, name=name)
+
+        def build(self, eq, use_jit=True, verbose=1):
+            self._dim_f = 1
+            super().build(eq, use_jit, verbose)
+
+        def compute(self, x):
+            return self.target * self.weight + self.y * x
+
+    objective = DummyObjective(3.0)
+    objective.build(Equilibrium())
+    assert objective.compute(4.0) == 12.0
+    objective.target = 1.0
+    objective.weight = 2.0
+    assert objective.compute(4.0) == 12.0
+    objective.jit()
+    assert objective.compute(4.0) == 14.0


### PR DESCRIPTION
- Because JAX compiles `self` as a static argument for jitted methods, updating the attributes of the objective (target, weight etc) are not correctly updated in the jitted code.
- This adds a `jit` method that will either jit the compute method, or delete and re-jit it, to ensure that any updates to `self` are correctly handled.
- Also moves some boilerplate code to the base class build method.
- `_set_derivatives` now no longer takes `use_jit` argument, as this is now part of a separate method.