### PR TITLE
Improved Benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,7 +34,7 @@ jobs:
           pwd
           lscpu
           cd tests/benchmarks
-          python -m pytest benchmark.py --benchmark-save='Latest_Commit'
+          python -m pytest benchmark_cpu_small.py --benchmark-save='Latest_Commit'
       - name:  Checkout current master
         uses: actions/checkout@v3
         with:
@@ -45,7 +45,7 @@ jobs:
           pwd
           lscpu
           cd tests/benchmarks
-          python -m pytest benchmark.py --benchmark-save='master'
+          python -m pytest benchmark_cpu_small.py --benchmark-save='master'
       - name: put benchmark results in same folder
         run: |
           pwd

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docs/_build
 htmlcov/
 local/
 matlab/
+tests/benchmarks/.benchmarks/
 .coverage
 .ipynb_checkpoints/
 .spyproject/

--- a/desc/examples/__init__.py
+++ b/desc/examples/__init__.py
@@ -10,8 +10,8 @@ def get(name, data=None):
 
     Returns a solved equilibrium or selected attributes for one of several examples.
 
-    Examples include: Solov'ev, D-shape, Heliotron, ATF, ESTELL, WISTELL-A, ARIES-CS,
-    QAS, NCSX, W7-X
+    Examples include: SOLOVEV, DSHAPE, DSHAPE_current, HELIOTRON, ATF, ESTELL,
+    WISTELL-A, ARIES-CS, QAS, NCSX, W7-X
 
     Parameters
     ----------
