### PR TITLE
updating della-gpu installation instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -123,16 +123,15 @@ specific JAX GPU installation instructions, as that is the main installation dif
 
 Della Cluster (Princeton)
 +++++++++++++++++++++++++
-These instructions were tested and confirmed to work on the Della cluster at Princeton as of 5-3-2023.
+These instructions were tested and confirmed to work on the Della cluster at Princeton as of 7-10-2023.
 
 First, install JAX (commands taken from `this tutorial <https://github.com/PrincetonUniversity/intro_ml_libs/tree/master/jax>`__ ):
 
 .. code-block:: sh
 
-    module load anaconda3/2022.5
-    conda create --name desc-env python=3.9
+    module load anaconda3/2023.3
+    CONDA_OVERRIDE_CUDA="11.2" conda create --name desc-env jax "jaxlib==0.4.10=cuda112*" -c conda-forge
     conda activate desc-env
-    pip install "jax[cuda11_cudnn82]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 Then, we install DESC:
 


### PR DESCRIPTION
The current instructions for installing DESC do not seem to work on Della. So, I have used the same instructions as the ones used for Traverse.