### PR TITLE
Updated definition of f_C in the list of variables to match the implementation

### DIFF
--- a/desc/compute/_qs.py
+++ b/desc/compute/_qs.py
@@ -295,8 +295,8 @@ def _B_modes(params, transforms, profiles, data, **kwargs):
 
 @register_compute_fun(
     name="f_C",
-    label="(\\mathbf{B} \\times \\nabla \\psi) \\cdot \\nabla B - "
-    + "(M G + N I) / (M \\iota - N) \\mathbf{B} \\cdot \\nabla B",
+    label="(M \\iota - N) (\\mathbf{B} \\times \\nabla \\psi) \\cdot \\nabla B"
+    + " - (M G + N I) \\mathbf{B} \\cdot \\nabla B",
     units="T^{3}",
     units_long="Tesla cubed",
     description="Two-term quasisymmetry metric",

--- a/docs/compute.rst
+++ b/docs/compute.rst
@@ -68,7 +68,7 @@ metadata about the quanity. The necessary fields are detailed below:
   this function). For most quantites this will be an empty list.
 * ``coordinates``: String denoting which coordinate the quanity depends on. Most will be
   ``"rtz"`` indicating it is a funciton of :math:`\rho, \theta, \zeta`. Profiles and flux surface
-  quantities would have ``coordinates="r"`` indicating it only depends on `:math:\rho`
+  quantities would have ``coordinates="r"`` indicating it only depends on :math:`\rho`
 * ``data``: What other physics quantites are needed to compute this quanity. In our
   example, we need the radial derivative of pressure ``p_r``, the Jacobian determinant
   ``sqrt(g)``, and contravariant components of current and magnetic field. These dependencies

--- a/docs/variables.csv
+++ b/docs/variables.csv
@@ -237,7 +237,7 @@ Name,Label,Units,Description,Module
 ``R0``,:math:`R_{0}`,meters,Average major radius,``desc.compute._geometry``
 ``a``,:math:`a`,meters,Average minor radius,``desc.compute._geometry``
 ``R0/a``,:math:`R_{0} / a`,None,Aspect ratio,``desc.compute._geometry``
-``a_major/a_minor``,:math:`a_{major} / a_{minor}`,None,Elongation,``desc.compute._geometry``
+``a_major/a_minor``,:math:`a_{major} / a_{minor}`,None,Maximum elongation,``desc.compute._geometry``
 ``n_rho``,:math:`\hat{\mathbf{n}}_{\rho}`,None,Unit normal vector to constant rho surface,``desc.compute._geometry``
 ``L_sff``,:math:`L_{sff}`,meters,L coefficient of second fundamental form,``desc.compute._geometry``
 ``M_sff``,:math:`M_{sff}`,meters,M coefficient of second fundamental form,``desc.compute._geometry``
@@ -317,7 +317,7 @@ Name,Label,Units,Description,Module
 ``sqrt(g)_B``,:math:`\sqrt{g}_{B}`,None,Jacobian determinant of Boozer coordinates,``desc.compute._qs``
 ``|B|_mn``,:math:`B_{mn}^{Boozer}`,Tesla,Boozer harmonics of magnetic field,``desc.compute._qs``
 ``B modes``,:math:`Boozer modes`,None,Boozer harmonics,``desc.compute._qs``
-``f_C``,:math:`(\mathbf{B} \times \nabla \psi) \cdot \nabla B - (M G + N I) / (M \iota - N) \mathbf{B} \cdot \nabla B`,Tesla cubed,Two-term quasisymmetry metric,``desc.compute._qs``
+``f_C``,:math:`(M \iota - N) (\mathbf{B} \times \nabla \psi) \cdot \nabla B - (M G + N I) \mathbf{B} \cdot \nabla B`,Tesla cubed,Two-term quasisymmetry metric,``desc.compute._qs``
 ``f_T``,:math:`\nabla \psi \times \nabla B \cdot \nabla (\mathbf{B} \cdot \nabla B)`,Tesla quarted / square meters,Triple product quasisymmetry metric,``desc.compute._qs``
 ``D_shear``,:math:`D_{shear}`,Inverse Webers squared,Mercier stability criterion magnetic shear term,``desc.compute._stability``
 ``D_current``,:math:`D_{current}`,Inverse Webers squared,Mercier stability criterion toroidal current term,``desc.compute._stability``


### PR DESCRIPTION
The compute function for `f_C` has the `(M iota - N)` factor in the numerator. Previously, the documentation of `f_C` in the "list of variables" had the `(M iota - N)` factor in the denominator. In this PR, the documentation is adjusted to match the implementation.

(When I ran `docs/variables.py` it also updated the entry for elongation.)