### PR TITLE
Add "looped" option for computing jacobian matrix

### DIFF
--- a/desc/derivatives.py
+++ b/desc/derivatives.py
@@ -150,7 +150,7 @@ class AutoDiffDerivative(_Derivative):
         return self._compute(*args)
 
     @classmethod
-    def compute_jvp(cls, fun, argnum, v, *args):
+    def compute_jvp(cls, fun, argnum, v, *args, **kwargs):
         """Compute df/dx*v.
 
         Parameters
@@ -162,7 +162,9 @@ class AutoDiffDerivative(_Derivative):
         v : array-like or tuple of array-like
             tangent vectors. Should be one for each argnum
         args : tuple
-            arguments passed to f
+            arguments passed to fun
+        kwargs : dict
+            keyword arguments passed to fun
 
         Returns
         -------
@@ -170,20 +172,21 @@ class AutoDiffDerivative(_Derivative):
             Jacobian times vectors v, summed over different argnums
 
         """
-        tangents = list(nested_zeros_like(args))
-        if jnp.isscalar(argnum):
-            argnum = (argnum,)
-        else:
-            argnum = tuple(argnum)
+        _ = kwargs.pop("rel_step", None)  # unused by autodiff
+        argnum = (argnum,) if jnp.isscalar(argnum) else tuple(argnum)
         v = (v,) if not isinstance(v, tuple) else v
 
-        for i, vi in enumerate(v):
-            tangents[argnum[i]] = vi
-        y, u = jax.jvp(fun, args, tuple(tangents))
+        def _fun(*x):
+            _args = list(args)
+            for i, xi in zip(argnum, x):
+                _args[i] = xi
+            return fun(*_args, **kwargs)
+
+        y, u = jax.jvp(_fun, tuple(args[i] for i in argnum), v)
         return u
 
     @classmethod
-    def compute_jvp2(cls, fun, argnum1, argnum2, v1, v2, *args):
+    def compute_jvp2(cls, fun, argnum1, argnum2, v1, v2, *args, **kwargs):
         """Compute d^2f/dx^2*v1*v2.
 
         Parameters
@@ -196,7 +199,9 @@ class AutoDiffDerivative(_Derivative):
         v1,v2 : array-like or tuple of array-like
             tangent vectors. Should be one for each argnum
         args : tuple
-            arguments passed to f
+            arguments passed to fun
+        kwargs : dict
+            keyword arguments passed to fun
 
         Returns
         -------
@@ -217,12 +222,14 @@ class AutoDiffDerivative(_Derivative):
             argnum2 = tuple([i + 1 for i in argnum2])
             v2 = tuple(v2)
 
-        dfdx = lambda dx1, *args: cls.compute_jvp(fun, argnum1, dx1, *args)
-        d2fdx2 = lambda dx1, dx2: cls.compute_jvp(dfdx, argnum2, dx2, dx1, *args)
+        dfdx = lambda dx1, *args: cls.compute_jvp(fun, argnum1, dx1, *args, **kwargs)
+        d2fdx2 = lambda dx1, dx2: cls.compute_jvp(
+            dfdx, argnum2, dx2, dx1, *args, **kwargs
+        )
         return d2fdx2(v1, v2)
 
     @classmethod
-    def compute_jvp3(cls, fun, argnum1, argnum2, argnum3, v1, v2, v3, *args):
+    def compute_jvp3(cls, fun, argnum1, argnum2, argnum3, v1, v2, v3, *args, **kwargs):
         """Compute d^3f/dx^3*v1*v2*v3.
 
         Parameters
@@ -235,7 +242,9 @@ class AutoDiffDerivative(_Derivative):
         v1,v2,v3 : array-like or tuple of array-like
             tangent vectors. Should be one for each argnum
         args : tuple
-            arguments passed to f
+            arguments passed to fun
+        kwargs : dict
+            keyword arguments passed to fun
 
         Returns
         -------
@@ -263,17 +272,19 @@ class AutoDiffDerivative(_Derivative):
             argnum3 = tuple([i + 2 for i in argnum3])
             v3 = tuple(v3)
 
-        dfdx = lambda dx1, *args: cls.compute_jvp(fun, argnum1, dx1, *args)
-        d2fdx2 = lambda dx1, dx2, *args: cls.compute_jvp(dfdx, argnum2, dx2, dx1, *args)
+        dfdx = lambda dx1, *args: cls.compute_jvp(fun, argnum1, dx1, *args, **kwargs)
+        d2fdx2 = lambda dx1, dx2, *args: cls.compute_jvp(
+            dfdx, argnum2, dx2, dx1, *args, **kwargs
+        )
         d3fdx3 = lambda dx1, dx2, dx3: cls.compute_jvp(
-            d2fdx2, argnum3, dx3, dx2, dx1, *args
+            d2fdx2, argnum3, dx3, dx2, dx1, *args, **kwargs
         )
         return d3fdx3(v1, v2, v3)
 
