### PR TITLE
Allow targets to be Profile objects

### DIFF
--- a/desc/objectives/_generic.py
+++ b/desc/objectives/_generic.py
@@ -5,6 +5,7 @@ from desc.compute import compute as compute_fun
 from desc.compute import data_index
 from desc.compute.utils import compress, get_params, get_profiles, get_transforms
 from desc.grid import LinearGrid, QuadratureGrid
+from desc.profiles import Profile
 from desc.utils import Timer
 
 from .normalization import compute_scaling_factors
@@ -131,9 +132,10 @@ class ToroidalCurrent(_Objective):
     ----------
     eq : Equilibrium, optional
         Equilibrium that will be optimized to satisfy the Objective.
-    target : float, ndarray, optional
+    target : Profile, float, ndarray, optional
         Target value(s) of the objective.
-        len(target) must be equal to Objective.dim_f == grid.num_rho
+        If a Profile, target the values of that profile at nodes specified by grid.
+        If an array, len(target) must be equal to Objective.dim_f == grid.num_rho
     weight : float, ndarray, optional
         Weighting to apply to the Objective, relative to other Objectives.
         len(weight) must be equal to Objective.dim_f == grid.num_rho
@@ -198,6 +200,9 @@ class ToroidalCurrent(_Objective):
                 sym=eq.sym,
                 axis=False,
             )
+
+        if isinstance(self._target, Profile):
+            self._target = self._target(self.grid.nodes[self.grid.unique_rho_idx])
 
         self._dim_f = self.grid.num_rho
         self._data_keys = ["current"]
@@ -264,9 +269,10 @@ class RotationalTransform(_Objective):
     ----------
     eq : Equilibrium, optional
         Equilibrium that will be optimized to satisfy the Objective.
-    target : float, ndarray, optional
+    target : Profile, float, ndarray, optional
         Target value(s) of the objective.
-        len(target) must be equal to Objective.dim_f == grid.num_rho
+        If a Profile, target the values of that profile at nodes specified by grid.
+        If an array, len(target) must be equal to Objective.dim_f == grid.num_rho
     weight : float, ndarray, optional
         Weighting to apply to the Objective, relative to other Objectives.
         len(weight) must be equal to Objective.dim_f == grid.num_rho
@@ -331,6 +337,8 @@ class RotationalTransform(_Objective):
                 sym=eq.sym,
                 axis=False,
             )
+        if isinstance(self._target, Profile):
+            self._target = self._target(self.grid.nodes[self.grid.unique_rho_idx])
 
         self._dim_f = self.grid.num_rho
         self._data_keys = ["iota"]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -130,6 +130,7 @@ Objective Functions
     desc.objectives.QuasisymmetryTwoTerm
     desc.objectives.QuasisymmetryTripleProduct
     desc.objectives.RadialForceBalance
+    desc.objectives.RotationalTransform
     desc.objectives.ToroidalCurrent
     desc.objectives.Volume
 

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -264,3 +264,22 @@ def test_generic_compute():
     obj = ObjectiveFunction(GenericObjective("R0/a", target=2, weight=1), eq=eq)
     a2 = obj.compute_scalar(obj.x(eq))
     assert np.allclose(a1, a2)
+
+
+@pytest.mark.unit
+def test_target_profiles():
+    """Tests for using Profile objects as targets for profile objectives."""
+    iota = PowerSeriesProfile([1, 0, -0.3])
+    current = PowerSeriesProfile([4, 0, 1, 0, -1])
+    eqi = Equilibrium(L=5, N=3, M=3, iota=iota)
+    eqc = Equilibrium(L=3, N=3, M=3, current=current)
+    obji = RotationalTransform(target=iota)
+    obji.build(eqc)
+    np.testing.assert_allclose(
+        obji.target, iota(obji.grid.nodes[obji.grid.unique_rho_idx])
+    )
+    objc = RotationalTransform(target=current)
+    objc.build(eqi)
+    np.testing.assert_allclose(
+        objc.target, current(objc.grid.nodes[objc.grid.unique_rho_idx])
+    )

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -278,7 +278,7 @@ def test_target_profiles():
     np.testing.assert_allclose(
         obji.target, iota(obji.grid.nodes[obji.grid.unique_rho_idx])
     )
-    objc = RotationalTransform(target=current)
+    objc = ToroidalCurrent(target=current)
     objc.build(eqi)
     np.testing.assert_allclose(
         objc.target, current(objc.grid.nodes[objc.grid.unique_rho_idx])


### PR DESCRIPTION
For objectives like targeting a particular iota or current, it feels weird to have to give targets as an array value, this allows the target to be a profile which is then evaluated at specific nodes when the objective is built.