### PR TITLE
Ensure that basis.L , basis.M, basis.N all return integers

### DIFF
--- a/desc/basis.py
+++ b/desc/basis.py
@@ -147,17 +147,17 @@ class Basis(IOAble, ABC):
     @property
     def L(self):
         """int: Maximum radial resolution."""
-        return self.__dict__.setdefault("_L", 0)
+        return round(self.__dict__.setdefault("_L", 0))
 
     @property
     def M(self):
         """int:  Maximum poloidal resolution."""
-        return self.__dict__.setdefault("_M", 0)
+        return round(self.__dict__.setdefault("_M", 0))
 
     @property
     def N(self):
         """int: Maximum toroidal resolution."""
-        return self.__dict__.setdefault("_N", 0)
+        return round(self.__dict__.setdefault("_N", 0))
 
     @property
     def NFP(self):

--- a/desc/basis.py
+++ b/desc/basis.py
@@ -147,17 +147,32 @@ class Basis(IOAble, ABC):
     @property
     def L(self):
         """int: Maximum radial resolution."""
-        return round(self.__dict__.setdefault("_L", 0))
+        return self.__dict__.setdefault("_L", 0)
+
+    @L.setter
+    def L(self, L):
+        assert isinstance(L, int), "Basis Resolution must be an integer!"
+        self._L = L
 
     @property
     def M(self):
         """int:  Maximum poloidal resolution."""
-        return round(self.__dict__.setdefault("_M", 0))
+        return self.__dict__.setdefault("_M", 0)
+
+    @M.setter
+    def M(self, M):
+        assert isinstance(M, int), "Basis Resolution must be an integer!"
+        self._M = M
 
     @property
     def N(self):
         """int: Maximum toroidal resolution."""
-        return round(self.__dict__.setdefault("_N", 0))
+        return self.__dict__.setdefault("_N", 0)
+
+    @N.setter
+    def N(self, N):
+        assert isinstance(N, int), "Basis Resolution must be an integer!"
+        self._N = N
 
     @property
     def NFP(self):
@@ -216,9 +231,9 @@ class PowerSeries(Basis):
     """
 
     def __init__(self, L, sym="even"):
-        self._L = L
-        self._M = 0
-        self._N = 0
+        self.L = L
+        self.M = 0
+        self.N = 0
         self._NFP = 1
         self._sym = sym
         self._spectral_indexing = "linear"
@@ -304,7 +319,7 @@ class PowerSeries(Basis):
 
         """
         if L != self.L:
-            self._L = L
+            self.L = L
             self._modes = self._get_modes(self.L)
             self._set_up()
 
@@ -328,9 +343,9 @@ class FourierSeries(Basis):
     """
 
     def __init__(self, N, NFP=1, sym=False):
-        self._L = 0
-        self._M = 0
-        self._N = N
+        self.L = 0
+        self.M = 0
+        self.N = N
         self._NFP = NFP
         self._sym = sym
         self._spectral_indexing = "linear"
@@ -421,7 +436,7 @@ class FourierSeries(Basis):
         """
         self._NFP = NFP if NFP is not None else self.NFP
         if N != self.N:
-            self._N = N
+            self.N = N
             self._sym = sym if sym is not None else self.sym
             self._modes = self._get_modes(self.N)
             self._set_up()
@@ -448,9 +463,9 @@ class DoubleFourierSeries(Basis):
     """
 
     def __init__(self, M, N, NFP=1, sym=False):
-        self._L = 0
-        self._M = M
-        self._N = N
+        self.L = 0
+        self.M = M
+        self.N = N
         self._NFP = NFP
         self._sym = sym
         self._spectral_indexing = "linear"
@@ -565,8 +580,8 @@ class DoubleFourierSeries(Basis):
         """
         self._NFP = NFP if NFP is not None else self.NFP
         if M != self.M or N != self.N or sym != self.sym:
-            self._M = M
-            self._N = N
+            self.M = M
+            self.N = N
             self._sym = sym if sym is not None else self.sym
             self._modes = self._get_modes(self.M, self.N)
             self._set_up()
