### PR TITLE
Rename ``theta_sfl`` to ``theta_PEST``

### DIFF
--- a/desc/compute/_core.py
+++ b/desc/compute/_core.py
@@ -247,7 +247,7 @@ def _zeta_z(params, transforms, profiles, data, **kwargs):
 
 
 @register_compute_fun(
-    name="theta_sfl",
+    name="theta_PEST",
     label="\\vartheta",
     units="rad",
     units_long="radians",
@@ -259,13 +259,13 @@ def _zeta_z(params, transforms, profiles, data, **kwargs):
     coordinates="rtz",
     data=["theta", "lambda"],
 )
-def _theta_sfl(params, transforms, profiles, data, **kwargs):
-    data["theta_sfl"] = (data["theta"] + data["lambda"]) % (2 * jnp.pi)
+def _theta_PEST(params, transforms, profiles, data, **kwargs):
+    data["theta_PEST"] = (data["theta"] + data["lambda"]) % (2 * jnp.pi)
     return data
 
 
 @register_compute_fun(
-    name="theta_sfl_r",
+    name="theta_PEST_r",
     label="\\partial_{\\rho} \\vartheta",
     units="rad",
     units_long="radians",
@@ -278,13 +278,13 @@ def _theta_sfl(params, transforms, profiles, data, **kwargs):
     coordinates="rtz",
     data=["lambda_r"],
 )
-def _theta_sfl_r(params, transforms, profiles, data, **kwargs):
-    data["theta_sfl_r"] = data["lambda_r"]
+def _theta_PEST_r(params, transforms, profiles, data, **kwargs):
+    data["theta_PEST_r"] = data["lambda_r"]
     return data
 
 
 @register_compute_fun(
-    name="theta_sfl_t",
+    name="theta_PEST_t",
     label="\\partial_{\\theta} \\vartheta",
     units="rad",
     units_long="radians",
@@ -297,13 +297,13 @@ def _theta_sfl_r(params, transforms, profiles, data, **kwargs):
     coordinates="rtz",
     data=["lambda_t"],
 )
-def _theta_sfl_t(params, transforms, profiles, data, **kwargs):
-    data["theta_sfl_t"] = 1 + data["lambda_t"]
+def _theta_PEST_t(params, transforms, profiles, data, **kwargs):
+    data["theta_PEST_t"] = 1 + data["lambda_t"]
     return data
 
 
 @register_compute_fun(
-    name="theta_sfl_z",
+    name="theta_PEST_z",
     label="\\partial_{\\zeta} \\vartheta",
     units="rad",
     units_long="radians",
@@ -316,8 +316,8 @@ def _theta_sfl_t(params, transforms, profiles, data, **kwargs):
     coordinates="rtz",
     data=["lambda_z"],
 )
-def _theta_sfl_z(params, transforms, profiles, data, **kwargs):
-    data["theta_sfl_z"] = data["lambda_z"]
+def _theta_PEST_z(params, transforms, profiles, data, **kwargs):
+    data["theta_PEST_z"] = data["lambda_z"]
     return data
 
 
@@ -332,10 +332,10 @@ def _theta_sfl_z(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["theta_sfl", "zeta", "iota"],
+    data=["theta_PEST", "zeta", "iota"],
 )
 def _alpha(params, transforms, profiles, data, **kwargs):
-    data["alpha"] = (data["theta_sfl"] - data["iota"] * data["zeta"]) % (2 * jnp.pi)
+    data["alpha"] = (data["theta_PEST"] - data["iota"] * data["zeta"]) % (2 * jnp.pi)
     return data
 
 

