### PR TITLE
Ensure derivatives of basis are zero for unused coordinates

### DIFF
--- a/desc/basis.py
+++ b/desc/basis.py
@@ -273,6 +273,8 @@ class PowerSeries(Basis):
         """
         if modes is None:
             modes = self.modes
+        if (derivatives[1] != 0) or (derivatives[2] != 0):
+            return jnp.zeros((nodes.shape[0], modes.shape[0]))
         if not len(modes):
             return np.array([]).reshape((len(nodes), 0))
 
@@ -385,6 +387,8 @@ class FourierSeries(Basis):
         """
         if modes is None:
             modes = self.modes
+        if (derivatives[0] != 0) or (derivatives[1] != 0):
+            return jnp.zeros((nodes.shape[0], modes.shape[0]))
         if not len(modes):
             return np.array([]).reshape((len(nodes), 0))
 
@@ -509,6 +513,8 @@ class DoubleFourierSeries(Basis):
         """
         if modes is None:
             modes = self.modes
+        if derivatives[0] != 0:
+            return jnp.zeros((nodes.shape[0], modes.shape[0]))
         if not len(modes):
             return np.array([]).reshape((len(nodes), 0))
 
@@ -713,6 +719,8 @@ class ZernikePolynomial(Basis):
         """
         if modes is None:
             modes = self.modes
+        if derivatives[2] != 0:
+            return jnp.zeros((nodes.shape[0], modes.shape[0]))
         if not len(modes):
             return np.array([]).reshape((len(nodes), 0))
 

--- a/desc/profiles.py
+++ b/desc/profiles.py
@@ -729,6 +729,8 @@ class PowerSeriesProfile(Profile):
         if params is None:
             params = self.params
         transform = self._get_transform(grid)
+        if (dt != 0) or (dz != 0):
+            return jnp.zeros(transform.grid.num_nodes)
         return transform.transform(params, dr=dr, dt=dt, dz=dz)
 
     @classmethod

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -279,3 +279,28 @@ class TestBasis:
         basis = FourierZernikeBasis(L=10, M=4, N=0, spectral_indexing="fringe")
         assert (basis.modes == [10, 0, 0]).all(axis=1).any()
         assert not (basis.modes == [10, 2, 0]).all(axis=1).any()
+
+    @pytest.mark.unit
+    def test_derivative_not_in_basis_zeros(self):
+        """Test that d/dx = 0 when x is not in the basis."""
+        nodes = np.random.random((10, 3))
+
+        basis = PowerSeries(L=3)
+        ft = basis.evaluate(nodes, derivatives=[0, 1, 0])
+        fz = basis.evaluate(nodes, derivatives=[0, 0, 1])
+        assert np.all(ft == 0)
+        assert np.all(fz == 0)
+
+        basis = FourierSeries(N=4)
+        fr = basis.evaluate(nodes, derivatives=[1, 0, 0])
+        ft = basis.evaluate(nodes, derivatives=[0, 1, 0])
+        assert np.all(fr == 0)
+        assert np.all(ft == 0)
+
+        basis = DoubleFourierSeries(M=2, N=4)
+        fr = basis.evaluate(nodes, derivatives=[1, 0, 0])
+        assert np.all(fr == 0)
+
+        basis = ZernikePolynomial(L=2, M=3)
+        fz = basis.evaluate(nodes, derivatives=[0, 0, 1])
+        assert np.all(fz == 0)


### PR DESCRIPTION
Currently taking derivatives of a basis wrt coordinates not in the basis basically ignores the derivative argument and returns the wrong value.

eg
```
d/dr FourierSeries(z) == FourierSeries(z)
d/dz PowerSeries(r) == PowerSeries(r)
etc
```

Which seems wrong, and could cause some issues.

This PR fixes this by always returning 0 if taking a derivative wrt to an ignored coordinate.