-    def _compute_jvp(self, v, *args):
-        return self.compute_jvp(self._fun, self.argnum, v, *args)
+    def _compute_jvp(self, v, *args, **kwargs):
+        return self.compute_jvp(self._fun, self.argnum, v, *args, **kwargs)
 
-    def _jac_looped(self, *args):
+    def _jac_looped(self, *args, **kwargs):
 
         n = args[self._argnum].size
         shp = jax.eval_shape(self._fun, *args).shape
@@ -282,7 +293,7 @@ class AutoDiffDerivative(_Derivative):
 
         def body(i, J):
             tangents = I[i]
-            Ji = self._compute_jvp(tangents, *args)
+            Ji = self._compute_jvp(tangents, *args, **kwargs)
             J = put(J, i, Ji.T)
             return J
 
@@ -343,9 +354,11 @@ class FiniteDiffDerivative(_Derivative):
 
         Parameters
         ----------
-        *args : list
+        args : tuple
             Arguments of the objective function where the derivative is to be
             evaluated at.
+        kwargs : dict
+            keyword arguments passed to fun
 
         Returns
         -------
@@ -386,9 +399,12 @@ class FiniteDiffDerivative(_Derivative):
 
         Parameters
         ----------
-        *args : list
+        args : tuple
             Arguments of the objective function where the derivative is to be
             evaluated at.
+        kwargs : dict
+            keyword arguments passed to fun
+
 
         Returns
         -------
@@ -435,7 +451,9 @@ class FiniteDiffDerivative(_Derivative):
         v : array-like or tuple of array-like
             tangent vectors. Should be one for each argnum
         args : tuple
-            arguments passed to f
+            arguments passed to fun
+        kwargs : dict
+            keyword arguments passed to fun
 
         Returns
         -------
@@ -443,7 +461,7 @@ class FiniteDiffDerivative(_Derivative):
             Jacobian times vectors v, summed over different argnums
 
         """
-        rel_step = kwargs.get("rel_step", 1e-3)
+        rel_step = kwargs.pop("rel_step", 1e-3)
 
         if np.isscalar(argnum):
             nargs = 1
@@ -454,14 +472,16 @@ class FiniteDiffDerivative(_Derivative):
 
         f = np.array(
             [
-                cls._compute_jvp_1arg(fun, argnum[i], v[i], *args, rel_step=rel_step)
+                cls._compute_jvp_1arg(
+                    fun, argnum[i], v[i], *args, rel_step=rel_step, **kwargs
+                )
                 for i in range(nargs)
             ]
         )
         return np.sum(f, axis=0)
 
     @classmethod
-    def compute_jvp2(cls, fun, argnum1, argnum2, v1, v2, *args):
+    def compute_jvp2(cls, fun, argnum1, argnum2, v1, v2, *args, **kwargs):
         """Compute d^2f/dx^2*v1*v2.
 
         Parameters
@@ -474,7 +494,9 @@ class FiniteDiffDerivative(_Derivative):
         v1,v2 : array-like or tuple of array-like
             tangent vectors. Should be one for each argnum
         args : tuple
-            arguments passed to f
+            arguments passed to fun
+        kwargs : dict
+            keyword arguments passed to fun
 
         Returns
         -------
@@ -495,12 +517,14 @@ class FiniteDiffDerivative(_Derivative):
             argnum2 = tuple([i + 1 for i in argnum2])
             v2 = tuple(v2)
 
-        dfdx = lambda dx1, *args: cls.compute_jvp(fun, argnum1, dx1, *args)
-        d2fdx2 = lambda dx1, dx2: cls.compute_jvp(dfdx, argnum2, dx2, dx1, *args)
+        dfdx = lambda dx1, *args: cls.compute_jvp(fun, argnum1, dx1, *args, **kwargs)
+        d2fdx2 = lambda dx1, dx2: cls.compute_jvp(
+            dfdx, argnum2, dx2, dx1, *args, **kwargs
+        )
         return d2fdx2(v1, v2)
 
     @classmethod
