### PR TITLE
have LinearGrid in plot_fsa function use eq.NFP instead of 1

### DIFF
--- a/desc/plotting.py
+++ b/desc/plotting.py
@@ -869,7 +869,7 @@ def plot_fsa(
     lw = kwargs.pop("lw", 1)
     fig, ax = _format_ax(ax, figsize=kwargs.pop("figsize", (4, 4)))
 
-    grid = LinearGrid(M=M, N=N, NFP=1, rho=rho)
+    grid = LinearGrid(M=M, N=N, NFP=eq.NFP, rho=rho)
     g, _ = _compute(eq, "sqrt(g)", grid, reshape=False)
     data, label = _compute(eq, name, grid, kwargs.pop("component", None), reshape=False)
     values = compress(grid, surface_averages(grid, q=data, sqrt_g=g))


### PR DESCRIPTION
this avoids a warning about a transform having unequal NFP for basis and grid, and I don't think this affects results of the FSA either