### PR TITLE
Dp/interpolate

### DIFF
--- a/desc/interpolate.py
+++ b/desc/interpolate.py
@@ -661,8 +661,7 @@ def _approx_df(x, f, method, axis, **kwargs):
             axis=axis,
         )
         return fx
-
-    if method == "cubic2":
+    elif method == "cubic2":
         dx = jnp.diff(x)
         df = jnp.diff(f, axis=axis)
         if df.ndim > dx.ndim:
@@ -705,8 +704,7 @@ def _approx_df(x, f, method, axis, **kwargs):
         fx = jnp.linalg.solve(A, b)
         fx = jnp.moveaxis(fx.reshape(f.shape), 0, axis)
         return fx
-
-    if method in ["cardinal", "catmull-rom"]:
+    elif method in ["cardinal", "catmull-rom"]:
         dx = x[2:] - x[:-2]
         df = jnp.take(f, jnp.arange(2, f.shape[axis]), axis, mode="wrap") - jnp.take(
             f, jnp.arange(0, f.shape[axis] - 2), axis, mode="wrap"
@@ -740,8 +738,7 @@ def _approx_df(x, f, method, axis, **kwargs):
             c = 0
         fx = (1 - c) * jnp.concatenate([fx0, df, fx1], axis=axis)
         return fx
-
-    if method in ["monotonic", "monotonic-0"]:
+    elif method in ["monotonic", "monotonic-0"]:
         f = jnp.moveaxis(f, axis, 0)
         fshp = f.shape
         if f.ndim == 1:
@@ -788,6 +785,8 @@ def _approx_df(x, f, method, axis, **kwargs):
 
         dk = jnp.concatenate([d0, dk, d1])
         return dk.reshape(fshp)
+    else:  # method passed in does not use df from this function, just return 0
+        return jnp.zeros_like(f)
 
 
 # fmt: off

--- a/desc/interpolate.py
+++ b/desc/interpolate.py
@@ -763,10 +763,10 @@ def _approx_df(x, f, method, axis, **kwargs):
         if df.ndim > w1.ndim:
             w1 = jnp.expand_dims(w1, tuple(range(1, df.ndim)))
             w1 = jnp.moveaxis(w1, 0, axis)
-            w2 = jnp.expand_dims(w1, tuple(range(1, df.ndim)))
-            w2 = jnp.moveaxis(w1, 0, axis)
+            w2 = jnp.expand_dims(w2, tuple(range(1, df.ndim)))
+            w2 = jnp.moveaxis(w2, 0, axis)
 
-        whmean = (w1 / mk[:-1] + w2 / mk[1:]) / (w1 + w2)
+        whmean = (w1 / mk[:-1, :] + w2 / mk[1:, :]) / (w1 + w2)
 
         dk = jnp.where(condition, 0, 1.0 / whmean)
 
@@ -792,10 +792,12 @@ def _approx_df(x, f, method, axis, **kwargs):
                 d = jnp.where(mmm, 3.0 * m0, d)
                 return d
 
-            d0 = _edge_case(hk[0], hk[1], mk[0], mk[1])[None]
-            d1 = _edge_case(hk[-1], hk[-2], mk[-1], mk[-2])[None]
+            hk = 1 / hki
+            d0 = _edge_case(hk[0, :], hk[1, :], mk[0, :], mk[1, :])[None]
+            d1 = _edge_case(hk[-1, :], hk[-2, :], mk[-1, :], mk[-2, :])[None]
 
         dk = np.concatenate([d0, dk, d1])
+        dk = dk.reshape(fshp)
         return dk.reshape(fshp)
     else:  # method passed in does not use df from this function, just return 0
         return jnp.zeros_like(f)

--- a/desc/interpolate.py
+++ b/desc/interpolate.py
@@ -746,21 +746,33 @@ def _approx_df(x, f, method, axis, **kwargs):
             x = x[:, None]
             f = f[:, None]
         hk = x[1:] - x[:-1]
-        mk = (f[1:] - f[:-1]) / hk
+        df = jnp.diff(f, axis=axis)
+        hki = jnp.where(hk == 0, 0, 1 / hk)
+        if df.ndim > hki.ndim:
+            hki = jnp.expand_dims(hki, tuple(range(1, df.ndim)))
+            hki = jnp.moveaxis(hki, 0, axis)
+
+        mk = hki * df
 
         smk = jnp.sign(mk)
-        condition = (smk[1:] != smk[:-1]) | (mk[1:] == 0) | (mk[:-1] == 0)
+        condition = (smk[1:, :] != smk[:-1, :]) | (mk[1:, :] == 0) | (mk[:-1, :] == 0)
 
         w1 = 2 * hk[1:] + hk[:-1]
         w2 = hk[1:] + 2 * hk[:-1]
+
+        if df.ndim > w1.ndim:
+            w1 = jnp.expand_dims(w1, tuple(range(1, df.ndim)))
+            w1 = jnp.moveaxis(w1, 0, axis)
+            w2 = jnp.expand_dims(w1, tuple(range(1, df.ndim)))
+            w2 = jnp.moveaxis(w1, 0, axis)
 
         whmean = (w1 / mk[:-1] + w2 / mk[1:]) / (w1 + w2)
 
         dk = jnp.where(condition, 0, 1.0 / whmean)
 
         if method == "monotonic-0":
-            d0 = jnp.zeros((1, 1))
-            d1 = jnp.zeros((1, 1))
+            d0 = jnp.zeros((1, dk.shape[1]))
+            d1 = jnp.zeros((1, dk.shape[1]))
 
         else:
             # special case endpoints, as suggested in
@@ -783,7 +795,7 @@ def _approx_df(x, f, method, axis, **kwargs):
             d0 = _edge_case(hk[0], hk[1], mk[0], mk[1])[None]
             d1 = _edge_case(hk[-1], hk[-2], mk[-1], mk[-2])[None]
 
-        dk = jnp.concatenate([d0, dk, d1])
+        dk = np.concatenate([d0, dk, d1])
         return dk.reshape(fshp)
     else:  # method passed in does not use df from this function, just return 0
         return jnp.zeros_like(f)

--- a/desc/profiles.py
+++ b/desc/profiles.py
@@ -10,7 +10,7 @@ from desc.backend import jit, jnp, put, sign
 from desc.basis import FourierZernikeBasis, PowerSeries
 from desc.derivatives import Derivative
 from desc.grid import Grid, LinearGrid
-from desc.interpolate import _approx_df, interp1d
+from desc.interpolate import interp1d
 from desc.io import IOAble
 from desc.transform import Transform
 from desc.utils import combination_permutation, copy_coeffs, multinomial_coefficients
@@ -812,9 +812,6 @@ class SplineProfile(Profile):
         self._knots = knots
         self._params = values
         self._method = method
-        self._Dx = _approx_df(
-            self._knots, np.eye(self._knots.size), self._method, axis=0
-        )
 
     def __repr__(self):
         """Get the string form of the object."""
@@ -885,12 +882,8 @@ class SplineProfile(Profile):
             return jnp.zeros_like(xq)
         x = self._knots
         f = params
-        if self._method == "monotonic":
-            df = None  # must create the df at compute time since the BCs
-            #  contain logic depending on f
-        else:
-            df = self._Dx @ f
-        fq = interp1d(xq, x, f, method=self._method, derivative=dr, extrap=True, fx=df)
+
+        fq = interp1d(xq, x, f, method=self._method, derivative=dr, extrap=True)
         return fq
 
 

--- a/desc/profiles.py
+++ b/desc/profiles.py
@@ -886,7 +886,7 @@ class SplineProfile(Profile):
         x = self._knots
         f = params
         df = self._Dx @ f
-        fq = interp1d(xq, x, f, method=self._method, derivative=dr, extrap=True, df=df)
+        fq = interp1d(xq, x, f, method=self._method, derivative=dr, extrap=True, fx=df)
         return fq
 
 

--- a/desc/profiles.py
+++ b/desc/profiles.py
@@ -885,7 +885,11 @@ class SplineProfile(Profile):
             return jnp.zeros_like(xq)
         x = self._knots
         f = params
-        df = self._Dx @ f
+        if self._method == "monotonic":
+            df = None  # must create the df at compute time since the BCs
+            #  contain logic depending on f
+        else:
+            df = self._Dx @ f
         fq = interp1d(xq, x, f, method=self._method, derivative=dr, extrap=True, fx=df)
         return fq
 

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -100,6 +100,19 @@ class TestInterp2D:
 
         fq = interp2d(x, y, xp, yp, fp, method="linear")
         np.testing.assert_allclose(fq, f(x, y), rtol=1e-4, atol=1e-2)
+        atol = 2e-3
+        rtol = 1e-5
+        fq = interp2d(x, y, xp, yp, fp, method="cubic")
+        np.testing.assert_allclose(fq, f(x, y), rtol=rtol, atol=atol)
+
+        fq = interp2d(x, y, xp, yp, fp, method="cubic2")
+        np.testing.assert_allclose(fq, f(x, y), rtol=rtol, atol=atol)
+
+        fq = interp2d(x, y, xp, yp, fp, method="catmull-rom")
+        np.testing.assert_allclose(fq, f(x, y), rtol=rtol, atol=atol)
+
+        fq = interp2d(x, y, xp, yp, fp, method="cardinal")
+        np.testing.assert_allclose(fq, f(x, y), rtol=rtol, atol=atol)
 
 
 class TestInterp3D:
@@ -127,3 +140,16 @@ class TestInterp3D:
 
         fq = interp3d(x, y, z, xp, yp, zp, fp, method="linear")
         np.testing.assert_allclose(fq, f(x, y, z), rtol=1e-3, atol=1e-1)
+        atol = 5.5e-3
+        rtol = 1e-5
+        fq = interp3d(x, y, z, xp, yp, zp, fp, method="cubic")
+        np.testing.assert_allclose(fq, f(x, y, z), rtol=rtol, atol=atol)
+
+        fq = interp3d(x, y, z, xp, yp, zp, fp, method="cubic2")
+        np.testing.assert_allclose(fq, f(x, y, z), rtol=rtol, atol=atol)
+
+        fq = interp3d(x, y, z, xp, yp, zp, fp, method="catmull-rom")
+        np.testing.assert_allclose(fq, f(x, y, z), rtol=rtol, atol=atol)
+
+        fq = interp3d(x, y, z, xp, yp, zp, fp, method="cardinal")
+        np.testing.assert_allclose(fq, f(x, y, z), rtol=rtol, atol=atol)

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 from scipy.constants import elementary_charge
+from scipy.interpolate import interp1d
 
 from desc.equilibrium import Equilibrium
 from desc.grid import LinearGrid
@@ -79,6 +80,42 @@ class TestProfiles:
         np.testing.assert_allclose(sp3(x), pp3(x), rtol=1e-5, atol=1e-3)
         sp4 = mp.to_spline()
         np.testing.assert_allclose(sp3(x), sp4(x), rtol=1e-5, atol=1e-2)
+
+    @pytest.mark.unit
+    def test_SplineProfile_methods(self):
+        """Test that all methods of SplineProfile work as intended without errors."""
+        pp = PowerSeriesProfile(
+            modes=np.array([0, 2, 4]), params=np.array([1, -2, 1]), sym=False
+        )  # base profile to work off of
+        knots = np.linspace(0, 1.0, 20, endpoint=True)
+        x = np.linspace(0, 0.9, 25)
+
+        method = "nearest"
+        sp = pp.to_spline(knots=knots, method=method)
+        # should be exactly same if evaluated at knots + eps
+        np.testing.assert_allclose(pp(knots), sp(knots + 0.02))
+
+        method = "linear"
+        sp = pp.to_spline(knots=knots, method=method)
+        # should match linear interpolation
+        scipy_interp = interp1d(x=knots, y=pp(knots))
+        np.testing.assert_allclose(scipy_interp(x), sp(x))
+
+        method = "cubic"
+        sp = pp.to_spline(knots=knots, method=method)
+        np.testing.assert_allclose(pp(x), sp(x), rtol=1e-5, atol=1e-3)
+
+        method = "cubic2"
+        sp = pp.to_spline(knots=knots, method=method)
+        np.testing.assert_allclose(pp(x), sp(x), rtol=1e-5, atol=1e-3)
+
+        method = "catmull-rom"
+        sp = pp.to_spline(knots=knots, method=method)
+        np.testing.assert_allclose(pp(x), sp(x), rtol=1e-5, atol=1e-3)
+
+        method = "cardinal"
+        sp = pp.to_spline(knots=knots, method=method)
+        np.testing.assert_allclose(pp(x), sp(x), rtol=1e-5, atol=1e-3)
 
     @pytest.mark.unit
     def test_repr(self):

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -123,7 +123,7 @@ class TestProfiles:
 
         method = "monotonic-0"
         sp = pp.to_spline(knots=knots, method=method)
-        np.testing.assert_allclose(pp(x), sp(x), rtol=1e-5, atol=1e-3)
+        np.testing.assert_allclose(pp(x), sp(x), rtol=1e-5, atol=5e-3)
 
         # test monotonic splines preserve monotonicity
         f = np.heaviside(knots - 0.5, 0) + 0.1 * knots


### PR DESCRIPTION
- No longer precomputes Df in SplineProfile, as it doesn't really help with speed.
- Fixes bug where approx_df returns None when method is not a cubic spline family
- refactor monotonic spline algorithm to work with 2-D inputs
- add tests for these fixes
- Test all available interpolation methods for interp2d and interp3d