### PR TITLE
Allow DESC optimizers to handle simple bound constraints

### DIFF
--- a/.github/workflows/nbtests.yml
+++ b/.github/workflows/nbtests.yml
@@ -40,4 +40,4 @@ jobs:
           pwd
           lscpu
           export PYTHONPATH=$(pwd)
-          pytest --nbmake "./docs/notebooks" --nbmake-timeout=600 --ignore=./docs/notebooks/zernike_eval.ipynb --ignore=./docs/notebooks/DESC_Solve_from_pyQSC.ipynb
+          pytest -v --nbmake "./docs/notebooks" --nbmake-timeout=600 --ignore=./docs/notebooks/zernike_eval.ipynb --ignore=./docs/notebooks/DESC_Solve_from_pyQSC.ipynb

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           pwd
           lscpu
-          python -m pytest -m regression --durations=0 --cov-report xml:cov.xml --cov-config=setup.cfg --cov=desc/ --mpl --mpl-results-path=mpl_results.html --mpl-generate-summary=html --splits 4 --group ${{ matrix.group }} --splitting-algorithm least_duration --db ./prof.db
+          python -m pytest -v -m regression --durations=0 --cov-report xml:cov.xml --cov-config=setup.cfg --cov=desc/ --mpl --mpl-results-path=mpl_results.html --mpl-generate-summary=html --splits 4 --group ${{ matrix.group }} --splitting-algorithm least_duration --db ./prof.db
       - name: save coverage file and plot comparison results
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           pwd
           lscpu
-          python -m pytest -m unit --durations=0 --cov-report xml:cov.xml --cov-config=setup.cfg --cov=desc/ --mpl --mpl-results-path=mpl_results.html --mpl-generate-summary=html --splits 3 --group ${{ matrix.group }} --splitting-algorithm least_duration --db ./prof.db
+          python -m pytest -v -m unit --durations=0 --cov-report xml:cov.xml --cov-config=setup.cfg --cov=desc/ --mpl --mpl-results-path=mpl_results.html --mpl-generate-summary=html --splits 3 --group ${{ matrix.group }} --splitting-algorithm least_duration --db ./prof.db
       - name: save coverage file and plot comparison results
         if: always()
         uses: actions/upload-artifact@v3

