### PR TITLE
remove solved attribute

### DIFF
--- a/desc/equilibrium/equilibrium.py
+++ b/desc/equilibrium/equilibrium.py
@@ -92,7 +92,6 @@ class Equilibrium(_Configuration, IOAble):
     """
 
     _io_attrs_ = _Configuration._io_attrs_ + [
-        "_solved",
         "_L_grid",
         "_M_grid",
         "_N_grid",
@@ -123,7 +122,6 @@ class Equilibrium(_Configuration, IOAble):
         spectral_indexing=None,
         **kwargs,
     ):
-
         super().__init__(
             Psi,
             NFP,
@@ -163,7 +161,6 @@ class Equilibrium(_Configuration, IOAble):
         self._M_grid = M_grid if M_grid is not None else 2 * self.M
         self._N_grid = N_grid if N_grid is not None else 2 * self.N
         self._node_pattern = node_pattern if node_pattern is not None else "jacobi"
-        self._solved = False
         self.optimizer_results = {}
 
     def __repr__(self):
@@ -221,15 +218,6 @@ class Equilibrium(_Configuration, IOAble):
         if not hasattr(self, "_node_pattern"):
             self._node_pattern = None
         return self._node_pattern
-
-    @property
-    def solved(self):
-        """bool: Whether the equilibrium has been solved."""
-        return self._solved
-
-    @solved.setter
-    def solved(self, solved):
-        self._solved = solved
 
     @property
     def resolution(self):
@@ -537,7 +525,6 @@ class Equilibrium(_Configuration, IOAble):
             print("End of solver")
             objective.print_value(objective.x(eq))
 
-        eq.solved = result["success"]
         return eq, result
 
     def optimize(
@@ -641,7 +628,6 @@ class Equilibrium(_Configuration, IOAble):
             for con in constraints:
                 con.print_value(*con.xs(eq))
 
-        eq.solved = result["success"]
         return eq, result
 
     def _optimize(  # noqa: C901
@@ -720,7 +706,6 @@ class Equilibrium(_Configuration, IOAble):
         iteration = 1
         success = None
         while success is None:
-
             timer.start("Step {} time".format(iteration))
             if verbose > 0:
                 print("====================")
@@ -881,7 +866,6 @@ class Equilibrium(_Configuration, IOAble):
             verbose=verbose,
             copy=copy,
         )
-        eq.solved = False
 
         return eq
 
@@ -907,7 +891,6 @@ class EquilibriaFamily(IOAble, MutableSequence):
     _io_attrs_ = ["_equilibria"]
 
     def __init__(self, *args):
-
         self.equilibria = []
         if len(args) == 1 and isinstance(args[0], list):
             for inp in args[0]:

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -251,8 +251,11 @@ class VMECIO:
         )
 
         ier_flag = file.createVariable("ier_flag", np.int32)
-        ier_flag.long_name = "error flag (0 = solved equilibrium, 1 = unsolved)"
-        ier_flag[:] = int(not eq.solved)
+        ier_flag.long_name = (
+            "error flag (DESC always outputs 0; "
+            + "manually check for a good equilibrium solution)"
+        )
+        ier_flag[:] = 0
 
         lfreeb = file.createVariable("lfreeb__logical__", np.int32)
         lfreeb.long_name = "free boundary logical (0 = fixed boundary)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ from desc.vmec import VMECIO
 
 # print full tracebacks to help find sources of warnings
 def _warn_with_traceback(message, category, filename, lineno, file=None, line=None):
-
     log = file if hasattr(file, "write") else sys.stderr
     traceback.print_stack(file=log)
     log.write(warnings.formatwarning(message, category, filename, lineno, line))
@@ -363,7 +362,6 @@ def VMEC_save(SOLOVEV, tmpdir_factory):
     vmec = Dataset(str(SOLOVEV["vmec_nc_path"]), mode="r")
     eq = EquilibriaFamily.load(load_from=str(SOLOVEV["desc_h5_path"]))[-1]
     eq.change_resolution(M=vmec.variables["mpol"][:] - 1, N=vmec.variables["ntor"][:])
-    eq._solved = True
     VMECIO.save(
         eq, str(SOLOVEV["desc_nc_path"]), surfs=vmec.variables["ns"][:], verbose=0
     )


### PR DESCRIPTION
`Equilibrium.solved` is only used to determine `ier_flag` in the VMEC wout files. This PR removes the attribute and always outputs `ier_flag = 0` (no error), with an explanation. 