### PR TITLE
Change default lagrange multipliers in augmented lagrangian

### DIFF
--- a/desc/optimize/aug_lagrangian.py
+++ b/desc/optimize/aug_lagrangian.py
@@ -164,8 +164,8 @@ def fmin_auglag(  # noqa: C901 - FIXME: simplify this
     nfev += 1
 
     mu = options.pop("initial_penalty_parameter", 10)
-    y = options.pop("initial_multipliers", None)
-    if y is None:  # use least squares multiplier estimates
+    y = options.pop("initial_multipliers", jnp.zeros_like(c))
+    if y == "least_squares":  # use least squares multiplier estimates
         _J = constraint_wrapped.jac(z, *args)
         _g = grad_wrapped(z, *args)
         y = jnp.linalg.lstsq(_J.T, _g)[0]

--- a/desc/optimize/aug_lagrangian_ls.py
+++ b/desc/optimize/aug_lagrangian_ls.py
@@ -153,8 +153,8 @@ def lsq_auglag(  # noqa: C901 - FIXME: simplify this
     nfev += 1
 
     mu = options.pop("initial_penalty_parameter", 10)
-    y = options.pop("initial_multipliers", None)
-    if y is None:  # use least squares multiplier estimates
+    y = options.pop("initial_multipliers", jnp.zeros_like(c))
+    if y == "least_squares":  # use least squares multiplier estimates
         _J = constraint_wrapped.jac(z, *args)
         _g = f @ jac_wrapped(z, *args)
         y = jnp.linalg.lstsq(_J.T, _g)[0]

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -797,7 +797,7 @@ def test_auglag():
         ctol=1e-6,
         verbose=3,
         maxiter=None,
-        options={},
+        options={"initial_multipliers": "least_squares"},
     )
     print(out1["active_mask"])
     out2 = lsq_auglag(
@@ -814,7 +814,7 @@ def test_auglag():
         ctol=1e-6,
         verbose=3,
         maxiter=None,
-        options={},
+        options={"initial_multipliers": "least_squares"},
     )
 
     out3 = minimize(


### PR DESCRIPTION
We previously defaulted to using the "least squares" estimates for the multipliers which works well if you start near the solution, but if you're far from the solution its a bad estimate. If the multipliers are way off it can send the whole thing off in some weird direction, and may never converge.

This changes the default initial guess for the multipliers to be 0 which makes the initial step a basic penalty method which should always converge. The old behavior can be recovered by passing ``options={"initial_multipliers": "least_squares"}``