--- a/desc/optimize/_desc_wrappers.py
+++ b/desc/optimize/_desc_wrappers.py
@@ -63,6 +63,8 @@ def _optimize_desc_least_squares(
     if not isinstance(x_scale, str) and jnp.allclose(x_scale, 1):
         options.setdefault("initial_trust_radius", 1e-3)
         options.setdefault("max_trust_radius", 1.0)
+    options["max_nfev"] = stoptol["max_nfev"]
+    options["max_njev"] = stoptol["max_njev"]
 
     result = lsqtr(
         objective.compute,
@@ -139,6 +141,9 @@ def _optimize_desc_fmin_scalar(
     if not isinstance(x_scale, str) and jnp.allclose(x_scale, 1):
         options.setdefault("initial_trust_ratio", 1e-3)
         options.setdefault("max_trust_radius", 1.0)
+    options["max_nfev"] = stoptol["max_nfev"]
+    options["max_ngev"] = stoptol["max_ngev"]
+    options["max_nhev"] = stoptol["max_nhev"]
 
     result = fmintr(
         objective.compute_scalar,

--- a/desc/optimize/_scipy_wrappers.py
+++ b/desc/optimize/_scipy_wrappers.py
@@ -147,7 +147,7 @@ def _optimize_scipy_minimize(  # noqa: C901 - FIXME: simplify this
                 H1 = np.eye(x1.size) / dx_norm
             if not H1.size:
                 H1 = np.eye(x1.size) / dx_norm
-            predicted_reduction = -evaluate_quadratic_form_hess(dx, 0, g1, H1)
+            predicted_reduction = -evaluate_quadratic_form_hess(H1, g1, dx)
             if predicted_reduction > 0:
                 reduction_ratio = df / predicted_reduction
             elif predicted_reduction == df == 0:

--- a/desc/optimize/bound_utils.py
+++ b/desc/optimize/bound_utils.py
@@ -1,0 +1,415 @@
+"""Utilities for dealing with simple bound constraints."""
+
+from desc.backend import jnp
+
+from .utils import evaluate_quadratic_form_hess, evaluate_quadratic_form_jac
+
+
+def cl_scaling_vector(x, g, lb, ub):
+    """Compute Coleman-Li scaling vector and its derivatives.
+
+    Components of a vector v are defined as follows:
+    ::
+               | ub[i] - x[i], if g[i] < 0 and ub[i] < np.inf
+        v[i] = | x[i] - lb[i], if g[i] > 0 and lb[i] > -np.inf
+               | 1,           otherwise
+
+    According to this definition v[i] >= 0 for all i. It differs from the
+    definition in paper [1]_ (eq. (2.2)), where the absolute value of v is
+    used. Both definitions are equivalent down the line.
+    Derivatives of v with respect to x take value 1, -1 or 0 depending on a
+    case.
+
+    Parameters
+    ----------
+    x : ndarray
+        state vector
+    g : ndarray
+        gradient of objective function
+    lb, ub : ndarray
+        lower and upper bounds on x
+
+    Returns
+    -------
+    v : ndarray with shape of x
+        Scaling vector.
+    dv : ndarray with shape of x
+        Derivatives of v[i] with respect to x[i], diagonal elements of v's
+        Jacobian.
+
+    References
+    ----------
+    .. [1] M.A. Branch, T.F. Coleman, and Y. Li, "A Subspace, Interior,
+           and Conjugate Gradient Method for Large-Scale Bound-Constrained
+           Minimization Problems," SIAM Journal on Scientific Computing,
+           Vol. 21, Number 1, pp 1-23, 1999.
+    """
+    v = jnp.ones_like(x)
+    dv = jnp.zeros_like(x)
+
+    mask = (g < 0) & jnp.isfinite(ub)
+    v = jnp.where(mask, ub - x, v)
+    dv = jnp.where(mask, -1, dv)
+
+    mask = (g > 0) & jnp.isfinite(lb)
+    v = jnp.where(mask, x - lb, v)
+    dv = jnp.where(mask, 1, dv)
+
+    return v, dv
+
+
+def step_size_to_bound(x, s, lb, ub):
+    """Compute a min_step size required to reach a bound.
+
+    The function computes a positive scalar t, such that x + s * t is on
+    the bound.
+
+    Parameters
+    ----------
+    x : ndarray
+        state vector
+    s : ndarray
+        proposed step
+    lb, ub : ndarray
+        lower and upper bounds on x
+
+    Returns
+    -------
+    step : float
+        Computed step. Non-negative value.
+    hits : ndarray of int with shape of x
+        Each element indicates whether a corresponding variable reaches the
+        bound:
+             *  0 - the bound was not hit.
+             * -1 - the lower bound was hit.
+             *  1 - the upper bound was hit.
+    """
+    steps = jnp.inf * jnp.ones(x.size)
+    mask = s != 0
+    steps = jnp.where(mask, jnp.maximum((lb - x) / s, (ub - x) / s), steps)
+    min_step = jnp.min(steps)
+    return min_step, jnp.equal(steps, min_step) * jnp.sign(s).astype(int)
+
+
+def find_active_constraints(x, lb, ub, rtol=1e-10):
+    """Determine which constraints are active in a given point.
+
+    The threshold is computed using `rtol` and the absolute value of the
+    closest bound.
+
+    Parameters
+    ----------
+    x : ndarray
+        state vector
+    lb, ub : ndarray
+        lower and upper bounds on x
+
+    Returns
+    -------
+    active : ndarray of int with shape of x
+        Each component shows whether the corresponding constraint is active:
+             *  0 - a constraint is not active.
+             * -1 - a lower bound is active.
+             *  1 - a upper bound is active.
+    """
+    active = jnp.zeros_like(x, dtype=int)
+
+    if rtol == 0:
+        active = jnp.where(x <= lb, -1, active)
+        active = jnp.where(x >= ub, 1, active)
+        return active
+
+    lower_dist = x - lb
+    upper_dist = ub - x
+
+    lower_threshold = rtol * jnp.maximum(1, jnp.abs(lb))
+    upper_threshold = rtol * jnp.maximum(1, jnp.abs(ub))
+
+    lower_active = jnp.isfinite(lb) & (
+        lower_dist <= jnp.minimum(upper_dist, lower_threshold)
+    )
+    active = jnp.where(lower_active, -1, active)
+
+    upper_active = jnp.isfinite(ub) & (
+        upper_dist <= jnp.minimum(lower_dist, upper_threshold)
+    )
+    active = jnp.where(upper_active, 1, active)
+
+    return active
+
+
+def make_strictly_feasible(x, lb, ub, rstep=1e-10):
+    """Shift a point to the interior of a feasible region.
+
+    Each element of the returned vector is at least at a relative distance
+    `rstep` from the closest bound. If ``rstep=0`` then `np.nextafter` is used.
+    """
+    active = find_active_constraints(x, lb, ub, rstep)
+    lower_mask = jnp.equal(active, -1)
+    upper_mask = jnp.equal(active, 1)
+
+    if rstep == 0:
+        lwr = jnp.nextafter(lb, ub)
+        upr = jnp.nextafter(ub, lb)
+    else:
+        lwr = lb + rstep * jnp.maximum(1, jnp.abs(lb))
+        upr = ub - rstep * jnp.maximum(1, jnp.abs(ub))
+
+    x_new = x.copy()
+    x_new = jnp.where(lower_mask, lwr, x_new)
+    x_new = jnp.where(upper_mask, upr, x_new)
+    tight_bounds = (x_new < lb) | (x_new > ub)
+    x_new = jnp.where(tight_bounds, 0.5 * (lb + ub), x_new)
+
+    return x_new
+
+
+def in_bounds(x, lb, ub):
+    """Check if a point lies within bounds."""
+    return jnp.all((x >= lb) & (x <= ub))
+
+
+def select_step(x, JorH, diag_h, g_h, p, p_h, d, Delta, lb, ub, theta, mode="jac"):
+    """Select the best step according to Trust Region Reflective algorithm."""
+    assert mode in ["jac", "hess"]
+
+    if mode == "jac":
+        evaluate_quadratic_form = evaluate_quadratic_form_jac
+        build_quadratic_1d = build_quadratic_1d_jac
+    else:
+        evaluate_quadratic_form = evaluate_quadratic_form_hess
+        build_quadratic_1d = build_quadratic_1d_hess
+
+    if in_bounds(x + p, lb, ub):
+        p_value = evaluate_quadratic_form(JorH, g_h, p_h, diag=diag_h)
+        return p, p_h, -p_value
+
+    p_stride, hits = step_size_to_bound(x, p, lb, ub)
+
+    # Compute the reflected direction.
+    r_h = jnp.copy(p_h)
+    r_h = jnp.where(hits.astype(bool), r_h * -1, r_h)
+    r = d * r_h
+
+    # Restrict trust-region step, such that it hits the bound.
+    p *= p_stride
+    p_h *= p_stride
+    x_on_bound = x + p
+
+    # Reflected direction will cross first either feasible region or trust region
+    # boundary.
+    _, to_tr = intersect_trust_region(p_h, r_h, Delta)
+    to_bound, _ = step_size_to_bound(x_on_bound, r, lb, ub)
+
+    # Find lower and upper bounds on a step size along the reflected
+    # direction, considering the strict feasibility requirement. There is no
+    # single correct way to do that, the chosen approach seems to work best
+    # on test problems.
+    r_stride = min(to_bound, to_tr)
+    if r_stride > 0:
+        r_stride_l = (1 - theta) * p_stride / r_stride
+        if r_stride == to_bound:
+            r_stride_u = theta * to_bound
+        else:
+            r_stride_u = to_tr
+    else:
+        r_stride_l = 0
+        r_stride_u = -1
+
+    # Check if reflection step is available.
+    if r_stride_l <= r_stride_u:
+        a, b, c = build_quadratic_1d(JorH, g_h, r_h, s0=p_h, diag=diag_h)
+        r_stride, r_value = minimize_quadratic_1d(a, b, r_stride_l, r_stride_u, c=c)
+        r_h *= r_stride
+        r_h += p_h
+        r = r_h * d
+    else:
+        r_value = jnp.inf
+
+    # Now correct p_h to make it strictly interior.
+    p *= theta
+    p_h *= theta
+    p_value = evaluate_quadratic_form(JorH, g_h, p_h, diag=diag_h)
+
+    ag_h = -g_h
+    ag = d * ag_h
+
+    to_tr = Delta / jnp.linalg.norm(ag_h)
+    to_bound, _ = step_size_to_bound(x, ag, lb, ub)
+    if to_bound < to_tr:
+        ag_stride = theta * to_bound
+    else:
+        ag_stride = to_tr
+
+    a, b = build_quadratic_1d(JorH, g_h, ag_h, diag=diag_h)
+    ag_stride, ag_value = minimize_quadratic_1d(a, b, 0, ag_stride)
+    ag_h *= ag_stride
+    ag *= ag_stride
+
+    if p_value < r_value and p_value < ag_value:
+        return p, p_h, -p_value
+    elif r_value < p_value and r_value < ag_value:
+        return r, r_h, -r_value
+    else:
+        return ag, ag_h, -ag_value
+
+
+def build_quadratic_1d_jac(J, g, s, diag=None, s0=None):
+    """Parameterize a multivariate quadratic function along a line.
+
+    The resulting univariate quadratic function is given as follows:
+    ::
+        f(t) = 0.5 * (s0 + s*t).T * (J.T*J + diag) * (s0 + s*t) +
+               g.T * (s0 + s*t)
+
+    Parameters
+    ----------
+    J : ndarray, shape (m, n)
+        Jacobian matrix, affects the quadratic term.
+    g : ndarray, shape (n,)
+        Gradient, defines the linear term.
+    s : ndarray, shape (n,)
+        Direction vector of a line.
+    diag : None or ndarray with shape (n,), optional
+        Addition diagonal part, affects the quadratic term.
+        If None, assumed to be 0.
+    s0 : None or ndarray with shape (n,), optional
+        Initial point. If None, assumed to be 0.
+
+    Returns
+    -------
+    a : float
+        Coefficient for t**2.
+    b : float
+        Coefficient for t.
+    c : float
+        Free term. Returned only if `s0` is provided.
+    """
+    v = J.dot(s)
+    a = jnp.dot(v, v)
+    if diag is not None:
+        a += jnp.dot(s * diag, s)
+    a *= 0.5
+
+    b = jnp.dot(g, s)
+
+    if s0 is not None:
+        u = J.dot(s0)
+        b += jnp.dot(u, v)
+        c = 0.5 * jnp.dot(u, u) + jnp.dot(g, s0)
+        if diag is not None:
+            b += jnp.dot(s0 * diag, s)
+            c += 0.5 * jnp.dot(s0 * diag, s0)
+        return a, b, c
+    else:
+        return a, b
+
+
+def build_quadratic_1d_hess(H, g, s, diag=None, s0=None):
+    """Parameterize a multivariate quadratic function along a line.
+
+    The resulting univariate quadratic function is given as follows:
+    ::
+        f(t) = 0.5 * (s0 + s*t).T * (H + diag) * (s0 + s*t) +
+               g.T * (s0 + s*t)
+
+    Parameters
+    ----------
+    H : ndarray, shape (n, n)
+        Hessian matrix, affects the quadratic term.
+    g : ndarray, shape (n,)
+        Gradient, defines the linear term.
+    s : ndarray, shape (n,)
+        Direction vector of a line.
+    diag : None or ndarray with shape (n,), optional
+        Addition diagonal part, affects the quadratic term.
+        If None, assumed to be 0.
+    s0 : None or ndarray with shape (n,), optional
+        Initial point. If None, assumed to be 0.
+
+    Returns
+    -------
+    a : float
+        Coefficient for t**2.
+    b : float
+        Coefficient for t.
+    c : float
+        Free term. Returned only if `s0` is provided.
+    """
+    a = H.dot(s).dot(s)
+    if diag is not None:
+        a += jnp.dot(s * diag, s)
+    a *= 0.5
+
+    b = jnp.dot(g, s)
+
+    if s0 is not None:
+        u = H.dot(s0)
+        b += jnp.dot(u, s)
+        c = 0.5 * jnp.dot(u, s0) + jnp.dot(g, s0)
+        if diag is not None:
+            b += jnp.dot(s0 * diag, s)
+            c += 0.5 * jnp.dot(s0 * diag, s0)
+        return a, b, c
+    else:
+        return a, b
+
+
+def minimize_quadratic_1d(a, b, lb, ub, c=0):
+    """Minimize a 1-D quadratic function subject to bounds.
+
+    The free term `c` is 0 by default. Bounds must be finite.
+
+    Returns
+    -------
+    t : float
+        Minimum point.
+    y : float
+        Minimum value.
+    """
+    t = [lb, ub]
+    if a != 0:
+        extremum = -0.5 * b / a
+        if lb < extremum < ub:
+            t.append(extremum)
+    t = jnp.asarray(t)
+    y = t * (a * t + b) + c
+    min_index = jnp.argmin(y)
+    return t[min_index], y[min_index]
+
+
+def intersect_trust_region(x, s, Delta):
+    """Find the intersection of a line with the boundary of a trust region.
+
+    This function solves the quadratic equation with respect to t
+
+    ||(x + s*t)||**2 = Delta**2.
+
+    Returns
+    -------
+    t_neg, t_pos : tuple of float
+        Negative and positive roots.
+
+    Raises
+    ------
+    AssertionError
+        If `s` is zero or `x` is not within the trust region.
+    """
+    a = jnp.dot(s, s)
+    assert a != 0, "`s` is zero."
+
+    b = jnp.dot(x, s)
+
+    c = jnp.dot(x, x) - Delta**2
+    assert c <= 0, f"`x` is not within the trust region, c={c}"
+
+    d = jnp.sqrt(b * b - a * c)  # Root from one fourth of the discriminant.
+
+    q = -(b + jnp.sign(b) * jnp.abs(d))
+    t1 = q / a
+    t2 = c / q
+
+    if t1 < t2:
+        return t1, t2
+    else:
+        return t2, t1

--- a/desc/optimize/fmin_scalar.py
+++ b/desc/optimize/fmin_scalar.py
@@ -377,14 +377,12 @@ def fmintr(  # noqa: C901 - FIXME: simplify this
             if g_norm < gtol:
                 success = True
                 message = STATUS_MESSAGES["gtol"]
-                break
 
             if callback is not None:
                 stop = callback(jnp.copy(x), *args)
                 if stop:
                     success = False
                     message = STATUS_MESSAGES["callback"]
-                    break
 
             if return_all:
                 allx.append(x)

--- a/desc/optimize/fmin_scalar.py
+++ b/desc/optimize/fmin_scalar.py
@@ -311,7 +311,6 @@ def fmintr(  # noqa: C901 - FIXME: simplify this
                 step_h_norm,
                 hits_boundary,
                 max_trust_radius,
-                min_trust_radius,
                 tr_increase_threshold,
                 tr_increase_ratio,
                 tr_decrease_threshold,

--- a/desc/optimize/least_squares.py
+++ b/desc/optimize/least_squares.py
@@ -298,7 +298,6 @@ def lsqtr(  # noqa: C901 - FIXME: simplify this
                 step_h_norm,
                 hits_boundary,
                 max_trust_radius,
-                min_trust_radius,
                 tr_increase_threshold,
                 tr_increase_ratio,
                 tr_decrease_threshold,

--- a/desc/optimize/least_squares.py
+++ b/desc/optimize/least_squares.py
@@ -359,14 +359,12 @@ def lsqtr(  # noqa: C901 - FIXME: simplify this
             if g_norm < gtol:
                 success = True
                 message = STATUS_MESSAGES["gtol"]
-                break
 
             if callback is not None:
                 stop = callback(jnp.copy(x), *args)
                 if stop:
                     success = False
                     message = STATUS_MESSAGES["callback"]
-                    break
 
         else:
             step_norm = 0

--- a/desc/optimize/least_squares.py
+++ b/desc/optimize/least_squares.py
@@ -138,8 +138,6 @@ def lsqtr(  # noqa: C901 - FIXME: simplify this
     xnorm_ord = options.pop("xnorm_ord", 2)
     max_dx = options.pop("max_dx", np.inf)
 
-    ga_fd_step = options.pop("ga_fd_step", 1e-3)
-    ga_tr_ratio = options.pop("ga_tr_ratio", 0)
     return_all = options.pop("return_all", True)
     return_tr = options.pop("return_tr", True)
 
@@ -261,24 +259,6 @@ def lsqtr(  # noqa: C901 - FIXME: simplify this
                 )
 
             step_h_norm = np.linalg.norm(step_h, ord=xnorm_ord)
-
-            # geodesic acceleration
-            if ga_tr_ratio > 0:
-                f0 = f
-                f1 = fun(x + ga_fd_step * step_h * scale, *args)
-                nfev += 1
-                df = (f1 - f0) / ga_fd_step
-                RHS = 2 / ga_fd_step * (df - J.dot(step_h * scale))
-                if tr_method == "svd":
-                    ga_step_h, _, _ = trust_region_step_exact_svd(
-                        RHS, U, s, Vt.T, ga_tr_ratio * step_h_norm, alpha
-                    )
-                elif tr_method == "cho":
-                    RHS = jnp.dot(J_h.T, RHS)
-                    ga_step_h, _, _ = trust_region_step_exact_cho(
-                        RHS, B_h, ga_tr_ratio * step_h_norm, alpha
-                    )
-                step_h += ga_step_h
 
             # calculate the predicted value at the proposed point
             predicted_reduction = -evaluate_quadratic_form_jac(J_h, g_h, step_h)

--- a/desc/optimize/optimizer.py
+++ b/desc/optimize/optimizer.py
@@ -343,10 +343,13 @@ def _get_default_tols(
     stoptol.setdefault("gtol", options.pop("gtol", 1e-8))
     stoptol.setdefault("maxiter", options.pop("maxiter", 100))
 
-    stoptol["max_nfev"] = options.pop("max_nfev", np.inf)
-    stoptol["max_ngev"] = options.pop("max_ngev", np.inf)
-    stoptol["max_njev"] = options.pop("max_njev", np.inf)
-    stoptol["max_nhev"] = options.pop("max_nhev", np.inf)
+    # if we define an "iteration" as a sucessful step, it can take a few function
+    # evaluations per iteration
+    stoptol["max_nfev"] = options.pop("max_nfev", 5 * stoptol["maxiter"] + 1)
+    # pretty much all the methods only evaluate derivatives once per iteration
+    stoptol["max_ngev"] = options.pop("max_ngev", stoptol["maxiter"] + 1)
+    stoptol["max_njev"] = options.pop("max_njev", stoptol["maxiter"] + 1)
+    stoptol["max_nhev"] = options.pop("max_nhev", stoptol["maxiter"] + 1)
 
     return stoptol
 

--- a/desc/optimize/stochastic.py
+++ b/desc/optimize/stochastic.py
@@ -1,7 +1,8 @@
 """Function for minimizing a scalar function of multiple variables."""
 
-import numpy as np
 from scipy.optimize import OptimizeResult
+
+from desc.backend import jnp
 
 from .utils import (
     STATUS_MESSAGES,
@@ -94,7 +95,7 @@ def sgd(
 
     N = x0.size
     x = x0.copy()
-    v = np.zeros_like(x)
+    v = jnp.zeros_like(x)
     f = fun(x, *args)
     nfev += 1
     g = grad(x, *args)
@@ -102,10 +103,10 @@ def sgd(
 
     if maxiter is None:
         maxiter = N * 1000
-    gnorm_ord = options.pop("gnorm_ord", np.inf)
+    gnorm_ord = options.pop("gnorm_ord", jnp.inf)
     xnorm_ord = options.pop("xnorm_ord", 2)
-    g_norm = np.linalg.norm(g, ord=gnorm_ord)
-    x_norm = np.linalg.norm(x, ord=xnorm_ord)
+    g_norm = jnp.linalg.norm(g, ord=gnorm_ord)
+    x_norm = jnp.linalg.norm(x, ord=xnorm_ord)
     return_all = options.pop("return_all", True)
     alpha = options.pop("alpha", 1e-2 * x_norm / g_norm)
     beta = options.pop("beta", 0.9)
@@ -113,8 +114,8 @@ def sgd(
 
     success = None
     message = None
-    step_norm = np.inf
-    df_norm = np.inf
+    step_norm = jnp.inf
+    df_norm = jnp.inf
 
     if verbose > 1:
         print_header_nonlinear()
@@ -136,11 +137,11 @@ def sgd(
             iteration,
             maxiter,
             nfev,
-            np.inf,
+            jnp.inf,
             0,
-            np.inf,
+            jnp.inf,
             0,
-            np.inf,
+            jnp.inf,
         )
         if success is not None:
             break
@@ -149,8 +150,8 @@ def sgd(
         x = x - alpha * v
         g = grad(x, *args)
         ngev += 1
-        step_norm = np.linalg.norm(alpha * v, ord=xnorm_ord)
-        g_norm = np.linalg.norm(g, ord=gnorm_ord)
+        step_norm = jnp.linalg.norm(alpha * v, ord=xnorm_ord)
+        g_norm = jnp.linalg.norm(g, ord=gnorm_ord)
         fnew = fun(x, *args)
         nfev += 1
         df = f - fnew
@@ -162,7 +163,7 @@ def sgd(
             print_iteration_nonlinear(iteration, nfev, f, df, step_norm, g_norm)
 
         if callback is not None:
-            stop = callback(np.copy(x), *args)
+            stop = callback(jnp.copy(x), *args)
             if stop:
                 success = False
                 message = STATUS_MESSAGES["callback"]

--- a/desc/optimize/tr_subproblems.py
+++ b/desc/optimize/tr_subproblems.py
@@ -330,7 +330,6 @@ def update_tr_radius(
     step_norm,
     bound_hit,
     max_tr=np.inf,
-    min_tr=0,
     increase_threshold=0.75,
     increase_ratio=2,
     decrease_threshold=0.25,
@@ -352,8 +351,6 @@ def update_tr_radius(
         whether the current step hits the trust region bound
     max_tr : float
         maximum allowed trust region radius
-    min_tr : float
-        minimum allowed trust region radius
     increase_threshold, increase_ratio : float
         if ratio > inrease_threshold, trust radius is increased by a factor
         of increase_ratio
@@ -380,7 +377,7 @@ def update_tr_radius(
     elif reduction_ratio > increase_threshold:
         trust_radius = max(step_norm * increase_ratio, trust_radius)
 
-    trust_radius = np.clip(trust_radius, min_tr, max_tr)
+    trust_radius = np.clip(trust_radius, 0, max_tr)
 
     return trust_radius, reduction_ratio
 

--- a/desc/optimize/utils.py
+++ b/desc/optimize/utils.py
@@ -119,34 +119,34 @@ def chol(A):
     return L
 
 
-def evaluate_quadratic_form_hess(x, f, g, H, scale=None):
+def evaluate_quadratic_form_hess(H, g, x, diag=None):
     """Compute values of a quadratic function arising in trust region subproblem.
 
-    The function is 0.5 * x.T * H * x + g.T * x + f.
+    The function is 0.5 * x.T * (H + diag) * x + g.T * x.
 
     Parameters
     ----------
-    x : ndarray, shape(n,)
-        position where to evaluate quadratic form
-    f : float
-        constant term
-    g : ndarray, shape(n,)
-        Gradient, defines the linear term.
     H : ndarray
         Hessian matrix
-    scale : ndarray, shape(n,)
-        scaling to apply. Scales hess -> scale*hess*scale, g-> scale*g
+    g : ndarray, shape(n,)
+        Gradient, defines the linear term.
+    x : ndarray, shape(n,)
+        position where to evaluate quadratic form
+    diag : ndarray, shape (n,), optional
+        Addition diagonal part, affects the quadratic term.
+        If None, assumed to be 0.
 
     Returns
     -------
     values : float
         Value of the function.
     """
-    scale = scale if scale is not None else 1
-    q = (x * scale) @ H @ (x * scale)
-    l = jnp.dot(scale * g, x)
+    q = x @ H @ x
+    if diag is not None:
+        q += jnp.sum(diag * x**2, axis=-1)
+    l = jnp.dot(g, x)
 
-    return f + l + 1 / 2 * q
+    return l + 1 / 2 * q
 
 
 def evaluate_quadratic_form_jac(J, g, s, diag=None):
@@ -181,7 +181,7 @@ def evaluate_quadratic_form_jac(J, g, s, diag=None):
         Js = J.dot(s.T)
         q = jnp.sum(Js**2, axis=0)
         if diag is not None:
-            q += jnp.sum(diag * s**2, axis=1)
+            q += jnp.sum(diag * s**2, axis=-1)
 
     l = jnp.dot(s, g)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -400,7 +400,7 @@ def test_ESTELL_results(tmpdir_factory):
     )
     eqf = load(output_dir.join("ESTELL.h5"))
     rho_err, theta_err = area_difference_desc(eq0, eqf[-1])
-    np.testing.assert_allclose(rho_err[:, 3:], 0, atol=5e-2)
+    np.testing.assert_allclose(rho_err[:, 4:], 0, atol=5e-2)
     np.testing.assert_allclose(theta_err, 0, atol=1e-4)
 
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -538,6 +538,7 @@ def test_all_optimizers():
         )
 
 
+@pytest.mark.unit
 def test_bounded_optimization():
     """Test that our bounded optimizers are as good as scipy."""
     p = np.array([1.0, 2.0, 3.0, 4.0, 1.0, 2.0])

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -118,6 +118,25 @@ class TestFmin:
         )
         np.testing.assert_allclose(out["x"], SCALAR_FUN_SOLN, atol=1e-8)
 
+    @pytest.mark.unit
+    def test_convex_full_hess_exact(self):
+        """Test minimizing rosenbrock function using exact method with full hess."""
+        x0 = np.ones(2)
+
+        out = fmintr(
+            scalar_fun,
+            x0,
+            scalar_grad,
+            scalar_hess,
+            verbose=1,
+            method="exact",
+            x_scale="hess",
+            ftol=0,
+            xtol=0,
+            gtol=1e-12,
+        )
+        np.testing.assert_allclose(out["x"], SCALAR_FUN_SOLN, atol=1e-8)
+
     @pytest.mark.slow
     @pytest.mark.unit
     def test_rosenbrock_bfgs_dogleg(self):
@@ -155,6 +174,28 @@ class TestFmin:
             hess=BFGS(),
             verbose=1,
             method="subspace",
+            x_scale=1,
+            ftol=1e-8,
+            xtol=1e-8,
+            gtol=1e-8,
+        )
+        np.testing.assert_allclose(out["x"], true_x)
+
+    @pytest.mark.slow
+    @pytest.mark.unit
+    def test_rosenbrock_bfgs_exact(self):
+        """Test minimizing rosenbrock function using exact method with BFGS hess."""
+        rando = default_rng(seed=4)
+
+        x0 = rando.random(7)
+        true_x = np.ones(7)
+        out = fmintr(
+            rosen,
+            x0,
+            rosen_der,
+            hess=BFGS(),
+            verbose=1,
+            method="exact",
             x_scale=1,
             ftol=1e-8,
             xtol=1e-8,

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -96,7 +96,6 @@ class TestFmin:
             ftol=0,
             xtol=0,
             gtol=1e-12,
-            options={"ga_accept_threshold": 0},
         )
         np.testing.assert_allclose(out["x"], SCALAR_FUN_SOLN, atol=1e-8)
 
@@ -116,7 +115,6 @@ class TestFmin:
             ftol=0,
             xtol=0,
             gtol=1e-12,
-            options={"ga_accept_threshold": 1},
         )
         np.testing.assert_allclose(out["x"], SCALAR_FUN_SOLN, atol=1e-8)
 
@@ -139,7 +137,6 @@ class TestFmin:
             ftol=1e-8,
             xtol=1e-8,
             gtol=1e-8,
-            options={"ga_accept_threshold": 0},
         )
         np.testing.assert_allclose(out["x"], true_x)
 
@@ -162,7 +159,6 @@ class TestFmin:
             ftol=1e-8,
             xtol=1e-8,
             gtol=1e-8,
-            options={"ga_accept_threshold": 0},
         )
         np.testing.assert_allclose(out["x"], true_x)
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -109,7 +109,7 @@ class TestFmin:
             x0,
             scalar_grad,
             scalar_hess,
-            verbose=1,
+            verbose=3,
             method="subspace",
             x_scale="hess",
             ftol=0,
@@ -128,7 +128,7 @@ class TestFmin:
             x0,
             scalar_grad,
             scalar_hess,
-            verbose=1,
+            verbose=3,
             method="exact",
             x_scale="hess",
             ftol=0,
@@ -150,7 +150,7 @@ class TestFmin:
             x0,
             rosen_der,
             hess="bfgs",
-            verbose=1,
+            verbose=3,
             method="dogleg",
             x_scale=1,
             ftol=1e-8,
@@ -172,7 +172,7 @@ class TestFmin:
             x0,
             rosen_der,
             hess=BFGS(),
-            verbose=1,
+            verbose=3,
             method="subspace",
             x_scale=1,
             ftol=1e-8,
@@ -194,7 +194,7 @@ class TestFmin:
             x0,
             rosen_der,
             hess=BFGS(),
-            verbose=1,
+            verbose=3,
             method="exact",
             x_scale=1,
             ftol=1e-8,
@@ -250,7 +250,7 @@ class TestLSQTR:
             res,
             p0,
             jac,
-            verbose=0,
+            verbose=3,
             x_scale=1,
             tr_method="cho",
             options={"initial_trust_radius": 0.15, "max_trust_radius": 0.25},
@@ -261,7 +261,7 @@ class TestLSQTR:
             res,
             p0,
             jac,
-            verbose=0,
+            verbose=3,
             x_scale=1,
             tr_method="svd",
             options={"initial_trust_radius": 0.15, "max_trust_radius": 0.25},
@@ -410,14 +410,14 @@ def test_maxiter_1_and_0_solve():
     eq = desc.examples.get("SOLOVEV")
     for opt in ["lsq-exact", "dogleg-bfgs"]:
         eq, result = eq.solve(
-            maxiter=1, constraints=constraints, objective=obj, optimizer=opt
+            maxiter=1, constraints=constraints, objective=obj, optimizer=opt, verbose=3
         )
-        assert result["nfev"] <= 2
+        assert result["nit"] == 1
     for opt in ["lsq-exact", "dogleg-bfgs"]:
         eq, result = eq.solve(
-            maxiter=0, constraints=constraints, objective=obj, optimizer=opt
+            maxiter=0, constraints=constraints, objective=obj, optimizer=opt, verbose=3
         )
-        assert result["nfev"] <= 1
+        assert result["nit"] == 0
 
 
 @pytest.mark.unit
@@ -438,6 +438,7 @@ def test_scipy_fail_message():
     for opt in ["scipy-trf"]:
         eq, result = eq.solve(
             maxiter=3,
+            verbose=3,
             constraints=constraints,
             objective=obj,
             optimizer=opt,
@@ -451,6 +452,7 @@ def test_scipy_fail_message():
     for opt in ["scipy-trust-exact"]:
         eq, result = eq.solve(
             maxiter=3,
+            verbose=3,
             constraints=constraints,
             objective=obj,
             optimizer=opt,
@@ -531,7 +533,9 @@ def test_all_optimizers():
             obj = eobj
         else:
             obj = fobj
-        eq.solve(objective=obj, constraints=constraints, optimizer=opt, maxiter=5)
+        eq.solve(
+            objective=obj, constraints=constraints, optimizer=opt, maxiter=5, verbose=3
+        )
 
 
 def test_bounded_optimization():


### PR DESCRIPTION
- Adds ability for `lsqtr` and `fmintr` to handle simple bounds on the variables.
- Implementation mostly copied from `scipy` with a few minor modifications.
- Currently unused, but will be needed to handle general nonlinear inequality constraints with augmented lagrangian methods.