### PR TITLE
Don't overwrite equilibria during automatic continuation method

### DIFF
--- a/desc/continuation.py
+++ b/desc/continuation.py
@@ -282,6 +282,7 @@ def _add_pressure(
             )
         stop = stop or not eqi.is_nested()
         eqfam.append(eqi)
+        eqi = eqi.copy()
 
         if checkpoint_path is not None:
             if verbose > 0:
@@ -414,6 +415,7 @@ def _add_shaping(
             )
         stop = stop or not eqi.is_nested()
         eqfam.append(eqi)
+        eqi = eqi.copy()
 
         if checkpoint_path is not None:
             if verbose > 0:


### PR DESCRIPTION
- Existing automatic continuation method would overwrite equilibria from intermediate steps, so final family wouldn't show every step along the way
- Fixes it so that each step is now saved