@@ -31,7 +31,7 @@ def get(name, data=None):
     """
     assert data in {None, "all", "boundary", "pressure", "iota", "current"}
     here = os.path.abspath(os.path.dirname(__file__)) + "/"
-    path = here + name.upper() + "_output.h5"
+    path = here + name + "_output.h5"
     if os.path.exists(path):
         eqf = desc.io.load(path)
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,8 @@ per-file-ignores =
     desc/optimize/__init__.py: F401
     # too many long lines to deal with now
     desc/compute/data_index.py: E501
+    # need imports in weird order for selecting device before benchmarks
+    tests/benchmarks/benchmark*.py: E402
 max-line-length = 88
 exclude = docs/*, examples/*, devtools/*, build/*, local/*, .git/*, versioneer.py
 max-complexity = 15

--- a/tests/benchmarks/benchmark_cpu_large.py
+++ b/tests/benchmarks/benchmark_cpu_large.py
@@ -1,0 +1,308 @@
+"""Benchmarks for timing comparison."""
+
+import os
+
+import numpy as np
+import pytest
+
+import desc
+
+desc.set_device("cpu")
+from desc.__main__ import main
+from desc.basis import FourierZernikeBasis
+from desc.equilibrium import EquilibriaFamily
+from desc.grid import ConcentricGrid
+from desc.objectives import get_equilibrium_objective, get_fixed_boundary_constraints
+from desc.perturbations import perturb
+from desc.transform import Transform
+
+
+@pytest.fixture(scope="session")
+def TmpDir(tmpdir_factory):
+    """Create a temporary directory to store testing files."""
+    dir_path = tmpdir_factory.mktemp("test_results")
+    return dir_path
+
+
+@pytest.fixture(scope="session")
+def SOLOVEV(tmpdir_factory):
+    """Run SOLOVEV example."""
+    input_path = "..//tests//inputs//SOLOVEV"
+    output_dir = tmpdir_factory.mktemp("result")
+    desc_h5_path = output_dir.join("SOLOVEV_out.h5")
+    desc_nc_path = output_dir.join("SOLOVEV_out.nc")
+    vmec_nc_path = "..//tests//inputs//wout_SOLOVEV.nc"
+    booz_nc_path = output_dir.join("SOLOVEV_bx.nc")
+
+    cwd = os.path.dirname(__file__)
+    exec_dir = os.path.join(cwd, "..")
+    input_filename = os.path.join(exec_dir, input_path)
+
+    print("Running SOLOVEV test.")
+    print("exec_dir=", exec_dir)
+    print("cwd=", cwd)
+
+    args = ["-o", str(desc_h5_path), input_filename, "--numpy", "-vv"]
+    main(args)
+
+    SOLOVEV_out = {
+        "input_path": input_path,
+        "desc_h5_path": desc_h5_path,
+        "desc_nc_path": desc_nc_path,
+        "vmec_nc_path": vmec_nc_path,
+        "booz_nc_path": booz_nc_path,
+    }
+    return SOLOVEV_out
+
+
+@pytest.mark.benchmark(
+    min_rounds=1, max_time=50, disable_gc=False, warmup=True, warmup_iterations=50
+)
+def test_build_transform_fft_lowres(benchmark):
+    """Test time to build a transform (after compilation) for low resolution."""
+
+    def build():
+        L = 5
+        M = 5
+        N = 5
+        grid = ConcentricGrid(L=L, M=M, N=N)
+        basis = FourierZernikeBasis(L=L, M=M, N=N)
+        transf = Transform(grid, basis, method="fft", build=False)
+        transf.build()
+
+    benchmark(build)
+
+
+@pytest.mark.benchmark(min_rounds=1, max_time=100, disable_gc=False, warmup=True)
+def test_build_transform_fft_midres(benchmark):
+    """Test time to build a transform (after compilation) for mid resolution."""
+
+    def build():
+        L = 15
+        M = 15
+        N = 15
+        grid = ConcentricGrid(L=L, M=M, N=N)
+        basis = FourierZernikeBasis(L=L, M=M, N=N)
+        transf = Transform(grid, basis, method="fft", build=False)
+        transf.build()
+
+    benchmark.pedantic(build, iterations=1, warmup_rounds=1, rounds=50)
+
+
+@pytest.mark.benchmark(min_rounds=1, max_time=100, disable_gc=False, warmup=True)
+def test_build_transform_fft_highres(benchmark):
+    """Test time to build a transform (after compilation) for high resolution."""
+
+    def build():
+        L = 25
+        M = 25
+        N = 25
+        grid = ConcentricGrid(L=L, M=M, N=N)
+        basis = FourierZernikeBasis(L=L, M=M, N=N)
+        transf = Transform(grid, basis, method="fft", build=False)
+        transf.build()
+
+    benchmark.pedantic(build, iterations=1, warmup_rounds=1, rounds=25)
+
+
+@pytest.mark.benchmark(min_rounds=5, max_time=300, disable_gc=True, warmup=False)
+def test_SOLOVEV_run(tmpdir_factory, benchmark):
+    """Benchmark the SOLOVEV example."""
+    input_path = ".//tests//inputs//SOLOVEV"
+    output_dir = tmpdir_factory.mktemp("result")
+    desc_h5_path = output_dir.join("SOLOVEV_out.h5")
+    cwd = os.path.dirname(__file__)
+    exec_dir = os.path.join(cwd, "../..")
+    input_filename = os.path.join(exec_dir, input_path)
+
+    print("Running SOLOVEV test.")
+    print("exec_dir=", exec_dir)
+    print("cwd=", cwd)
+
+    args = ["-o", str(desc_h5_path), input_filename, "-vv"]
+    benchmark(main, args)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark(min_rounds=5, max_time=300, disable_gc=True, warmup=False)
+def test_DSHAPE_run(tmpdir_factory, benchmark):
+    """Benchmark the DSHAPE fixed rotational transform example."""
+    input_path = ".//tests//inputs//DSHAPE"
+    output_dir = tmpdir_factory.mktemp("result")
+    desc_h5_path = output_dir.join("DSHAPE_out.h5")
+    cwd = os.path.dirname(__file__)
+    exec_dir = os.path.join(cwd, "../..")
+    input_filename = os.path.join(exec_dir, input_path)
+
+    print("Running DSHAPE fixed rotational transform test.")
+    print("exec_dir=", exec_dir)
+    print("cwd=", cwd)
+
+    args = ["-o", str(desc_h5_path), input_filename, "-vv"]
+    benchmark(main, args)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark(min_rounds=5, max_time=300, disable_gc=True, warmup=False)
+def test_DSHAPE_current_run(tmpdir_factory, benchmark):
+    """Benchmark the DSHAPE fixed toroidal current example."""
+    input_path = ".//tests//inputs//DSHAPE_current"
+    output_dir = tmpdir_factory.mktemp("result")
+    desc_h5_path = output_dir.join("DSHAPE_current_out.h5")
+    cwd = os.path.dirname(__file__)
+    exec_dir = os.path.join(cwd, "../..")
+    input_filename = os.path.join(exec_dir, input_path)
+
+    print("Running DSHAPE fixed toroidal current test.")
+    print("exec_dir=", exec_dir)
+    print("cwd=", cwd)
+
+    args = ["-o", str(desc_h5_path), input_filename, "-vv"]
+    benchmark(main, args)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark(min_rounds=3, max_time=300, disable_gc=True, warmup=False)
+def test_HELIOTRON_run(tmpdir_factory, benchmark):
+    """Benchmark the HELIOTRON fixed rotational transform example."""
+    input_path = ".//tests//inputs//HELIOTRON"
+    output_dir = tmpdir_factory.mktemp("result")
+    desc_h5_path = output_dir.join("HELIOTRON_out.h5")
+    cwd = os.path.dirname(__file__)
+    exec_dir = os.path.join(cwd, "../..")
+    input_filename = os.path.join(exec_dir, input_path)
+
+    print("Running HELIOTRON fixed rotational transform test.")
+    print("exec_dir=", exec_dir)
+    print("cwd=", cwd)
+
+    args = ["-o", str(desc_h5_path), input_filename, "-vv"]
+    benchmark(main, args)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark(min_rounds=3, max_time=300, disable_gc=True, warmup=False)
+def test_HELIOTRON_vacuum_run(tmpdir_factory, benchmark):
+    """Benchmark the HELIOTRON vacuum (fixed current) example."""
+    input_path = ".//tests//inputs//HELIOTRON_vacuum"
+    output_dir = tmpdir_factory.mktemp("result")
+    desc_h5_path = output_dir.join("HELIOTRON_vacuum_out.h5")
+    cwd = os.path.dirname(__file__)
+    exec_dir = os.path.join(cwd, "../..")
+    input_filename = os.path.join(exec_dir, input_path)
+
+    print("Running HELIOTRON vacuum (fixed current) test.")
+    print("exec_dir=", exec_dir)
+    print("cwd=", cwd)
+
+    args = ["-o", str(desc_h5_path), input_filename, "-vv"]
+    benchmark(main, args)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark(min_rounds=3, max_time=300, disable_gc=True, warmup=False)
+def test_ESTELL_run(tmpdir_factory, benchmark):
+    """Benchmark the ESTELL example."""
+    input_path = ".//examples//DESC//ESTELL"
+    output_dir = tmpdir_factory.mktemp("result")
+    desc_h5_path = output_dir.join("ESTELL_out.h5")
+    cwd = os.path.dirname(__file__)
+    exec_dir = os.path.join(cwd, "../..")
+    input_filename = os.path.join(exec_dir, input_path)
+
+    print("Running ESTELL test.")
+    print("exec_dir=", exec_dir)
+    print("cwd=", cwd)
+
+    args = ["-o", str(desc_h5_path), input_filename, "-vv", "-g"]
+    benchmark(main, args)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark(min_rounds=3, max_time=300, disable_gc=True, warmup=False)
+def test_W7X_run(tmpdir_factory, benchmark):
+    """Benchmark the W7X example."""
+    input_path = ".//examples//DESC//W7-X"
+    output_dir = tmpdir_factory.mktemp("result")
+    desc_h5_path = output_dir.join("W7X_out.h5")
+    cwd = os.path.dirname(__file__)
+    exec_dir = os.path.join(cwd, "../..")
+    input_filename = os.path.join(exec_dir, input_path)
+
+    print("Running W7X test.")
+    print("exec_dir=", exec_dir)
+    print("cwd=", cwd)
+
+    args = ["-o", str(desc_h5_path), input_filename, "-vv", "-g"]
+    benchmark(main, args)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_perturb_1(SOLOVEV, benchmark):
+    """Benchmark 1st order perturbations."""
+
+    def setup():
+        eq = EquilibriaFamily.load(load_from=str(SOLOVEV["desc_h5_path"]))[-1]
+        objective = get_equilibrium_objective()
+        constraints = get_fixed_boundary_constraints()
+        tr_ratio = [0.01, 0.25, 0.25]
+        dp = np.zeros_like(eq.p_l)
+        objective.build(eq)
+        dp[np.array([0, 2])] = 8e3 * np.array([1, -1])
+
+        args = (
+            eq,
+            objective,
+            constraints,
+        )
+        kwargs = {
+            "dp": dp,
+            "tr_ratio": tr_ratio,
+            "order": 1,
+            "verbose": 2,
+            "copy": True,
+        }
+        return args, kwargs
+
+    benchmark.pedantic(perturb, setup=setup, rounds=5, iterations=1)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_perturb_2(SOLOVEV, benchmark):
+    """Benchmark 2nd order perturbations."""
+
+    def setup():
+        eq = EquilibriaFamily.load(load_from=str(SOLOVEV["desc_h5_path"]))[-1]
+        objective = get_equilibrium_objective()
+        constraints = get_fixed_boundary_constraints()
+        tr_ratio = [0.01, 0.25, 0.25]
+        dp = np.zeros_like(eq.p_l)
+        objective.build(eq)
+        dp[np.array([0, 2])] = 8e3 * np.array([1, -1])
+
+        args = (
+            eq,
+            objective,
+            constraints,
+        )
+        kwargs = {
+            "dp": dp,
+            "tr_ratio": tr_ratio,
+            "order": 2,
+            "verbose": 2,
+            "copy": True,
+        }
+        return args, kwargs
+
+    benchmark.pedantic(perturb, setup=setup, rounds=5, iterations=1)
+    return None

--- a/tests/benchmarks/benchmark_cpu_small.py
+++ b/tests/benchmarks/benchmark_cpu_small.py
@@ -1,0 +1,346 @@
+"""Benchmarks for timing comparison on cpu (that are small enough to run on CI)."""
+
+import numpy as np
+import pytest
+
+import desc
+
+desc.set_device("cpu")
+import desc.examples
+from desc.basis import FourierZernikeBasis
+from desc.equilibrium import Equilibrium
+from desc.grid import ConcentricGrid
+from desc.objectives import get_equilibrium_objective, get_fixed_boundary_constraints
+from desc.perturbations import perturb
+from desc.transform import Transform
+
+
+@pytest.fixture(scope="session")
+def TmpDir(tmpdir_factory):
+    """Create a temporary directory to store testing files."""
+    dir_path = tmpdir_factory.mktemp("test_results")
+    return dir_path
+
+
+@pytest.mark.benchmark(
+    min_rounds=1, max_time=50, disable_gc=False, warmup=True, warmup_iterations=50
+)
+def test_build_transform_fft_lowres(benchmark):
+    """Test time to build a transform (after compilation) for low resolution."""
+
+    def build():
+        L = 5
+        M = 5
+        N = 5
+        grid = ConcentricGrid(L=L, M=M, N=N)
+        basis = FourierZernikeBasis(L=L, M=M, N=N)
+        transf = Transform(grid, basis, method="fft", build=False)
+        transf.build()
+
+    benchmark(build)
+
+
+@pytest.mark.benchmark(min_rounds=1, max_time=100, disable_gc=False, warmup=True)
+def test_build_transform_fft_midres(benchmark):
+    """Test time to build a transform (after compilation) for mid resolution."""
+
+    def build():
+        L = 15
+        M = 15
+        N = 15
+        grid = ConcentricGrid(L=L, M=M, N=N)
+        basis = FourierZernikeBasis(L=L, M=M, N=N)
+        transf = Transform(grid, basis, method="fft", build=False)
+        transf.build()
+
+    benchmark.pedantic(build, iterations=1, warmup_rounds=1, rounds=50)
+
+
+@pytest.mark.benchmark(min_rounds=1, max_time=100, disable_gc=False, warmup=True)
+def test_build_transform_fft_highres(benchmark):
+    """Test time to build a transform (after compilation) for high resolution."""
+
+    def build():
+        L = 25
+        M = 25
+        N = 25
+        grid = ConcentricGrid(L=L, M=M, N=N)
+        basis = FourierZernikeBasis(L=L, M=M, N=N)
+        transf = Transform(grid, basis, method="fft", build=False)
+        transf.build()
+
+    benchmark.pedantic(build, iterations=1, warmup_rounds=1, rounds=25)
+
+
+@pytest.mark.benchmark(min_rounds=1, max_time=100, disable_gc=False, warmup=True)
+def test_equilibrium_init_lowres(benchmark):
+    """Test time to create an equilibrium for low resolution."""
+
+    def build():
+        L = 5
+        M = 5
+        N = 5
+        _ = Equilibrium(L=L, M=M, N=N)
+
+    benchmark.pedantic(build, iterations=1, warmup_rounds=1, rounds=25)
+
+
+@pytest.mark.benchmark(min_rounds=1, max_time=100, disable_gc=False, warmup=True)
+def test_equilibrium_init_medres(benchmark):
+    """Test time to create an equilibrium for medium resolution."""
+
+    def build():
+        L = 15
+        M = 15
+        N = 15
+        _ = Equilibrium(L=L, M=M, N=N)
+
+    benchmark.pedantic(build, iterations=1, warmup_rounds=1, rounds=25)
+
+
+@pytest.mark.benchmark(min_rounds=1, max_time=100, disable_gc=False, warmup=True)
+def test_equilibrium_init_highres(benchmark):
+    """Test time to create an equilibrium for high resolution."""
+
+    def build():
+        L = 25
+        M = 25
+        N = 25
+        _ = Equilibrium(L=L, M=M, N=N)
+
+    benchmark.pedantic(build, iterations=1, warmup_rounds=1, rounds=25)
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_compile_heliotron(benchmark):
+    """Benchmark compiling objective."""
+
+    def setup():
+        eq = desc.examples.get("HELIOTRON")
+        objective = get_equilibrium_objective()
+        objective.build(eq)
+        args = (
+            objective,
+            eq,
+        )
+        kwargs = {}
+        return args, kwargs
+
+    def run(objective, eq):
+        objective.compile()
+
+    benchmark.pedantic(run, setup=setup, rounds=5, iterations=1)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_compile_dshape_current(benchmark):
+    """Benchmark compiling objective."""
+
+    def setup():
+        eq = desc.examples.get("DSHAPE_current")
+        objective = get_equilibrium_objective()
+        objective.build(eq)
+        args = (
+            objective,
+            eq,
+        )
+        kwargs = {}
+        return args, kwargs
+
+    def run(objective, eq):
+        objective.compile()
+
+    benchmark.pedantic(run, setup=setup, rounds=5, iterations=1)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_compile_atf(benchmark):
+    """Benchmark compiling objective."""
+
+    def setup():
+        eq = desc.examples.get("ATF")
+        objective = get_equilibrium_objective()
+        objective.build(eq)
+        args = (
+            objective,
+            eq,
+        )
+        kwargs = {}
+        return args, kwargs
+
+    def run(objective, eq):
+        objective.compile()
+
+    benchmark.pedantic(run, setup=setup, rounds=5, iterations=1)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_compute_heliotron(benchmark):
+    """Benchmark computing objective."""
+    eq = desc.examples.get("HELIOTRON")
+    objective = get_equilibrium_objective()
+    objective.build(eq)
+    objective.compile()
+    x = objective.x(eq)
+
+    def run(x):
+        objective.compute(x).block_until_ready()
+
+    benchmark.pedantic(run, args=(x,), rounds=10, iterations=10)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_compute_dshape_current(benchmark):
+    """Benchmark computing objective."""
+    eq = desc.examples.get("DSHAPE_current")
+    objective = get_equilibrium_objective()
+    objective.build(eq)
+    objective.compile()
+    x = objective.x(eq)
+
+    def run(x):
+        objective.compute(x).block_until_ready()
+
+    benchmark.pedantic(run, args=(x,), rounds=10, iterations=10)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_compute_atf(benchmark):
+    """Benchmark computing objective."""
+    eq = desc.examples.get("ATF")
+    objective = get_equilibrium_objective()
+    objective.build(eq)
+    objective.compile()
+    x = objective.x(eq)
+
+    def run(x):
+        objective.compute(x).block_until_ready()
+
+    benchmark.pedantic(run, args=(x,), rounds=10, iterations=10)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_jac_heliotron(benchmark):
+    """Benchmark computing jacobian."""
+    eq = desc.examples.get("HELIOTRON")
+    objective = get_equilibrium_objective()
+    objective.build(eq)
+    objective.compile()
+    x = objective.x(eq)
+
+    def run(x):
+        objective.jac(x).block_until_ready()
+
+    benchmark.pedantic(run, args=(x,), rounds=5, iterations=5)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_jac_dshape_current(benchmark):
+    """Benchmark computing jacobian."""
+    eq = desc.examples.get("DSHAPE_current")
+    objective = get_equilibrium_objective()
+    objective.build(eq)
+    objective.compile()
+    x = objective.x(eq)
+
+    def run(x):
+        objective.jac(x).block_until_ready()
+
+    benchmark.pedantic(run, args=(x,), rounds=5, iterations=5)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_jac_atf(benchmark):
+    """Benchmark computing jacobian."""
+    eq = desc.examples.get("ATF")
+    objective = get_equilibrium_objective()
+    objective.build(eq)
+    objective.compile()
+    x = objective.x(eq)
+
+    def run(x):
+        objective.jac(x).block_until_ready()
+
+    benchmark.pedantic(run, args=(x,), rounds=5, iterations=5)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_perturb_1(benchmark):
+    """Benchmark 1st order perturbations."""
+
+    def setup():
+        eq = desc.examples.get("SOLOVEV")
+        objective = get_equilibrium_objective()
+        constraints = get_fixed_boundary_constraints()
+        tr_ratio = [0.01, 0.25, 0.25]
+        dp = np.zeros_like(eq.p_l)
+        objective.build(eq)
+        dp[np.array([0, 2])] = 8e3 * np.array([1, -1])
+
+        args = (
+            eq,
+            objective,
+            constraints,
+        )
+        kwargs = {
+            "dp": dp,
+            "tr_ratio": tr_ratio,
+            "order": 1,
+            "verbose": 2,
+            "copy": True,
+        }
+        return args, kwargs
+
+    benchmark.pedantic(perturb, setup=setup, rounds=5, iterations=1)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_perturb_2(benchmark):
+    """Benchmark 2nd order perturbations."""
+
+    def setup():
+        eq = desc.examples.get("SOLOVEV")
+        objective = get_equilibrium_objective()
+        constraints = get_fixed_boundary_constraints()
+        tr_ratio = [0.01, 0.25, 0.25]
+        dp = np.zeros_like(eq.p_l)
+        objective.build(eq)
+        dp[np.array([0, 2])] = 8e3 * np.array([1, -1])
+
+        args = (
+            eq,
+            objective,
+            constraints,
+        )
+        kwargs = {
+            "dp": dp,
+            "tr_ratio": tr_ratio,
+            "order": 2,
+            "verbose": 2,
+            "copy": True,
+        }
+        return args, kwargs
+
+    benchmark.pedantic(perturb, setup=setup, rounds=5, iterations=1)
+    return None

--- a/tests/benchmarks/benchmark_gpu_large.py
+++ b/tests/benchmarks/benchmark_gpu_large.py
@@ -1,10 +1,13 @@
-"""Benchmarks for timing comparison."""
+"""Benchmarks for timing comparison on gpu backend."""
 
 import os
 
 import numpy as np
 import pytest
 
+import desc
+
+desc.set_device("gpu")
 from desc.__main__ import main
 from desc.basis import FourierZernikeBasis
 from desc.equilibrium import EquilibriaFamily
@@ -39,7 +42,7 @@ def SOLOVEV(tmpdir_factory):
     print("exec_dir=", exec_dir)
     print("cwd=", cwd)
 
-    args = ["-o", str(desc_h5_path), input_filename, "--numpy", "-vv"]
+    args = ["-o", str(desc_h5_path), input_filename, "--numpy", "-vv", "-g"]
     main(args)
 
     SOLOVEV_out = {
@@ -116,7 +119,7 @@ def test_SOLOVEV_run(tmpdir_factory, benchmark):
     print("exec_dir=", exec_dir)
     print("cwd=", cwd)
 
-    args = ["-o", str(desc_h5_path), input_filename, "-vv"]
+    args = ["-o", str(desc_h5_path), input_filename, "-vv", "-g"]
     benchmark(main, args)
     return None
 
@@ -136,7 +139,7 @@ def test_DSHAPE_run(tmpdir_factory, benchmark):
     print("exec_dir=", exec_dir)
     print("cwd=", cwd)
 
-    args = ["-o", str(desc_h5_path), input_filename, "-vv"]
+    args = ["-o", str(desc_h5_path), input_filename, "-vv", "-g"]
     benchmark(main, args)
     return None
 
@@ -156,7 +159,7 @@ def test_DSHAPE_current_run(tmpdir_factory, benchmark):
     print("exec_dir=", exec_dir)
     print("cwd=", cwd)
 
-    args = ["-o", str(desc_h5_path), input_filename, "-vv"]
+    args = ["-o", str(desc_h5_path), input_filename, "-vv", "-g"]
     benchmark(main, args)
     return None
 
@@ -176,7 +179,7 @@ def test_HELIOTRON_run(tmpdir_factory, benchmark):
     print("exec_dir=", exec_dir)
     print("cwd=", cwd)
 
-    args = ["-o", str(desc_h5_path), input_filename, "-vv"]
+    args = ["-o", str(desc_h5_path), input_filename, "-vv", "-g"]
     benchmark(main, args)
     return None
 
@@ -196,7 +199,47 @@ def test_HELIOTRON_vacuum_run(tmpdir_factory, benchmark):
     print("exec_dir=", exec_dir)
     print("cwd=", cwd)
 
-    args = ["-o", str(desc_h5_path), input_filename, "-vv"]
+    args = ["-o", str(desc_h5_path), input_filename, "-vv", "-g"]
+    benchmark(main, args)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark(min_rounds=3, max_time=300, disable_gc=True, warmup=False)
+def test_ESTELL_run(tmpdir_factory, benchmark):
+    """Benchmark the ESTELL example."""
+    input_path = ".//examples//DESC//ESTELL"
+    output_dir = tmpdir_factory.mktemp("result")
+    desc_h5_path = output_dir.join("ESTELL_out.h5")
+    cwd = os.path.dirname(__file__)
+    exec_dir = os.path.join(cwd, "../..")
+    input_filename = os.path.join(exec_dir, input_path)
+
+    print("Running ESTELL test.")
+    print("exec_dir=", exec_dir)
+    print("cwd=", cwd)
+
+    args = ["-o", str(desc_h5_path), input_filename, "-vv", "-g"]
+    benchmark(main, args)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark(min_rounds=3, max_time=300, disable_gc=True, warmup=False)
+def test_W7X_run(tmpdir_factory, benchmark):
+    """Benchmark the W7X example."""
+    input_path = ".//examples//DESC//W7-X"
+    output_dir = tmpdir_factory.mktemp("result")
+    desc_h5_path = output_dir.join("W7X_out.h5")
+    cwd = os.path.dirname(__file__)
+    exec_dir = os.path.join(cwd, "../..")
+    input_filename = os.path.join(exec_dir, input_path)
+
+    print("Running W7X test.")
+    print("exec_dir=", exec_dir)
+    print("cwd=", cwd)
+
+    args = ["-o", str(desc_h5_path), input_filename, "-vv", "-g"]
     benchmark(main, args)
     return None
 

--- a/tests/benchmarks/benchmark_gpu_small.py
+++ b/tests/benchmarks/benchmark_gpu_small.py
@@ -1,0 +1,346 @@
+"""Benchmarks for timing comparison on gpu (that are small enough to run on CI)."""
+
+import numpy as np
+import pytest
+
+import desc
+
+desc.set_device("gpu")
+import desc.examples
+from desc.basis import FourierZernikeBasis
+from desc.equilibrium import Equilibrium
+from desc.grid import ConcentricGrid
+from desc.objectives import get_equilibrium_objective, get_fixed_boundary_constraints
+from desc.perturbations import perturb
+from desc.transform import Transform
+
+
+@pytest.fixture(scope="session")
+def TmpDir(tmpdir_factory):
+    """Create a temporary directory to store testing files."""
+    dir_path = tmpdir_factory.mktemp("test_results")
+    return dir_path
+
+
+@pytest.mark.benchmark(
+    min_rounds=1, max_time=50, disable_gc=False, warmup=True, warmup_iterations=50
+)
+def test_build_transform_fft_lowres(benchmark):
+    """Test time to build a transform (after compilation) for low resolution."""
+
+    def build():
+        L = 5
+        M = 5
+        N = 5
+        grid = ConcentricGrid(L=L, M=M, N=N)
+        basis = FourierZernikeBasis(L=L, M=M, N=N)
+        transf = Transform(grid, basis, method="fft", build=False)
+        transf.build()
+
+    benchmark(build)
+
+
+@pytest.mark.benchmark(min_rounds=1, max_time=100, disable_gc=False, warmup=True)
+def test_build_transform_fft_midres(benchmark):
+    """Test time to build a transform (after compilation) for mid resolution."""
+
+    def build():
+        L = 15
+        M = 15
+        N = 15
+        grid = ConcentricGrid(L=L, M=M, N=N)
+        basis = FourierZernikeBasis(L=L, M=M, N=N)
+        transf = Transform(grid, basis, method="fft", build=False)
+        transf.build()
+
+    benchmark.pedantic(build, iterations=1, warmup_rounds=1, rounds=50)
+
+
+@pytest.mark.benchmark(min_rounds=1, max_time=100, disable_gc=False, warmup=True)
+def test_build_transform_fft_highres(benchmark):
+    """Test time to build a transform (after compilation) for high resolution."""
+
+    def build():
+        L = 25
+        M = 25
+        N = 25
+        grid = ConcentricGrid(L=L, M=M, N=N)
+        basis = FourierZernikeBasis(L=L, M=M, N=N)
+        transf = Transform(grid, basis, method="fft", build=False)
+        transf.build()
+
+    benchmark.pedantic(build, iterations=1, warmup_rounds=1, rounds=25)
+
+
+@pytest.mark.benchmark(min_rounds=1, max_time=100, disable_gc=False, warmup=True)
+def test_equilibrium_init_lowres(benchmark):
+    """Test time to create an equilibrium for low resolution."""
+
+    def build():
+        L = 5
+        M = 5
+        N = 5
+        _ = Equilibrium(L=L, M=M, N=N)
+
+    benchmark.pedantic(build, iterations=1, warmup_rounds=1, rounds=25)
+
+
+@pytest.mark.benchmark(min_rounds=1, max_time=100, disable_gc=False, warmup=True)
+def test_equilibrium_init_medres(benchmark):
+    """Test time to create an equilibrium for medium resolution."""
+
+    def build():
+        L = 15
+        M = 15
+        N = 15
+        _ = Equilibrium(L=L, M=M, N=N)
+
+    benchmark.pedantic(build, iterations=1, warmup_rounds=1, rounds=25)
+
+
+@pytest.mark.benchmark(min_rounds=1, max_time=100, disable_gc=False, warmup=True)
+def test_equilibrium_init_highres(benchmark):
+    """Test time to create an equilibrium for high resolution."""
+
+    def build():
+        L = 25
+        M = 25
+        N = 25
+        _ = Equilibrium(L=L, M=M, N=N)
+
+    benchmark.pedantic(build, iterations=1, warmup_rounds=1, rounds=25)
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_compile_heliotron(benchmark):
+    """Benchmark compiling objective."""
+
+    def setup():
+        eq = desc.examples.get("HELIOTRON")
+        objective = get_equilibrium_objective()
+        objective.build(eq)
+        args = (
+            objective,
+            eq,
+        )
+        kwargs = {}
+        return args, kwargs
+
+    def run(objective, eq):
+        objective.compile()
+
+    benchmark.pedantic(run, setup=setup, rounds=5, iterations=1)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_compile_dshape_current(benchmark):
+    """Benchmark compiling objective."""
+
+    def setup():
+        eq = desc.examples.get("DSHAPE_current")
+        objective = get_equilibrium_objective()
+        objective.build(eq)
+        args = (
+            objective,
+            eq,
+        )
+        kwargs = {}
+        return args, kwargs
+
+    def run(objective, eq):
+        objective.compile()
+
+    benchmark.pedantic(run, setup=setup, rounds=5, iterations=1)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_compile_atf(benchmark):
+    """Benchmark compiling objective."""
+
+    def setup():
+        eq = desc.examples.get("ATF")
+        objective = get_equilibrium_objective()
+        objective.build(eq)
+        args = (
+            objective,
+            eq,
+        )
+        kwargs = {}
+        return args, kwargs
+
+    def run(objective, eq):
+        objective.compile()
+
+    benchmark.pedantic(run, setup=setup, rounds=5, iterations=1)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_compute_heliotron(benchmark):
+    """Benchmark computing objective."""
+    eq = desc.examples.get("HELIOTRON")
+    objective = get_equilibrium_objective()
+    objective.build(eq)
+    objective.compile()
+    x = objective.x(eq)
+
+    def run(x):
+        objective.compute(x).block_until_ready()
+
+    benchmark.pedantic(run, args=(x,), rounds=10, iterations=10)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_compute_dshape_current(benchmark):
+    """Benchmark computing objective."""
+    eq = desc.examples.get("DSHAPE_current")
+    objective = get_equilibrium_objective()
+    objective.build(eq)
+    objective.compile()
+    x = objective.x(eq)
+
+    def run(x):
+        objective.compute(x).block_until_ready()
+
+    benchmark.pedantic(run, args=(x,), rounds=10, iterations=10)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_compute_atf(benchmark):
+    """Benchmark computing objective."""
+    eq = desc.examples.get("ATF")
+    objective = get_equilibrium_objective()
+    objective.build(eq)
+    objective.compile()
+    x = objective.x(eq)
+
+    def run(x):
+        objective.compute(x).block_until_ready()
+
+    benchmark.pedantic(run, args=(x,), rounds=10, iterations=10)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_jac_heliotron(benchmark):
+    """Benchmark computing jacobian."""
+    eq = desc.examples.get("HELIOTRON")
+    objective = get_equilibrium_objective()
+    objective.build(eq)
+    objective.compile()
+    x = objective.x(eq)
+
+    def run(x):
+        objective.jac(x).block_until_ready()
+
+    benchmark.pedantic(run, args=(x,), rounds=5, iterations=5)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_jac_dshape_current(benchmark):
+    """Benchmark computing jacobian."""
+    eq = desc.examples.get("DSHAPE_current")
+    objective = get_equilibrium_objective()
+    objective.build(eq)
+    objective.compile()
+    x = objective.x(eq)
+
+    def run(x):
+        objective.jac(x).block_until_ready()
+
+    benchmark.pedantic(run, args=(x,), rounds=5, iterations=5)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_objective_jac_atf(benchmark):
+    """Benchmark computing jacobian."""
+    eq = desc.examples.get("ATF")
+    objective = get_equilibrium_objective()
+    objective.build(eq)
+    objective.compile()
+    x = objective.x(eq)
+
+    def run(x):
+        objective.jac(x).block_until_ready()
+
+    benchmark.pedantic(run, args=(x,), rounds=5, iterations=5)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_perturb_1(benchmark):
+    """Benchmark 1st order perturbations."""
+
+    def setup():
+        eq = desc.examples.get("SOLOVEV")
+        objective = get_equilibrium_objective()
+        constraints = get_fixed_boundary_constraints()
+        tr_ratio = [0.01, 0.25, 0.25]
+        dp = np.zeros_like(eq.p_l)
+        objective.build(eq)
+        dp[np.array([0, 2])] = 8e3 * np.array([1, -1])
+
+        args = (
+            eq,
+            objective,
+            constraints,
+        )
+        kwargs = {
+            "dp": dp,
+            "tr_ratio": tr_ratio,
+            "order": 1,
+            "verbose": 2,
+            "copy": True,
+        }
+        return args, kwargs
+
+    benchmark.pedantic(perturb, setup=setup, rounds=5, iterations=1)
+    return None
+
+
+@pytest.mark.slow
+@pytest.mark.benchmark
+def test_perturb_2(benchmark):
+    """Benchmark 2nd order perturbations."""
+
+    def setup():
+        eq = desc.examples.get("SOLOVEV")
+        objective = get_equilibrium_objective()
+        constraints = get_fixed_boundary_constraints()
+        tr_ratio = [0.01, 0.25, 0.25]
+        dp = np.zeros_like(eq.p_l)
+        objective.build(eq)
+        dp[np.array([0, 2])] = 8e3 * np.array([1, -1])
+
+        args = (
+            eq,
+            objective,
+            constraints,
+        )
+        kwargs = {
+            "dp": dp,
+            "tr_ratio": tr_ratio,
+            "order": 2,
+            "verbose": 2,
+            "copy": True,
+        }
+        return args, kwargs
+
+    benchmark.pedantic(perturb, setup=setup, rounds=5, iterations=1)
+    return None


### PR DESCRIPTION
Breaks benchmarks into "small" and "large" varieties, along with different ones for cpu and gpu.
Small benchmarks just profiles individual objective and jacobian calls, and should be small enough to work on CI without running out of memory but still give an indication of performance changes.
Large benchmarks profile full equilibrium solves and optimizations and should be run manually on a cluster.

Note that running benchmarks on this PR won't work because the benchmark files on master are different.

Resolves #281 