@@ -606,9 +621,9 @@ class ZernikePolynomial(Basis):
     """
 
     def __init__(self, L, M, sym=False, spectral_indexing="ansi"):
-        self._L = L
-        self._M = M
-        self._N = 0
+        self.L = L
+        self.M = M
+        self.N = 0
         self._NFP = 1
         self._sym = sym
         self._spectral_indexing = spectral_indexing
@@ -659,7 +674,7 @@ class ZernikePolynomial(Basis):
         ], "Unknown spectral_indexing: {}".format(spectral_indexing)
         default_L = {"ansi": M, "fringe": 2 * M}
         L = L if L >= 0 else default_L.get(spectral_indexing, M)
-        self._L = L
+        self.L = L
 
         if spectral_indexing == "ansi":
             pol_posm = [
@@ -778,8 +793,8 @@ class ZernikePolynomial(Basis):
 
         """
         if L != self.L or M != self.M or sym != self.sym:
-            self._L = L
-            self._M = M
+            self.L = L
+            self.M = M
             self._sym = sym if sym is not None else self.sym
             self._modes = self._get_modes(
                 self.L, self.M, spectral_indexing=self.spectral_indexing
@@ -828,9 +843,9 @@ class FourierZernikeBasis(Basis):
     """
 
     def __init__(self, L, M, N, NFP=1, sym=False, spectral_indexing="ansi"):
-        self._L = L
-        self._M = M
-        self._N = N
+        self.L = L
+        self.M = M
+        self.N = N
         self._NFP = NFP
         self._sym = sym
         self._spectral_indexing = spectral_indexing
@@ -883,7 +898,7 @@ class FourierZernikeBasis(Basis):
         ], "Unknown spectral_indexing: {}".format(spectral_indexing)
         default_L = {"ansi": M, "fringe": 2 * M}
         L = L if L >= 0 else default_L.get(spectral_indexing, M)
-        self._L = L
+        self.L = L
 
         if spectral_indexing == "ansi":
             pol_posm = [
@@ -1018,9 +1033,9 @@ class FourierZernikeBasis(Basis):
         """
         self._NFP = NFP if NFP is not None else self.NFP
         if L != self.L or M != self.M or N != self.N or sym != self.sym:
-            self._L = L
-            self._M = M
-            self._N = N
+            self.L = L
+            self.M = M
+            self.N = N
             self._sym = sym if sym is not None else self.sym
             self._modes = self._get_modes(
                 self.L, self.M, self.N, spectral_indexing=self.spectral_indexing

--- a/desc/basis.py
+++ b/desc/basis.py
@@ -151,7 +151,7 @@ class Basis(IOAble, ABC):
 
     @L.setter
     def L(self, L):
-        assert isinstance(L, int), "Basis Resolution must be an integer!"
+        assert int(L) == L, "Basis Resolution must be an integer!"
         self._L = L
 
     @property
@@ -161,7 +161,7 @@ class Basis(IOAble, ABC):
 
     @M.setter
     def M(self, M):
-        assert isinstance(M, int), "Basis Resolution must be an integer!"
+        assert int(M) == M, "Basis Resolution must be an integer!"
         self._M = M
 
     @property
@@ -171,7 +171,7 @@ class Basis(IOAble, ABC):
 
     @N.setter
     def N(self, N):
-        assert isinstance(N, int), "Basis Resolution must be an integer!"
+        assert int(N) == N, "Basis Resolution must be an integer!"
         self._N = N
 
     @property

--- a/desc/basis.py
+++ b/desc/basis.py
@@ -152,7 +152,7 @@ class Basis(IOAble, ABC):
     @L.setter
     def L(self, L):
         assert int(L) == L, "Basis Resolution must be an integer!"
-        self._L = L
+        self._L = int(L)
 
     @property
     def M(self):
@@ -162,7 +162,7 @@ class Basis(IOAble, ABC):
     @M.setter
     def M(self, M):
         assert int(M) == M, "Basis Resolution must be an integer!"
-        self._M = M
+        self._M = int(M)
 
     @property
     def N(self):
@@ -172,7 +172,7 @@ class Basis(IOAble, ABC):
     @N.setter
     def N(self, N):
         assert int(N) == N, "Basis Resolution must be an integer!"
-        self._N = N
+        self._N = int(N)
 
     @property
     def NFP(self):

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -311,6 +311,31 @@ class TestBasis:
         L = 3.0
         M = 3.0
         N = 3.0
+
+        basis = PowerSeries(L=L)
+        assert isinstance(basis.L, int)
+        assert basis.L == 3
+
+        basis = FourierSeries(N=N)
+        assert isinstance(basis.N, int)
+        assert basis.N == 3
+
+        basis = DoubleFourierSeries(M=M, N=N)
+        assert isinstance(basis.M, int)
+        assert isinstance(basis.N, int)
+        assert basis.M == 3
+        assert basis.N == 3
+
+        basis = ZernikePolynomial(L=L, M=M)
+        assert isinstance(basis.M, int)
+        assert isinstance(basis.L, int)
+        assert basis.M == 3
+        assert basis.L == 3
+
+        L = 3.1
+        M = 3.1
+        N = 3.1
+
         with pytest.raises(AssertionError):
             PowerSeries(L=L)
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -306,28 +306,19 @@ class TestBasis:
         assert np.all(fz == 0)
 
     @pytest.mark.unit
-    def test_basis_resolutions_are_integers(self):
-        """Test that basis modes are integers."""
+    def test_basis_resolutions_assert_integers(self):
+        """Test that basis modes are asserted as integers."""
         L = 3.0
         M = 3.0
         N = 3.0
+        with pytest.raises(AssertionError):
+            PowerSeries(L=L)
 
-        basis = PowerSeries(L=L)
-        assert isinstance(basis.L, int)
-        assert basis.L == 3
+        with pytest.raises(AssertionError):
+            FourierSeries(N=N)
 
-        basis = FourierSeries(N=N)
-        assert isinstance(basis.N, int)
-        assert basis.N == 3
+        with pytest.raises(AssertionError):
+            DoubleFourierSeries(M=M, N=N)
 
-        basis = DoubleFourierSeries(M=M, N=N)
-        assert isinstance(basis.M, int)
-        assert isinstance(basis.N, int)
-        assert basis.M == 3
-        assert basis.N == 3
-
-        basis = ZernikePolynomial(L=L, M=M)
-        assert isinstance(basis.M, int)
-        assert isinstance(basis.L, int)
-        assert basis.M == 3
-        assert basis.L == 3
+        with pytest.raises(AssertionError):
+            ZernikePolynomial(L=L, M=M)

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -304,3 +304,30 @@ class TestBasis:
         basis = ZernikePolynomial(L=2, M=3)
         fz = basis.evaluate(nodes, derivatives=[0, 0, 1])
         assert np.all(fz == 0)
+
+    @pytest.mark.unit
+    def test_basis_resolutions_are_integers(self):
+        """Test that basis modes are integers."""
+        L = 3.0
+        M = 3.0
+        N = 3.0
+
+        basis = PowerSeries(L=L)
+        assert isinstance(basis.L, int)
+        assert basis.L == 3
+
+        basis = FourierSeries(N=N)
+        assert isinstance(basis.N, int)
+        assert basis.N == 3
+
+        basis = DoubleFourierSeries(M=M, N=N)
+        assert isinstance(basis.M, int)
+        assert isinstance(basis.N, int)
+        assert basis.M == 3
+        assert basis.N == 3
+
+        basis = ZernikePolynomial(L=L, M=M)
+        assert isinstance(basis.M, int)
+        assert isinstance(basis.L, int)
+        assert basis.M == 3
+        assert basis.L == 3


### PR DESCRIPTION
- Fixes bug where if a `Basis` object were instantiated with a float passed in as one of the resolutions, such as `PowerSeries(L=1.0)`, then `basis.L` would be a float. This caused issues during the init of most bases, except DoubleFourierSeries, which could cause further headaches when down the line another object using that basis runs into issues because it expected an int and got a float instead for `basis.N`