### PR TITLE
Fix simsopt QH comparison test

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -420,7 +420,7 @@ def test_simsopt_QH_comparison():
     nfp = 4
     aspect_target = 8.0
     # Initial (m=0, n=nfp) mode of the axis:
-    Delta = 0.2
+    Delta = 0.4
     LMN_resolution = 6
     # Set shape of the initial condition.
     # R_lmn and Z_lmn are the amplitudes. modes_R and modes_Z are the (m,n) pairs.
@@ -508,7 +508,7 @@ def test_simsopt_QH_comparison():
                 eq=eq, target=aspect_target, weight=aspect_weight, normalize=False
             ),
             QuasisymmetryTwoTerm(
-                eq=eq, helicity=(1, nfp), grid=grid, weight=qs_weight, normalize=False
+                eq=eq, helicity=(-1, nfp), grid=grid, weight=qs_weight, normalize=False
             ),
         )
     )
@@ -517,10 +517,12 @@ def test_simsopt_QH_comparison():
         objective=objective,
         constraints=constraints,
         optimizer=Optimizer("proximal-lsq-exact"),
+        ftol=1e-3,
     )
     aspect = eq2.compute("R0/a")["R0/a"]
-    np.testing.assert_allclose(aspect, aspect_target, atol=1e-2, rtol=1e-3)
-    np.testing.assert_array_less(objective.compute_scalar(objective.x(eq)), 1e-2)
+    np.testing.assert_allclose(aspect, aspect_target, atol=1e-2, rtol=1e-2)
+    np.testing.assert_array_less(objective.compute_scalar(objective.x(eq)), 0.075)
+    np.testing.assert_array_less(eq2.compute("a_major/a_minor")["a_major/a_minor"], 5)
 
 
 @pytest.mark.regression

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -420,14 +420,14 @@ def test_simsopt_QH_comparison():
     nfp = 4
     aspect_target = 8.0
     # Initial (m=0, n=nfp) mode of the axis:
-    Delta = 0.4
+    torsion = 0.4
     LMN_resolution = 6
     # Set shape of the initial condition.
     # R_lmn and Z_lmn are the amplitudes. modes_R and modes_Z are the (m,n) pairs.
     surface = FourierRZToroidalSurface(
-        R_lmn=[1.0, 1.0 / aspect_target, Delta],
+        R_lmn=[1.0, 1.0 / aspect_target, torsion],
         modes_R=[[0, 0], [1, 0], [0, 1]],
-        Z_lmn=[0, -1.0 / aspect_target, Delta],
+        Z_lmn=[0, -1.0 / aspect_target, torsion],
         modes_Z=[[0, 0], [-1, 0], [0, -1]],
         NFP=nfp,
     )


### PR DESCRIPTION
There were a few issues:

- After switching the sign of the jacobian, we forgot to switch the sign of the target helicity
- Per the email chain with Matt that inspired the test, 
> Unfortunately the optimizer then fell into an unphysical minimum with very small objective resembling a tall cylinder. I get this sometimes in simsopt too with QH optimizations if the initial condition doesn't have enough axis torsion. Increasing the (m=0,n=4) mode of the initial condition resolved this, and now desc gets the real QH solution with f=0.075, nearly identical to the simsopt result.

So we should have increased Delta from the start, the one in the original test was expected to converge to a really high elongation.

With the fixes, we get a nice reasonable QH:
![image](https://github.com/PlasmaControl/DESC/assets/22567458/1b9ca48b-6472-4a8f-8d61-be7590b13ba9)


Resolves #599 