### PR TITLE
Unify ``Objective.compute`` signatures

### DIFF
--- a/desc/compute/__init__.py
+++ b/desc/compute/__init__.py
@@ -39,6 +39,7 @@ from . import (
 )
 from .data_index import data_index
 from .utils import (
+    arg_order,
     compute,
     get_data_deps,
     get_derivs,
@@ -46,9 +47,6 @@ from .utils import (
     get_profiles,
     get_transforms,
 )
-
-# defines the order in which objective arguments get concatenated into the state vector
-arg_order = ("R_lmn", "Z_lmn", "L_lmn", "p_l", "i_l", "c_l", "Psi", "Rb_lmn", "Zb_lmn")
 
 
 # rather than having to recursively compute the full dependencies every time we

--- a/desc/compute/utils.py
+++ b/desc/compute/utils.py
@@ -11,6 +11,13 @@ from desc.grid import ConcentricGrid
 
 from .data_index import data_index
 
+# defines the order in which objective arguments get concatenated into the state vector
+arg_order = ("R_lmn", "Z_lmn", "L_lmn", "p_l", "i_l", "c_l", "Psi", "Rb_lmn", "Zb_lmn")
+
+
+def _sort_args(args):
+    return [arg for arg in arg_order if arg in args]
+
 
 def compute(names, params, transforms, profiles, data=None, **kwargs):
     """Compute the quantity given by name on grid.
@@ -221,7 +228,7 @@ def get_params(keys, eq=None, **kwargs):
     params = []
     for key in deps:
         params += data_index[key]["dependencies"]["params"]
-    params = sorted(list(set(params)))
+    params = _sort_args(list(set(params)))
     if eq is None:
         return params
     params = {name: np.atleast_1d(getattr(eq, name)).copy() for name in params}

--- a/desc/objectives/_equilibrium.py
+++ b/desc/objectives/_equilibrium.py
@@ -6,7 +6,7 @@ from termcolor import colored
 
 from desc.backend import jnp
 from desc.compute import compute as compute_fun
-from desc.compute import get_profiles, get_transforms
+from desc.compute import get_params, get_profiles, get_transforms
 from desc.grid import ConcentricGrid, QuadratureGrid
 from desc.utils import Timer
 
@@ -119,6 +119,7 @@ class ForceBalance(_Objective):
             "F_helical",
             "|e^helical|",
         ]
+        self._args = get_params(self._data_keys)
 
         timer = Timer()
         if verbose > 0:
@@ -139,7 +140,7 @@ class ForceBalance(_Objective):
 
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, R_lmn, Z_lmn, L_lmn, p_l, i_l, c_l, Psi, **kwargs):
+    def compute(self, *args, **kwargs):
         """Compute MHD force balance errors.
 
         Parameters
@@ -165,15 +166,7 @@ class ForceBalance(_Objective):
             MHD force balance error at each node (N).
 
         """
-        params = {
-            "R_lmn": R_lmn,
-            "Z_lmn": Z_lmn,
-            "L_lmn": L_lmn,
-            "p_l": p_l,
-            "i_l": i_l,
-            "c_l": c_l,
-            "Psi": Psi,
-        }
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self._data_keys,
             params=params,
@@ -285,6 +278,7 @@ class RadialForceBalance(_Objective):
 
         self._dim_f = self.grid.num_nodes
         self._data_keys = ["F_rho", "|grad(rho)|", "sqrt(g)"]
+        self._args = get_params(self._data_keys)
 
         timer = Timer()
         if verbose > 0:
@@ -305,7 +299,7 @@ class RadialForceBalance(_Objective):
 
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, R_lmn, Z_lmn, L_lmn, p_l, i_l, c_l, Psi, **kwargs):
+    def compute(self, *args, **kwargs):
         """Compute radial MHD force balance errors.
 
         Parameters
@@ -331,15 +325,7 @@ class RadialForceBalance(_Objective):
             Radial MHD force balance error at each node (N).
 
         """
-        params = {
-            "R_lmn": R_lmn,
-            "Z_lmn": Z_lmn,
-            "L_lmn": L_lmn,
-            "p_l": p_l,
-            "i_l": i_l,
-            "c_l": c_l,
-            "Psi": Psi,
-        }
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self._data_keys,
             params=params,
@@ -448,6 +434,7 @@ class HelicalForceBalance(_Objective):
 
         self._dim_f = self.grid.num_nodes
         self._data_keys = ["F_helical", "|e^helical|", "sqrt(g)"]
+        self._args = get_params(self._data_keys)
 
         timer = Timer()
         if verbose > 0:
@@ -468,7 +455,7 @@ class HelicalForceBalance(_Objective):
 
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, R_lmn, Z_lmn, L_lmn, p_l, i_l, c_l, Psi, **kwargs):
+    def compute(self, *args, **kwargs):
         """Compute helical MHD force balance errors.
 
         Parameters
@@ -494,15 +481,7 @@ class HelicalForceBalance(_Objective):
             Helical MHD force balance error at each node (N).
 
         """
-        params = {
-            "R_lmn": R_lmn,
-            "Z_lmn": Z_lmn,
-            "L_lmn": L_lmn,
-            "p_l": p_l,
-            "i_l": i_l,
-            "c_l": c_l,
-            "Psi": Psi,
-        }
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self._data_keys,
             params=params,
@@ -624,6 +603,7 @@ class Energy(_Objective):
 
         self._dim_f = 1
         self._data_keys = ["W"]
+        self._args = get_params(self._data_keys)
 
         timer = Timer()
         if verbose > 0:
@@ -643,7 +623,7 @@ class Energy(_Objective):
 
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, R_lmn, Z_lmn, L_lmn, p_l, i_l, c_l, Psi, **kwargs):
+    def compute(self, *args, **kwargs):
         """Compute MHD energy.
 
         Parameters
@@ -669,15 +649,7 @@ class Energy(_Objective):
             Total MHD energy in the plasma volume (J).
 
         """
-        params = {
-            "R_lmn": R_lmn,
-            "Z_lmn": Z_lmn,
-            "L_lmn": L_lmn,
-            "p_l": p_l,
-            "i_l": i_l,
-            "c_l": c_l,
-            "Psi": Psi,
-        }
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self._data_keys,
             params=params,
@@ -791,6 +763,7 @@ class CurrentDensity(_Objective):
 
         self._dim_f = 3 * self.grid.num_nodes
         self._data_keys = ["J^rho", "J^theta", "J^zeta", "sqrt(g)"]
+        self._args = get_params(self._data_keys)
 
         timer = Timer()
         if verbose > 0:
@@ -811,7 +784,7 @@ class CurrentDensity(_Objective):
 
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, R_lmn, Z_lmn, L_lmn, i_l, c_l, Psi, **kwargs):
+    def compute(self, *args, **kwargs):
         """Compute toroidal current density.
 
         Parameters
@@ -835,14 +808,7 @@ class CurrentDensity(_Objective):
             Toroidal current at each node (A*m).
 
         """
-        params = {
-            "R_lmn": R_lmn,
-            "Z_lmn": Z_lmn,
-            "L_lmn": L_lmn,
-            "i_l": i_l,
-            "c_l": c_l,
-            "Psi": Psi,
-        }
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self._data_keys,
             params=params,

--- a/desc/objectives/_generic.py
+++ b/desc/objectives/_generic.py
@@ -86,7 +86,12 @@ class GenericObjective(_Objective):
         if self.grid is None:
             self.grid = QuadratureGrid(eq.L_grid, eq.M_grid, eq.N_grid, eq.NFP)
 
-        self._dim_f = self.grid.num_nodes
+        if data_index[self.f]["dim"] == 0:
+            self._dim_f = 1
+            self._scalar = True
+        else:
+            self._dim_f = self.grid.num_nodes * data_index[self.f]["dim"]
+            self._scalar = False
         self._args = get_params(self.f)
         self._profiles = get_profiles(self.f, eq=eq, grid=self.grid)
         self._transforms = get_transforms(self.f, eq=eq, grid=self.grid)
@@ -113,7 +118,9 @@ class GenericObjective(_Objective):
             transforms=self._transforms,
             profiles=self._profiles,
         )
-        f = data[self.f] * self.grid.weights
+        f = data[self.f]
+        if not self.scalar:
+            f = (f.T * self.grid.weights).flatten()
         return self._shift_scale(f)
 
 

--- a/desc/objectives/_generic.py
+++ b/desc/objectives/_generic.py
@@ -92,13 +92,13 @@ class GenericObjective(_Objective):
         self._transforms = get_transforms(self.f, eq=eq, grid=self.grid)
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, **params):
+    def compute(self, *args, **kwargs):
         """Compute the quantity.
 
         Parameters
         ----------
-        args : list of ndarray
-            Any of the arguments given in `arg_order`.
+        args : ndarray
+            Parameters given by self.args.
 
         Returns
         -------
@@ -106,6 +106,7 @@ class GenericObjective(_Objective):
             Computed quantity.
 
         """
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self.f,
             params=params,
@@ -193,6 +194,7 @@ class ToroidalCurrent(_Objective):
 
         self._dim_f = self.grid.num_rho
         self._data_keys = ["current"]
+        self._args = get_params(self._data_keys)
 
         timer = Timer()
         if verbose > 0:
@@ -212,7 +214,7 @@ class ToroidalCurrent(_Objective):
 
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, R_lmn, Z_lmn, L_lmn, i_l, c_l, Psi, **kwargs):
+    def compute(self, *args, **kwargs):
         """Compute toroidal current.
 
         Parameters
@@ -236,14 +238,7 @@ class ToroidalCurrent(_Objective):
             Toroidal current (A) through specified surfaces.
 
         """
-        params = {
-            "R_lmn": R_lmn,
-            "Z_lmn": Z_lmn,
-            "L_lmn": L_lmn,
-            "i_l": i_l,
-            "c_l": c_l,
-            "Psi": Psi,
-        }
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self._data_keys,
             params=params,
@@ -332,6 +327,7 @@ class RotationalTransform(_Objective):
 
         self._dim_f = self.grid.num_rho
         self._data_keys = ["iota"]
+        self._args = get_params(self._data_keys)
 
         timer = Timer()
         if verbose > 0:
@@ -347,7 +343,7 @@ class RotationalTransform(_Objective):
 
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, R_lmn, Z_lmn, L_lmn, i_l, c_l, Psi, **kwargs):
+    def compute(self, *args, **kwargs):
         """Compute rotational transform profile errors.
 
         Parameters
@@ -370,14 +366,7 @@ class RotationalTransform(_Objective):
         iota : ndarray
             rotational transform on specified flux surfaces.
         """
-        params = {
-            "R_lmn": R_lmn,
-            "Z_lmn": Z_lmn,
-            "L_lmn": L_lmn,
-            "i_l": i_l,
-            "c_l": c_l,
-            "Psi": Psi,
-        }
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self._data_keys,
             params=params,

--- a/desc/objectives/_geometry.py
+++ b/desc/objectives/_geometry.py
@@ -1,7 +1,7 @@
 """Objectives for targeting geometrical quantities."""
 
 from desc.compute import compute as compute_fun
-from desc.compute import get_profiles, get_transforms
+from desc.compute import get_params, get_profiles, get_transforms
 from desc.grid import QuadratureGrid
 from desc.utils import Timer
 
@@ -81,6 +81,7 @@ class Volume(_Objective):
 
         self._dim_f = 1
         self._data_keys = ["V"]
+        self._args = get_params(self._data_keys)
 
         timer = Timer()
         if verbose > 0:
@@ -100,7 +101,7 @@ class Volume(_Objective):
 
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, R_lmn, Z_lmn, **kwargs):
+    def compute(self, *args, **kwargs):
         """Compute plasma volume.
 
         Parameters
@@ -116,10 +117,7 @@ class Volume(_Objective):
             Plasma volume (m^3).
 
         """
-        params = {
-            "R_lmn": R_lmn,
-            "Z_lmn": Z_lmn,
-        }
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self._data_keys,
             params=params,
@@ -203,6 +201,8 @@ class AspectRatio(_Objective):
 
         self._dim_f = 1
         self._data_keys = ["R0/a"]
+        self._args = get_params(self._data_keys)
+
         timer = Timer()
         if verbose > 0:
             print("Precomputing transforms")
@@ -217,7 +217,7 @@ class AspectRatio(_Objective):
 
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, R_lmn, Z_lmn, **kwargs):
+    def compute(self, *args, **kwargs):
         """Compute aspect ratio.
 
         Parameters
@@ -233,10 +233,7 @@ class AspectRatio(_Objective):
             Aspect ratio, dimensionless.
 
         """
-        params = {
-            "R_lmn": R_lmn,
-            "Z_lmn": Z_lmn,
-        }
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self._data_keys,
             params=params,

--- a/desc/objectives/_qs.py
+++ b/desc/objectives/_qs.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from desc.backend import jnp
 from desc.compute import compute as compute_fun
-from desc.compute import get_profiles, get_transforms
+from desc.compute import get_params, get_profiles, get_transforms
 from desc.grid import LinearGrid
 from desc.utils import Timer
 
@@ -105,6 +105,7 @@ class QuasisymmetryBoozer(_Objective):
                 M=2 * self.M_booz, N=2 * self.N_booz, NFP=eq.NFP, sym=False
             )
         self._data_keys = ["|B|_mn"]
+        self._args = get_params(self._data_keys)
 
         timer = Timer()
         if verbose > 0:
@@ -149,7 +150,7 @@ class QuasisymmetryBoozer(_Objective):
 
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, R_lmn, Z_lmn, L_lmn, i_l, c_l, Psi, **kwargs):
+    def compute(self, *args, **kwargs):
         """Compute quasi-symmetry Boozer harmonics error.
 
         Parameters
@@ -173,14 +174,7 @@ class QuasisymmetryBoozer(_Objective):
             Quasi-symmetry flux function error at each node (T^3).
 
         """
-        params = {
-            "R_lmn": R_lmn,
-            "Z_lmn": Z_lmn,
-            "L_lmn": L_lmn,
-            "i_l": i_l,
-            "c_l": c_l,
-            "Psi": Psi,
-        }
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self._data_keys,
             params=params,
@@ -297,6 +291,7 @@ class QuasisymmetryTwoTerm(_Objective):
 
         self._dim_f = self.grid.num_nodes
         self._data_keys = ["f_C"]
+        self._args = get_params(self._data_keys)
 
         timer = Timer()
         if verbose > 0:
@@ -316,7 +311,7 @@ class QuasisymmetryTwoTerm(_Objective):
 
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, R_lmn, Z_lmn, L_lmn, i_l, c_l, Psi, **kwargs):
+    def compute(self, *args, **kwargs):
         """Compute quasi-symmetry two-term errors.
 
         Parameters
@@ -340,14 +335,7 @@ class QuasisymmetryTwoTerm(_Objective):
             Quasi-symmetry flux function error at each node (T^3).
 
         """
-        params = {
-            "R_lmn": R_lmn,
-            "Z_lmn": Z_lmn,
-            "L_lmn": L_lmn,
-            "i_l": i_l,
-            "c_l": c_l,
-            "Psi": Psi,
-        }
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self._data_keys,
             params=params,
@@ -452,6 +440,7 @@ class QuasisymmetryTripleProduct(_Objective):
 
         self._dim_f = self.grid.num_nodes
         self._data_keys = ["f_T"]
+        self._args = get_params(self._data_keys)
 
         timer = Timer()
         if verbose > 0:
@@ -473,7 +462,7 @@ class QuasisymmetryTripleProduct(_Objective):
 
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, R_lmn, Z_lmn, L_lmn, i_l, c_l, Psi, **kwargs):
+    def compute(self, *args, **kwargs):
         """Compute quasi-symmetry triple product errors.
 
         Parameters
@@ -497,14 +486,7 @@ class QuasisymmetryTripleProduct(_Objective):
             Quasi-symmetry flux function error at each node (T^4/m^2).
 
         """
-        params = {
-            "R_lmn": R_lmn,
-            "Z_lmn": Z_lmn,
-            "L_lmn": L_lmn,
-            "i_l": i_l,
-            "c_l": c_l,
-            "Psi": Psi,
-        }
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self._data_keys,
             params=params,

--- a/desc/objectives/_stability.py
+++ b/desc/objectives/_stability.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from desc.backend import jnp
 from desc.compute import compute as compute_fun
-from desc.compute import get_profiles, get_transforms
+from desc.compute import get_params, get_profiles, get_transforms
 from desc.compute.utils import compress
 from desc.grid import LinearGrid
 from desc.utils import Timer
@@ -96,6 +96,7 @@ class MercierStability(_Objective):
 
         self._dim_f = self.grid.num_rho
         self._data_keys = ["D_Mercier"]
+        self._args = get_params(self._data_keys)
 
         timer = Timer()
         if verbose > 0:
@@ -115,7 +116,7 @@ class MercierStability(_Objective):
 
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, R_lmn, Z_lmn, L_lmn, p_l, i_l, c_l, Psi, **kwargs):
+    def compute(self, *args, **kwargs):
         """Compute the Mercier stability criterion.
 
         Parameters
@@ -141,15 +142,7 @@ class MercierStability(_Objective):
             Mercier stability criterion.
 
         """
-        params = {
-            "R_lmn": R_lmn,
-            "Z_lmn": Z_lmn,
-            "L_lmn": L_lmn,
-            "p_l": p_l,
-            "i_l": i_l,
-            "c_l": c_l,
-            "Psi": Psi,
-        }
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self._data_keys,
             params=params,
@@ -272,6 +265,7 @@ class MagneticWell(_Objective):
 
         self._dim_f = self.grid.num_rho
         self._data_keys = ["magnetic well"]
+        self._args = get_params(self._data_keys)
 
         timer = Timer()
         if verbose > 0:
@@ -287,7 +281,7 @@ class MagneticWell(_Objective):
 
         super().build(eq=eq, use_jit=use_jit, verbose=verbose)
 
-    def compute(self, R_lmn, Z_lmn, L_lmn, p_l, i_l, c_l, Psi, **kwargs):
+    def compute(self, *args, **kwargs):
         """Compute a magnetic well parameter.
 
         Parameters
@@ -313,15 +307,7 @@ class MagneticWell(_Objective):
             Magnetic well parameter.
 
         """
-        params = {
-            "R_lmn": R_lmn,
-            "Z_lmn": Z_lmn,
-            "L_lmn": L_lmn,
-            "p_l": p_l,
-            "i_l": i_l,
-            "c_l": c_l,
-            "Psi": Psi,
-        }
+        params = self._parse_args(*args, **kwargs)
         data = compute_fun(
             self._data_keys,
             params=params,

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -648,6 +648,24 @@ class _Objective(IOAble, ABC):
         """Return a tuple of args required by this objective from the Equilibrium eq."""
         return tuple(getattr(eq, arg) for arg in self.args)
 
+    def _parse_args(self, *args, **kwargs):
+        assert (len(args) == 0) or (len(kwargs) == 0), (
+            "compute should be called with either positional or keyword arguments,"
+            + " not both"
+        )
+        if len(args):
+            assert len(args) == len(
+                self.args
+            ), f"compute expected {len(self.args)} arguments, got {len(args)}"
+            params = {key: val for key, val in zip(self.args, args)}
+        else:
+            assert all([arg in kwargs for arg in self.args]), (
+                "compute missing required keyword arguments "
+                + f"{set(self.args).difference(kwargs.keys())}"
+            )
+            params = kwargs
+        return params
+
     @property
     def target(self):
         """float: Target value(s) of the objective."""

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -253,3 +253,14 @@ def test_rejit():
     objective2.jit()
     assert objective2.compute(x)[0] == 2012.0
     np.testing.assert_allclose(objective2.jac(x), J / 3 * 2)
+
+
+@pytest.mark.unit
+def test_generic_compute():
+    """Test for gh issue #388."""
+    eq = Equilibrium()
+    obj = ObjectiveFunction(AspectRatio(target=2, weight=1), eq=eq)
+    a1 = obj.compute_scalar(obj.x(eq))
+    obj = ObjectiveFunction(GenericObjective("R0/a", target=2, weight=1), eq=eq)
+    a2 = obj.compute_scalar(obj.x(eq))
+    assert np.allclose(a1, a2)


### PR DESCRIPTION
- All compute methods now take generic `*args, **kwargs`, and are parsed accordingly.
- Fixes `dim_f` and `scalar` attributes of `GenericObjective` when the requested value is a global scalar.
- `Objective.args` now determined during build using `get_params` rather than introspection.

Note: this doesn't affect the linear fixed constraints for now, since we've always treated those a bit differently and it doesn't really affect them.

Resolves #388 