### PR TITLE
Hotfix perturb with a 0D array or scalar

### DIFF
--- a/desc/perturbations.py
+++ b/desc/perturbations.py
@@ -141,6 +141,11 @@ def perturb(  # noqa: C901 - FIXME: break this up into simpler pieces
     # remove deltas that are zero
     deltas = {key: val for key, val in deltas.items() if np.any(val)}
 
+    # make sure things are at least 1D for np.concatenate later
+    # in case only a single delta is being passed
+    for key in deltas.keys():
+        deltas[key] = np.atleast_1d(deltas[key])
+
     if not objective.built:
         objective.build(eq, verbose=verbose)
     for constraint in constraints:

--- a/tests/test_perturbations.py
+++ b/tests/test_perturbations.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import desc.examples
-from desc.equilibrium import EquilibriaFamily
+from desc.equilibrium import EquilibriaFamily, Equilibrium
 from desc.grid import ConcentricGrid, QuadratureGrid
 from desc.objectives import (
     ForceBalance,
@@ -95,6 +95,28 @@ def test_perturbation_orders(SOLOVEV):
     assert f2 < f1
     assert f3 < f2
     assert fS < f3
+
+
+def test_perturb_with_float_without_error():
+    """Test that perturb works without error if only a single float is passed."""
+    # PR #
+    # fixed bug where np.concatenate( [float] ) was called resulting in error that
+    # np.concatenate cannot concatenate 0-D arrays. This test exercises the fix.
+    eq = Equilibrium()
+    objective = get_equilibrium_objective()
+    constraints = get_fixed_boundary_constraints(iota=False)
+
+    # perturb Psi with a float
+    deltas = {"Psi": float(eq.Psi)}
+    eq = perturb(
+        eq,
+        objective,
+        constraints,
+        deltas,
+        order=0,
+        verbose=2,
+        copy=True,
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Add statement in perturb function that makes sure all deltas are np.atleast_1D inside perturb to prevent error in np.concatenate if only a single delta is passed that is a scalar or 0D array