-    def compute_jvp3(cls, fun, argnum1, argnum2, argnum3, v1, v2, v3, *args):
+    def compute_jvp3(cls, fun, argnum1, argnum2, argnum3, v1, v2, v3, *args, **kwargs):
         """Compute d^3f/dx^3*v1*v2*v3.
 
         Parameters
@@ -513,7 +537,9 @@ class FiniteDiffDerivative(_Derivative):
         v1,v2,v3 : array-like or tuple of array-like
             tangent vectors. Should be one for each argnum
         args : tuple
-            arguments passed to f
+            arguments passed to fun
+        kwargs : dict
+            keyword arguments passed to fun
 
         Returns
         -------
@@ -541,22 +567,24 @@ class FiniteDiffDerivative(_Derivative):
             argnum3 = tuple([i + 2 for i in argnum3])
             v3 = tuple(v3)
 
-        dfdx = lambda dx1, *args: cls.compute_jvp(fun, argnum1, dx1, *args)
-        d2fdx2 = lambda dx1, dx2, *args: cls.compute_jvp(dfdx, argnum2, dx2, dx1, *args)
+        dfdx = lambda dx1, *args: cls.compute_jvp(fun, argnum1, dx1, *args, **kwargs)
+        d2fdx2 = lambda dx1, dx2, *args: cls.compute_jvp(
+            dfdx, argnum2, dx2, dx1, *args, **kwargs
+        )
         d3fdx3 = lambda dx1, dx2, dx3: cls.compute_jvp(
-            d2fdx2, argnum3, dx3, dx2, dx1, *args
+            d2fdx2, argnum3, dx3, dx2, dx1, *args, **kwargs
         )
         return d3fdx3(v1, v2, v3)
 
-    def _compute_jvp(self, v, *args):
+    def _compute_jvp(self, v, *args, **kwargs):
         return self.compute_jvp(
-            self._fun, self._argnum, v, *args, rel_step=self.rel_step
+            self._fun, self._argnum, v, *args, rel_step=self.rel_step, **kwargs
         )
 
     @classmethod
     def _compute_jvp_1arg(cls, fun, argnum, v, *args, **kwargs):
         """Compute a jvp wrt a single argument."""
-        rel_step = kwargs.get("rel_step", 1e-3)
+        rel_step = kwargs.pop("rel_step", 1e-3)
         normv = np.linalg.norm(v)
         if normv != 0:
             vh = v / normv
@@ -566,7 +594,7 @@ class FiniteDiffDerivative(_Derivative):
 
         def f(x):
             tempargs = args[0:argnum] + (x,) + args[argnum + 1 :]
-            return fun(*tempargs)
+            return fun(*tempargs, **kwargs)
 
         h = rel_step
         df = (f(x + h * vh) - f(x - h * vh)) / (2 * h)

--- a/desc/derivatives.py
+++ b/desc/derivatives.py
@@ -640,21 +640,6 @@ class FiniteDiffDerivative(_Derivative):
         return self._compute(*args)
 
 
-def nested_zeros_like(x):
-    """Get a nested pytree of zeros like a given pytree."""
-    if x is None:
-        return None
-    if jnp.isscalar(x) and isinstance(x, int):
-        return 0
-    if jnp.isscalar(x):
-        return 0.0
-    if isinstance(x, tuple):
-        return tuple([nested_zeros_like(a) for a in x])
-    if isinstance(x, list):
-        return list([nested_zeros_like(a) for a in x])
-    return jnp.zeros_like(x)
-
-
 if use_jax:
     Derivative = AutoDiffDerivative
 else:

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -45,7 +45,7 @@ class ObjectiveFunction(IOAble):
             isinstance(obj, _Objective) for obj in objectives
         ), "members of ObjectiveFunction should be instances of _Objective"
         assert use_jit in {True, False}
-        assert deriv_mode in {"batched", "blocked"}
+        assert deriv_mode in {"batched", "blocked", "looped"}
 
         self._objectives = objectives
         self._use_jit = use_jit
@@ -137,11 +137,15 @@ class ObjectiveFunction(IOAble):
             self._hess = lambda x: block_diag(
                 *[self._derivatives["hess"][arg](x) for arg in self.args]
             )
-        if self._deriv_mode == "batched":
+        if self._deriv_mode in {"batched", "looped"}:
             self._grad = Derivative(self.compute_scalar, mode="grad")
             self._hess = Derivative(self.compute_scalar, mode="hess")
+        if self._deriv_mode == "batched":
             self._jac_scaled = Derivative(self.compute_scaled, mode="fwd")
             self._jac_unscaled = Derivative(self.compute_unscaled, mode="fwd")
+        if self._deriv_mode == "looped":
+            self._jac_scaled = Derivative(self.compute_scaled, mode="looped")
+            self._jac_unscaled = Derivative(self.compute_unscaled, mode="looped")
 
     def jit(self):  # noqa: C901
         """Apply JIT to compute methods, or re-apply after updating self."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ jax[cpu] >= 0.3.2, <= 0.4.11
 matplotlib >= 3.3.0, <= 3.6.0, != 3.4.3
 mpmath >= 1.0.0
 netcdf4 >= 1.5.4
