### PR TITLE
fix bug in QSBoozer

### DIFF
--- a/desc/objectives/_qs.py
+++ b/desc/objectives/_qs.py
@@ -143,7 +143,7 @@ class QuasisymmetryBoozer(_Objective):
             helicity=self.helicity,
             NFP=self._transforms["B"].basis.NFP,
         )
-        self._idx = np.where(self._idx)[0]
+
         self._constants = {
             "transforms": self._transforms,
             "profiles": self._profiles,

--- a/desc/objectives/_qs.py
+++ b/desc/objectives/_qs.py
@@ -143,6 +143,7 @@ class QuasisymmetryBoozer(_Objective):
             helicity=self.helicity,
             NFP=self._transforms["B"].basis.NFP,
         )
+        self._idx = np.where(self._idx)[0]
         self._constants = {
             "transforms": self._transforms,
             "profiles": self._profiles,

--- a/desc/vmec_utils.py
+++ b/desc/vmec_utils.py
@@ -267,7 +267,7 @@ def ptolemy_linear_transform(desc_modes, vmec_modes=None, helicity=None, NFP=Non
         else:
             idx_MN = np.nonzero(vmec_modes[:, 1] * N == vmec_modes[:, 2] * M)[0]
         idx[idx_MN] = False
-        idx = np.where(idx)[0]
+        idx = np.nonzero(idx)[0]
         return matrix, vmec_modes, idx
 
     return matrix, vmec_modes

--- a/desc/vmec_utils.py
+++ b/desc/vmec_utils.py
@@ -267,7 +267,7 @@ def ptolemy_linear_transform(desc_modes, vmec_modes=None, helicity=None, NFP=Non
         else:
             idx_MN = np.nonzero(vmec_modes[:, 1] * N == vmec_modes[:, 2] * M)[0]
         idx[idx_MN] = False
-
+        idx = np.where(idx)[0]
         return matrix, vmec_modes, idx
 
     return matrix, vmec_modes

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ markers=
 filterwarnings=
     error
     ignore::pytest.PytestUnraisableExceptionWarning
-    ignore::RuntimeWarning:desc.compute
+    ignore::RuntimeWarning
     # Ignore division by zero warnings.
     ignore::DeprecationWarning:ml_dtypes.*
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ markers=
 filterwarnings=
     error
     ignore::pytest.PytestUnraisableExceptionWarning
-    ignore::RuntimeWarning
+    ignore::RuntimeWarning:desc.compute
     # Ignore division by zero warnings.
     ignore::DeprecationWarning:ml_dtypes.*
 

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -198,6 +198,20 @@ class TestObjectiveFunction:
         test(Equilibrium(L=2, M=2, N=1, current=PowerSeriesProfile(0)))
 
     @pytest.mark.unit
+    def test_jax_compile_boozer(self):
+        """Test compilation of Boozer QA metric in ObjectiveFunction."""
+        # making sure that compiles without any errors from JAX
+        # Related to issue #625
+        def test(eq):
+            obj = ObjectiveFunction(QuasisymmetryBoozer(eq=eq))
+            obj.build()
+            obj.compile()
+            fb = obj.compute_unscaled(obj.x(eq))
+            np.testing.assert_allclose(fb, 0, atol=1e-12)
+
+        test(Equilibrium(L=2, M=2, N=1, current=PowerSeriesProfile(0)))
+
+    @pytest.mark.unit
     def test_qh_boozer(self):
         """Test calculation of Boozer QH metric."""
         eq = get("WISTELL-A")  # WISTELL-A is optimized for QH symmetry

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -245,7 +245,7 @@ class TestObjectiveFunction:
         idx_B = np.argsort(np.abs(B_mn))
 
         # check that largest amplitudes are the QH modes
-        np.testing.assert_allclose(B_mn[idx_B[-3:]], np.flip(B_mn[~idx][:3]))
+        np.testing.assert_allclose(B_mn[idx_B[-3:]], np.flip(np.delete(B_mn, idx)[:3]))
         # check that these QH modes are not returned by the objective
         assert [b not in f for b in B_mn[idx_B[-3:]]]
         # check that the objective returns the lowest amplitudes

--- a/tests/test_vmec.py
+++ b/tests/test_vmec.py
@@ -182,7 +182,7 @@ class TestVMECIO:
                 [1, 3, 3],
             ]
         )
-        np.testing.assert_allclose(modes[~idx], sym_modes)
+        np.testing.assert_allclose(np.delete(modes, idx), sym_modes)
 
     @pytest.mark.unit
     def test_fourier_to_zernike(self):

--- a/tests/test_vmec.py
+++ b/tests/test_vmec.py
@@ -182,7 +182,7 @@ class TestVMECIO:
                 [1, 3, 3],
             ]
         )
-        np.testing.assert_allclose(np.delete(modes, idx), sym_modes)
+        np.testing.assert_allclose(np.delete(modes, idx, axis=0), sym_modes)
 
     @pytest.mark.unit
     def test_fourier_to_zernike(self):


### PR DESCRIPTION
change ptolemy_linear_transform to actually return integer indices of non symmetric modes when helicity is passed, as opposed to  a boolean mask of the same length as modes. Puts the output in line with the docstring and fixes JAX error with boolean indexing and tracing

resolves #625 