### PR TITLE
Fix bug in metric tensor elements

### DIFF
--- a/desc/compute/_metric.py
+++ b/desc/compute/_metric.py
@@ -762,37 +762,10 @@ def _g_sup_tz(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^rho",
-        "sqrt(g)_r",
-        "sqrt(g)",
-        "e_theta",
-        "e_theta_r",
-        "e_zeta_r",
-        "e_zeta",
-    ],
+    data=["e^rho", "e^rho_r"],
 )
 def _g_sup_rr_r(params, transforms, profiles, data, **kwargs):
-    data["g^rr_r"] = (
-        -data["sqrt(g)_r"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^rho"], cross(data["e_theta"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_theta_r"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_theta"], data["e_zeta_r"]))
-        - data["sqrt(g)_r"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^rho"], cross(data["e_theta"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_theta_r"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_theta"], data["e_zeta_r"]))
-    )
+    data["g^rr_r"] = 2 * dot(data["e^rho_r"], data["e^rho"])
     return data
 
 
@@ -808,39 +781,11 @@ def _g_sup_rr_r(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^rho",
-        "e^theta",
-        "sqrt(g)_r",
-        "sqrt(g)",
-        "e_rho",
-        "e_theta",
-        "e_zeta",
-        "e_rho_r",
-        "e_theta_r",
-        "e_zeta_r",
-    ],
+    data=["e^rho", "e^theta", "e^rho_r", "e^theta_r"],
 )
 def _g_sup_rt_r(params, transforms, profiles, data, **kwargs):
-    data["g^rt_r"] = (
-        -data["sqrt(g)_r"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^theta"], cross(data["e_theta"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_theta_r"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_zeta"], data["e_zeta_r"]))
-        - data["sqrt(g)_r"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^rho"], cross(data["e_zeta"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_zeta_r"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_zeta"], data["e_rho_r"]))
+    data["g^rt_r"] = dot(data["e^rho_r"], data["e^theta"]) + dot(
+        data["e^rho"], data["e^theta_r"]
     )
     return data
 
@@ -857,39 +802,11 @@ def _g_sup_rt_r(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^rho",
-        "e^zeta",
-        "sqrt(g)_r",
-        "sqrt(g)",
-        "e_rho",
-        "e_zeta",
-        "e_theta",
-        "e_rho_r",
-        "e_zeta_r",
-        "e_theta_r",
-    ],
+    data=["e^rho", "e^zeta", "e^rho_r", "e^zeta_r"],
 )
 def _g_sup_rz_r(params, transforms, profiles, data, **kwargs):
-    data["g^rz_r"] = (
-        -data["sqrt(g)_r"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^zeta"], cross(data["e_theta"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_theta_r"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_rho"], data["e_zeta_r"]))
-        - data["sqrt(g)_r"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^rho"], cross(data["e_rho"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_rho_r"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_rho"], data["e_theta_r"]))
+    data["g^rz_r"] = dot(data["e^rho_r"], data["e^zeta"]) + dot(
+        data["e^rho"], data["e^zeta_r"]
     )
     return data
 
@@ -906,37 +823,10 @@ def _g_sup_rz_r(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^theta",
-        "sqrt(g)_r",
-        "sqrt(g)",
-        "e_rho",
-        "e_rho_r",
-        "e_zeta_r",
-        "e_zeta",
-    ],
+    data=["e^theta", "e^theta_r"],
 )
 def _g_sup_tt_r(params, transforms, profiles, data, **kwargs):
-    data["g^tt_r"] = (
-        -data["sqrt(g)_r"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^theta"], cross(data["e_zeta"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_zeta_r"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_zeta"], data["e_rho_r"]))
-        - data["sqrt(g)_r"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^theta"], cross(data["e_zeta"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_zeta_r"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_zeta"], data["e_rho_r"]))
-    )
+    data["g^tt_r"] = 2 * dot(data["e^theta_r"], data["e^theta"])
     return data
 
 
@@ -952,39 +842,11 @@ def _g_sup_tt_r(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^theta",
-        "e^zeta",
-        "sqrt(g)_r",
-        "sqrt(g)",
-        "e_theta",
-        "e_zeta",
-        "e_rho",
-        "e_theta_r",
-        "e_zeta_r",
-        "e_rho_r",
-    ],
+    data=["e^theta", "e^zeta", "e^theta_r", "e^zeta_r"],
 )
 def _g_sup_tz_r(params, transforms, profiles, data, **kwargs):
-    data["g^tz_r"] = (
-        -data["sqrt(g)_r"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^zeta"], cross(data["e_zeta"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_zeta_r"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_zeta"], data["e_rho_r"]))
-        - data["sqrt(g)_r"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^theta"], cross(data["e_rho"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_rho_r"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_rho"], data["e_theta_r"]))
+    data["g^tz_r"] = dot(data["e^theta_r"], data["e^zeta"]) + dot(
+        data["e^theta"], data["e^zeta_r"]
     )
     return data
 
@@ -1001,37 +863,10 @@ def _g_sup_tz_r(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^zeta",
-        "sqrt(g)_r",
-        "sqrt(g)",
-        "e_theta",
-        "e_rho",
-        "e_theta_r",
-        "e_rho_r",
-    ],
+    data=["e^zeta", "e^zeta_r"],
 )
 def _g_sup_zz_r(params, transforms, profiles, data, **kwargs):
-    data["g^zz_r"] = (
-        -data["sqrt(g)_r"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^zeta"], cross(data["e_rho"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_rho_r"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_rho"], data["e_theta_r"]))
-        - data["sqrt(g)_r"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^zeta"], cross(data["e_rho"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_rho_r"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_rho"], data["e_theta_r"]))
-    )
+    data["g^zz_r"] = 2 * dot(data["e^zeta_r"], data["e^zeta"])
     return data
 
 
@@ -1047,37 +882,10 @@ def _g_sup_zz_r(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^rho",
-        "sqrt(g)_t",
-        "sqrt(g)",
-        "e_theta",
-        "e_theta_t",
-        "e_zeta_t",
-        "e_zeta",
-    ],
+    data=["e^rho", "e^rho_t"],
 )
 def _g_sup_rr_t(params, transforms, profiles, data, **kwargs):
-    data["g^rr_t"] = (
-        -data["sqrt(g)_t"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^rho"], cross(data["e_theta"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_theta_t"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_theta"], data["e_zeta_t"]))
-        - data["sqrt(g)_t"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^rho"], cross(data["e_theta"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_theta_t"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_theta"], data["e_zeta_t"]))
-    )
+    data["g^rr_t"] = 2 * dot(data["e^rho_t"], data["e^rho"])
     return data
 
 
@@ -1093,39 +901,11 @@ def _g_sup_rr_t(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^rho",
-        "e^theta",
-        "sqrt(g)_t",
-        "sqrt(g)",
-        "e_rho",
-        "e_theta",
-        "e_zeta",
-        "e_rho_t",
-        "e_theta_t",
-        "e_zeta_t",
-    ],
+    data=["e^rho", "e^theta", "e^rho_t", "e^theta_t"],
 )
 def _g_sup_rt_t(params, transforms, profiles, data, **kwargs):
-    data["g^rt_t"] = (
-        -data["sqrt(g)_t"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^theta"], cross(data["e_theta"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_theta_t"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_theta"], data["e_zeta_t"]))
-        - data["sqrt(g)_t"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^rho"], cross(data["e_zeta"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_zeta_t"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_zeta"], data["e_rho_t"]))
+    data["g^rt_t"] = dot(data["e^rho_t"], data["e^theta"]) + dot(
+        data["e^rho"], data["e^theta_t"]
     )
     return data
 
@@ -1142,39 +922,11 @@ def _g_sup_rt_t(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^rho",
-        "e^zeta",
-        "sqrt(g)_t",
-        "sqrt(g)",
-        "e_rho",
-        "e_zeta",
-        "e_theta",
-        "e_rho_t",
-        "e_zeta_t",
-        "e_theta_t",
-    ],
+    data=["e^rho", "e^zeta", "e^rho_t", "e^zeta_t"],
 )
 def _g_sup_rz_t(params, transforms, profiles, data, **kwargs):
-    data["g^rz_t"] = (
-        -data["sqrt(g)_t"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^zeta"], cross(data["e_theta"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_theta_t"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_theta"], data["e_zeta_t"]))
-        - data["sqrt(g)_t"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^rho"], cross(data["e_rho"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_rho_t"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_rho"], data["e_theta_t"]))
+    data["g^rz_t"] = dot(data["e^rho_t"], data["e^zeta"]) + dot(
+        data["e^rho"], data["e^zeta_t"]
     )
     return data
 
@@ -1191,37 +943,10 @@ def _g_sup_rz_t(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^theta",
-        "sqrt(g)_t",
-        "sqrt(g)",
-        "e_zeta",
-        "e_rho",
-        "e_zeta_t",
-        "e_rho_t",
-    ],
+    data=["e^theta", "e^theta_t"],
 )
 def _g_sup_tt_t(params, transforms, profiles, data, **kwargs):
-    data["g^tt_t"] = (
-        -data["sqrt(g)_t"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^theta"], cross(data["e_zeta"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_zeta_t"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_zeta"], data["e_rho_t"]))
-        - data["sqrt(g)_t"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^theta"], cross(data["e_zeta"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_zeta_t"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_zeta"], data["e_rho_t"]))
-    )
+    data["g^tt_t"] = 2 * dot(data["e^theta_t"], data["e^theta"])
     return data
 
 
@@ -1237,39 +962,11 @@ def _g_sup_tt_t(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^theta",
-        "e^zeta",
-        "sqrt(g)_t",
-        "sqrt(g)",
-        "e_theta",
-        "e_zeta",
-        "e_rho",
-        "e_theta_t",
-        "e_zeta_t",
-        "e_rho_t",
-    ],
+    data=["e^theta", "e^zeta", "e^theta_t", "e^zeta_t"],
 )
 def _g_sup_tz_t(params, transforms, profiles, data, **kwargs):
-    data["g^tz_t"] = (
-        -data["sqrt(g)_t"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^zeta"], cross(data["e_zeta"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_zeta_t"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_zeta"], data["e_rho_t"]))
-        - data["sqrt(g)_t"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^theta"], cross(data["e_rho"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_rho_t"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_rho"], data["e_theta_t"]))
+    data["g^tz_t"] = dot(data["e^theta_t"], data["e^zeta"]) + dot(
+        data["e^theta"], data["e^zeta_t"]
     )
     return data
 
@@ -1286,37 +983,10 @@ def _g_sup_tz_t(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^zeta",
-        "sqrt(g)_t",
-        "sqrt(g)",
-        "e_theta",
-        "e_rho",
-        "e_theta_t",
-        "e_rho_t",
-    ],
+    data=["e^zeta", "e^zeta_t"],
 )
 def _g_sup_zz_t(params, transforms, profiles, data, **kwargs):
-    data["g^zz_t"] = (
-        -data["sqrt(g)_t"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^zeta"], cross(data["e_rho"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_rho_t"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_rho"], data["e_theta_t"]))
-        - data["sqrt(g)_t"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^zeta"], cross(data["e_rho"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_rho_t"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_rho"], data["e_theta_t"]))
-    )
+    data["g^zz_t"] = 2 * dot(data["e^zeta_t"], data["e^zeta"])
     return data
 
 
@@ -1332,37 +1002,10 @@ def _g_sup_zz_t(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^rho",
-        "sqrt(g)_z",
-        "sqrt(g)",
-        "e_zeta",
-        "e_theta",
-        "e_zeta_z",
-        "e_theta_z",
-    ],
+    data=["e^rho", "e^rho_z"],
 )
 def _g_sup_rr_z(params, transforms, profiles, data, **kwargs):
-    data["g^rr_z"] = (
-        -data["sqrt(g)_z"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^rho"], cross(data["e_theta"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_theta_z"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_theta"], data["e_zeta_z"]))
-        - data["sqrt(g)_z"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^rho"], cross(data["e_theta"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_theta_z"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_theta"], data["e_zeta_z"]))
-    )
+    data["g^rr_z"] = 2 * dot(data["e^rho_z"], data["e^rho"])
     return data
 
 
@@ -1378,39 +1021,11 @@ def _g_sup_rr_z(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^rho",
-        "e^theta",
-        "sqrt(g)_z",
-        "sqrt(g)",
-        "e_rho",
-        "e_theta",
-        "e_zeta",
-        "e_rho_z",
-        "e_theta_z",
-        "e_zeta_z",
-    ],
+    data=["e^rho", "e^theta", "e^rho_z", "e^theta_z"],
 )
 def _g_sup_rt_z(params, transforms, profiles, data, **kwargs):
-    data["g^rt_z"] = (
-        -data["sqrt(g)_z"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^theta"], cross(data["e_theta"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_theta_z"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_theta"], data["e_zeta_z"]))
-        - data["sqrt(g)_z"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^rho"], cross(data["e_zeta"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_zeta_z"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_zeta"], data["e_rho_z"]))
+    data["g^rt_z"] = dot(data["e^rho_z"], data["e^theta"]) + dot(
+        data["e^rho"], data["e^theta_z"]
     )
     return data
 
@@ -1427,39 +1042,11 @@ def _g_sup_rt_z(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^rho",
-        "e^zeta",
-        "sqrt(g)_z",
-        "sqrt(g)",
-        "e_rho",
-        "e_zeta",
-        "e_theta",
-        "e_rho_z",
-        "e_zeta_z",
-        "e_theta_z",
-    ],
+    data=["e^rho", "e^zeta", "e^rho_z", "e^zeta_z"],
 )
 def _g_sup_rz_z(params, transforms, profiles, data, **kwargs):
-    data["g^rz_z"] = (
-        -data["sqrt(g)_z"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^zeta"], cross(data["e_theta"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_theta_z"], data["e_zeta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_theta"], data["e_zeta_z"]))
-        - data["sqrt(g)_z"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^rho"], cross(data["e_rho"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_rho_z"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^rho"], cross(data["e_rho"], data["e_theta_z"]))
+    data["g^rz_z"] = dot(data["e^rho_z"], data["e^zeta"]) + dot(
+        data["e^rho"], data["e^zeta_z"]
     )
     return data
 
@@ -1476,37 +1063,10 @@ def _g_sup_rz_z(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^theta",
-        "sqrt(g)_z",
-        "sqrt(g)",
-        "e_zeta",
-        "e_rho",
-        "e_zeta_z",
-        "e_rho_z",
-    ],
+    data=["e^theta", "e^theta_z"],
 )
 def _g_sup_tt_z(params, transforms, profiles, data, **kwargs):
-    data["g^tt_z"] = (
-        -data["sqrt(g)_z"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^theta"], cross(data["e_zeta"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_zeta_z"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_zeta"], data["e_rho_z"]))
-        - data["sqrt(g)_z"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^theta"], cross(data["e_zeta"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_zeta_z"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_zeta"], data["e_rho_z"]))
-    )
+    data["g^tt_z"] = 2 * dot(data["e^theta_z"], data["e^theta"])
     return data
 
 
@@ -1522,39 +1082,11 @@ def _g_sup_tt_z(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^theta",
-        "e^zeta",
-        "sqrt(g)_z",
-        "sqrt(g)",
-        "e_theta",
-        "e_zeta",
-        "e_rho",
-        "e_theta_z",
-        "e_zeta_z",
-        "e_rho_z",
-    ],
+    data=["e^theta", "e^zeta", "e^theta_z", "e^zeta_z"],
 )
 def _g_sup_tz_z(params, transforms, profiles, data, **kwargs):
-    data["g^tz_z"] = (
-        -data["sqrt(g)_z"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^zeta"], cross(data["e_zeta"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_zeta_z"], data["e_rho"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_zeta"], data["e_rho_z"]))
-        - data["sqrt(g)_z"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^theta"], cross(data["e_rho"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_rho_z"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^theta"], cross(data["e_rho"], data["e_theta_z"]))
+    data["g^tz_z"] = dot(data["e^theta_z"], data["e^zeta"]) + dot(
+        data["e^theta"], data["e^zeta_z"]
     )
     return data
 
@@ -1571,37 +1103,10 @@ def _g_sup_tz_z(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=[
-        "e^zeta",
-        "sqrt(g)_z",
-        "sqrt(g)",
-        "e_theta",
-        "e_rho",
-        "e_theta_z",
-        "e_rho_z",
-    ],
+    data=["e^zeta", "e^zeta_z"],
 )
 def _g_sup_zz_z(params, transforms, profiles, data, **kwargs):
-    data["g^zz_z"] = (
-        -data["sqrt(g)_z"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^zeta"], cross(data["e_rho"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_rho_z"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_rho"], data["e_theta_z"]))
-        - data["sqrt(g)_z"]
-        / data["sqrt(g)"] ** 2
-        * dot(data["e^zeta"], cross(data["e_rho"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_rho_z"], data["e_theta"]))
-        + 1
-        / data["sqrt(g)"]
-        * dot(data["e^zeta"], cross(data["e_rho"], data["e_theta_z"]))
-    )
+    data["g^zz_z"] = 2 * dot(data["e^zeta_z"], data["e^zeta"])
     return data
 
 


### PR DESCRIPTION
Fix bugs in g^rt_r and g^rz_r and maybe others.
Changes are just copied from github pull request #556

One bug on master is that https://github.com/PlasmaControl/DESC/blob/6b366f5b2e3b096615fd6b7f9129a2a0c5d6a483/desc/compute/_metric.py#L834 should be
$$e_{\theta} \times \partial_{\rho} e_{\zeta}$$
There might be more bugs on master, but I stopped looking after I found the above because they should be corrected by the changes in this PR.