### PR TITLE
Have stability objectives print their max, min and average value at end of solve

### DIFF
--- a/desc/objectives/_stability.py
+++ b/desc/objectives/_stability.py
@@ -165,24 +165,27 @@ class MercierStability(_Objective):
 
     def print_value(self, *args, **kwargs):
         """Print the value of the objective."""
-        x = self._unshift_unscale(self.compute(*args, **kwargs))
-        print("Maximum" + self._print_value_fmt.format(jnp.max(x)) + self._units)
-        print("Minimum" + self._print_value_fmt.format(jnp.min(x)) + self._units)
-        print("Average" + self._print_value_fmt.format(jnp.mean(x)) + self._units)
+        x = self._unshift_unscale(
+            self.compute(*args, **kwargs)
+            / compress(self.grid, self.grid.spacing[:, 0], surface_label="rho")
+        )
+        print("Maximum " + self._print_value_fmt.format(jnp.max(x)) + self._units)
+        print("Minimum " + self._print_value_fmt.format(jnp.min(x)) + self._units)
+        print("Average " + self._print_value_fmt.format(jnp.mean(x)) + self._units)
 
         if self._normalize:
             print(
-                "Maximum"
+                "Maximum "
                 + self._print_value_fmt.format(jnp.max(x / self.normalization))
                 + "(normalized)"
             )
             print(
-                "Minimum"
+                "Minimum "
                 + self._print_value_fmt.format(jnp.min(x / self.normalization))
                 + "(normalized)"
             )
             print(
-                "Average"
+                "Average "
                 + self._print_value_fmt.format(jnp.mean(x / self.normalization))
                 + "(normalized)"
             )
@@ -333,7 +336,10 @@ class MagneticWell(_Objective):
 
     def print_value(self, *args, **kwargs):
         """Print the value of the objective."""
-        x = self._unshift_unscale(self.compute(*args, **kwargs))
-        print("Maximum" + self._print_value_fmt.format(jnp.max(x)) + self._units)
-        print("Minimum" + self._print_value_fmt.format(jnp.min(x)) + self._units)
-        print("Average" + self._print_value_fmt.format(jnp.mean(x)) + self._units)
+        x = self._unshift_unscale(
+            self.compute(*args, **kwargs)
+            / compress(self.grid, self.grid.spacing[:, 0], surface_label="rho")
+        )
+        print("Maximum " + self._print_value_fmt.format(jnp.max(x)) + self._units)
+        print("Minimum " + self._print_value_fmt.format(jnp.min(x)) + self._units)
+        print("Average " + self._print_value_fmt.format(jnp.mean(x)) + self._units)

--- a/desc/objectives/_stability.py
+++ b/desc/objectives/_stability.py
@@ -168,6 +168,7 @@ class MercierStability(_Objective):
         x = self._unshift_unscale(self.compute(*args, **kwargs))
         print("Maximum" + self._print_value_fmt.format(jnp.max(x)) + self._units)
         print("Minimum" + self._print_value_fmt.format(jnp.min(x)) + self._units)
+        print("Average" + self._print_value_fmt.format(jnp.mean(x)) + self._units)
 
         if self._normalize:
             print(
@@ -178,6 +179,11 @@ class MercierStability(_Objective):
             print(
                 "Minimum"
                 + self._print_value_fmt.format(jnp.min(x / self.normalization))
+                + "(normalized)"
+            )
+            print(
+                "Average"
+                + self._print_value_fmt.format(jnp.mean(x / self.normalization))
                 + "(normalized)"
             )
 
@@ -330,3 +336,4 @@ class MagneticWell(_Objective):
         x = self._unshift_unscale(self.compute(*args, **kwargs))
         print("Maximum" + self._print_value_fmt.format(jnp.max(x)) + self._units)
         print("Minimum" + self._print_value_fmt.format(jnp.min(x)) + self._units)
+        print("Average" + self._print_value_fmt.format(jnp.mean(x)) + self._units)

--- a/desc/objectives/_stability.py
+++ b/desc/objectives/_stability.py
@@ -163,6 +163,24 @@ class MercierStability(_Objective):
         w = compress(self.grid, self.grid.spacing[:, 0], surface_label="rho")
         return self._shift_scale(f) * w
 
+    def print_value(self, *args, **kwargs):
+        """Print the value of the objective."""
+        x = self._unshift_unscale(self.compute(*args, **kwargs))
+        print("Maximum" + self._print_value_fmt.format(jnp.max(x)) + self._units)
+        print("Minimum" + self._print_value_fmt.format(jnp.min(x)) + self._units)
+
+        if self._normalize:
+            print(
+                "Maximum"
+                + self._print_value_fmt.format(jnp.max(x / self.normalization))
+                + "(normalized)"
+            )
+            print(
+                "Minimum"
+                + self._print_value_fmt.format(jnp.min(x / self.normalization))
+                + "(normalized)"
+            )
+
 
 class MagneticWell(_Objective):
     """The magnetic well is a fast proxy for MHD stability.
@@ -306,3 +324,9 @@ class MagneticWell(_Objective):
         f = compress(self.grid, data["magnetic well"], surface_label="rho")
         w = compress(self.grid, self.grid.spacing[:, 0], surface_label="rho")
         return self._shift_scale(f) * w
+
+    def print_value(self, *args, **kwargs):
+        """Print the value of the objective."""
+        x = self._unshift_unscale(self.compute(*args, **kwargs))
+        print("Maximum" + self._print_value_fmt.format(jnp.max(x)) + self._units)
+        print("Minimum" + self._print_value_fmt.format(jnp.min(x)) + self._units)

--- a/tests/test_stability_funs.py
+++ b/tests/test_stability_funs.py
@@ -72,15 +72,11 @@ def get_vmec_data(stellarator, quantity):
 def test_mercier_vacuum():
     """Test that the Mercier stability criteria are 0 without pressure."""
     eq = Equilibrium()
-    grid = LinearGrid(L=10, M=10, N=5)
-    np.testing.assert_allclose(eq.compute("D_shear", grid=grid)["D_shear"], 0)
-    np.testing.assert_allclose(eq.compute("D_current", grid=grid)["D_current"], 0)
-    np.testing.assert_allclose(eq.compute("D_well", grid=grid)["D_well"], 0)
-    np.testing.assert_allclose(eq.compute("D_geodesic", grid=grid)["D_geodesic"], 0)
-    np.testing.assert_allclose(eq.compute("D_Mercier", grid=grid)["D_Mercier"], 0)
-
-    mercier_obj = MercierStability(eq=eq, grid=grid)
-    np.testing.assert_allclose(mercier_obj.compute(*mercier_obj.xs(eq)), 0)
+    np.testing.assert_allclose(eq.compute("D_shear")["D_shear"], 0)
+    np.testing.assert_allclose(eq.compute("D_current")["D_current"], 0)
+    np.testing.assert_allclose(eq.compute("D_well")["D_well"], 0)
+    np.testing.assert_allclose(eq.compute("D_geodesic")["D_geodesic"], 0)
+    np.testing.assert_allclose(eq.compute("D_Mercier")["D_Mercier"], 0)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Stability objective normed values are meaningless when what really matters is the sign, so this makes the print statement for the end-of-solve change so that it prints the max, min and average values for MagneticWell and MercierStability

addresses #360 