### PR TITLE
move warning for helicity into the if statement to avoid being warned…

### DIFF
--- a/desc/objectives/_qs.py
+++ b/desc/objectives/_qs.py
@@ -200,6 +200,7 @@ class QuasisymmetryBoozer(_Objective):
         )
         if hasattr(self, "_helicity") and self._helicity != helicity:
             self._built = False
+            warnings.warn("Re-build objective after changing the helicity!")
         self._helicity = helicity
         if hasattr(self, "_print_value_fmt"):
             units = "(T)"
@@ -210,7 +211,6 @@ class QuasisymmetryBoozer(_Objective):
                 + "{:10.3e} "
                 + units
             )
-        warnings.warn("Re-build objective after changing the helicity!")
 
 
 class QuasisymmetryTwoTerm(_Objective):


### PR DESCRIPTION
… everytime QuasisymmetryBoozer object is instantiated

currently, the warning is thrown even if the helicity is being set during the init of the object, but we only need to throw the warning if the object had a helicity already and we are changing it to a different value.