-numpy >= 1.20.0
+numpy >= 1.20.0, < 1.25.0
 nvgpu
 psutil
 scipy >= 1.5.0

--- a/requirements_conda.yml
+++ b/requirements_conda.yml
@@ -6,7 +6,7 @@ dependencies:
   - matplotlib >= 3.3.0, <= 3.6.0, != 3.4.3
   - mpmath >= 1.0.0
   - netcdf4 >= 1.5.4
-  - numpy >= 1.20.0
+  - numpy >= 1.20.0, < 1.25.0
   - psutil
   - scipy >= 1.5.0
   - termcolor

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -121,6 +121,25 @@ class TestDerivative:
         jac = AutoDiffDerivative(fun, num_blocks=3, shape=A.shape)
         np.testing.assert_allclose(jac(x), A)
 
+    @pytest.mark.unit
+    def test_jac_looped(self):
+        """Test computing the jacobian by explicit looping jvp."""
+
+        def test_fun(x, y, a):
+            return jnp.cos(x) + x * y + a
+
+        x = np.array([1, 5, 0.01, 200])
+        y = np.array([60, 1, 100, 0.02])
+        a = -2.0
+
+        jac1 = AutoDiffDerivative(test_fun, argnum=0, mode="fwd")
+        J1 = jac1.compute(x, y, a)
+
+        jac2 = AutoDiffDerivative(test_fun, argnum=0, mode="looped")
+        J2 = jac2.compute(x, y, a)
+
+        np.testing.assert_allclose(J1, J2, atol=1e-8)
+
 
 class TestJVP:
     """Test calculation of jacobian vector products."""

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -306,26 +306,38 @@ class TestObjectiveFunction:
 
 @pytest.mark.unit
 def test_derivative_modes():
-    """Test equality of derivatives using batched and blocked methods."""
+    """Test equality of derivatives using batched, blocked, looped methods."""
     eq = Equilibrium(M=2, N=1, L=2)
     obj1 = ObjectiveFunction(MagneticWell(), deriv_mode="batched", use_jit=False)
     obj2 = ObjectiveFunction(MagneticWell(), deriv_mode="blocked", use_jit=False)
+    obj3 = ObjectiveFunction(MagneticWell(), deriv_mode="looped", use_jit=False)
 
     obj1.build(eq)
     obj2.build(eq)
+    obj3.build(eq)
     x = obj1.x(eq)
     g1 = obj1.grad(x)
     g2 = obj2.grad(x)
+    g3 = obj3.grad(x)
     np.testing.assert_allclose(g1, g2, atol=1e-10)
+    np.testing.assert_allclose(g1, g3, atol=1e-10)
     J1 = obj1.jac_scaled(x)
     J2 = obj2.jac_scaled(x)
+    J3 = obj3.jac_scaled(x)
     np.testing.assert_allclose(J1, J2, atol=1e-10)
+    np.testing.assert_allclose(J1, J3, atol=1e-10)
     J1 = obj1.jac_unscaled(x)
     J2 = obj2.jac_unscaled(x)
+    J3 = obj3.jac_unscaled(x)
     np.testing.assert_allclose(J1, J2, atol=1e-10)
+    np.testing.assert_allclose(J1, J3, atol=1e-10)
     H1 = obj1.hess(x)
     H2 = obj2.hess(x)
+    H3 = obj3.hess(x)
+    # blocked hessian is only block diagonal, so we only check the diag part
     np.testing.assert_allclose(np.diag(H1), np.diag(H2), atol=1e-10)
+    # looped and batched should be full matrices
+    np.testing.assert_allclose(H1, H3, atol=1e-10)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
The standard way jax computes the jacobian matrix is with ``vmap(jvp(fun))``, which attempts to vectorize the jacobian vector product to compute the entire jacobian at once. This is usually the fastest way, but because it has to materialize all the intermediate matrices in memory at the same time, it limits the resolution we can use.

Another option is to instead manually loop over the columns of the jacobian and build it one at a time. This is a bit slower, but much more memory efficient.

Some profiling results:

[looped](https://gist.github.com/f0uriest/9f5f915bede37d3f68868b29979e8bd2)
[master](https://gist.github.com/f0uriest/c3d7c15642bae9e563048c4beb0b9787)

On master, on an A100, we max out around L=M=N=14, with the nodes oversampled by 2 in each direction (probably overkill)

With the looped jacobian for the same specs, we max out around L=M=N=20.

Overall speed is a bit slower with the looped jacobian: 
![image](https://github.com/PlasmaControl/DESC/assets/22567458/1c9f83ad-fcce-4d3c-82e0-1d3fd3d201f2)

But still a very useful option when we need higher resolution.