--- a/desc/equilibrium/coords.py
+++ b/desc/equilibrium/coords.py
@@ -62,6 +62,8 @@ def map_coordinates(  # noqa: C901
         coordinate is not in the plasma volume.
 
     """
+    inbasis = list(inbasis)
+    outbasis = list(outbasis)
     assert (
         np.isfinite(maxiter) and maxiter > 0
     ), f"maxiter must be a positive integer, got {maxiter}"
@@ -123,8 +125,8 @@ def map_coordinates(  # noqa: C901
             rho_g = np.linspace(0, 1, eq.L_grid + 1)
         if "theta" in inbasis:
             theta_g = np.unique(coords[:, inbasis.index("theta")])
-        elif "theta_sfl" in inbasis:  # lambda is usually small
-            theta_g = np.unique(coords[:, inbasis.index("theta_sfl")])
+        elif "theta_PEST" in inbasis:  # lambda is usually small
+            theta_g = np.unique(coords[:, inbasis.index("theta_PEST")])
         else:
             theta_g = np.linspace(0, 2 * np.pi, 2 * eq.M_grid + 1)
         if "zeta" in inbasis:

--- a/desc/plotting.py
+++ b/desc/plotting.py
@@ -1113,7 +1113,10 @@ def plot_section(
         nr, nt, nz = grid.num_rho, grid.num_theta, grid.num_zeta
         phi = np.unique(grid.nodes[:, 2])
         coords = eq.map_coordinates(
-            grid.nodes, ["rho", "theta", "phi"], ["rho", "theta", "zeta"]
+            grid.nodes,
+            ["rho", "theta", "phi"],
+            ["rho", "theta", "zeta"],
+            period=(np.inf, 2 * np.pi, 2 * np.pi),
         )
         grid = Grid(coords, sort=False)
 
@@ -1122,7 +1125,10 @@ def plot_section(
         nphi = phi.size
         nr, nt, nz = grid.num_rho, grid.num_theta, grid.num_zeta
         coords = eq.map_coordinates(
-            grid.nodes, ["rho", "theta", "phi"], ["rho", "theta", "zeta"]
+            grid.nodes,
+            ["rho", "theta", "phi"],
+            ["rho", "theta", "zeta"],
+            period=(np.inf, 2 * np.pi, 2 * np.pi),
         )
         grid = Grid(coords, sort=False)
     rows = np.floor(np.sqrt(nphi)).astype(int)
@@ -1367,7 +1373,10 @@ def plot_surfaces(eq, rho=8, theta=8, phi=None, ax=None, return_data=False, **kw
     rnr, rnt, rnz = r_grid.num_rho, r_grid.num_theta, r_grid.num_zeta
     r_grid = Grid(
         eq.map_coordinates(
-            r_grid.nodes, ["rho", "theta", "phi"], ["rho", "theta", "zeta"]
+            r_grid.nodes,
+            ["rho", "theta", "phi"],
+            ["rho", "theta", "zeta"],
+            period=(np.inf, 2 * np.pi, 2 * np.pi),
         ),
         sort=False,
     )
@@ -1384,7 +1393,10 @@ def plot_surfaces(eq, rho=8, theta=8, phi=None, ax=None, return_data=False, **kw
         tnr, tnt, tnz = t_grid.num_rho, t_grid.num_theta, t_grid.num_zeta
         v_grid = Grid(
             eq.map_coordinates(
-                t_grid.nodes, ["rho", "theta_sfl", "phi"], ["rho", "theta", "zeta"]
+                t_grid.nodes,
+                ["rho", "theta_PEST", "phi"],
+                ["rho", "theta", "zeta"],
+                period=(np.inf, 2 * np.pi, 2 * np.pi),
             ),
             sort=False,
         )
@@ -1568,7 +1580,10 @@ def plot_boundary(eq, phi=None, plot_axis=False, ax=None, return_data=False, **k
     nr, nt, nz = grid.num_rho, grid.num_theta, grid.num_zeta
     grid = Grid(
         eq.map_coordinates(
-            grid.nodes, ["rho", "theta", "phi"], ["rho", "theta", "zeta"]
+            grid.nodes,
+            ["rho", "theta", "phi"],
+            ["rho", "theta", "zeta"],
+            period=(np.inf, 2 * np.pi, 2 * np.pi),
         ),
         sort=False,
     )
@@ -1737,7 +1752,10 @@ def plot_boundaries(eqs, labels=None, phi=None, ax=None, return_data=False, **kw
         nr, nt, nz = grid.num_rho, grid.num_theta, grid.num_zeta
         grid = Grid(
             eqs[i].map_coordinates(
-                grid.nodes, ["rho", "theta", "phi"], ["rho", "theta", "zeta"]
+                grid.nodes,
+                ["rho", "theta", "phi"],
+                ["rho", "theta", "zeta"],
+                period=(np.inf, 2 * np.pi, 2 * np.pi),
             ),
             sort=False,
         )

--- a/tests/test_equilibrium.py
+++ b/tests/test_equilibrium.py
@@ -106,7 +106,7 @@ def test_map_coordinates():
     eq = desc.examples.get("DSHAPE")
 
     inbasis = ["alpha", "phi", "rho"]
-    outbasis = ["rho", "theta_sfl", "zeta"]
+    outbasis = ["rho", "theta_PEST", "zeta"]
 
     rho = np.linspace(0.01, 0.99, 100)
     theta = np.linspace(0, np.pi, 100, endpoint=False)
@@ -149,7 +149,7 @@ def test_map_coordinates2():
 
     out = eq.map_coordinates(
         t_grid.nodes,
-        ["rho", "theta_sfl", "phi"],
+        ["rho", "theta_PEST", "phi"],
         ["rho", "theta", "zeta"],
         period=(np.inf, 2 * np.pi, 2 * np.pi),
     )


### PR DESCRIPTION
To avoid confusion with other straight field line coordinate systems, and make it consistent with other naming conventions (eg, we already have ``sqrt(g)_PEST`` and ``e_theta_PEST``)