### PR TITLE
add fix for older numpy versions when loading in equilibria

### DIFF
--- a/desc/basis.py
+++ b/desc/basis.py
@@ -42,11 +42,12 @@ class Basis(IOAble, ABC):
         """Do things after loading or changing resolution."""
         # Also recreates any attributes not in _io_attrs on load from input file.
         # See IOAble class docstring for more info.
-        # older numpy versions can load the modes with an extra dimension of len 1,
+        self._enforce_symmetry()
+        # in older numpy versions, self._modes after enforce_symmetry ends up
+        # with an extra dimension of len 1,
         # check and remove that unneeded first dimension if it is present
         if self.modes.ndim == 3:
             self.modes = self.modes.squeeze(axis=0)
-        self._enforce_symmetry()
         self._sort_modes()
         self._create_idx()
 

--- a/desc/basis.py
+++ b/desc/basis.py
@@ -71,6 +71,10 @@ class Basis(IOAble, ABC):
 
     def _sort_modes(self):
         """Sorts modes for use with FFT."""
+        # older numpy versions can load the modes with an extra dimension of len 1,
+        # remove that unneeded first dimension
+        if self.modes.ndim == 3:
+            self.modes = self.modes.squeeze(axis=0)
         sort_idx = np.lexsort((self.modes[:, 1], self.modes[:, 0], self.modes[:, 2]))
         self._modes = self.modes[sort_idx]
 

--- a/desc/basis.py
+++ b/desc/basis.py
@@ -42,6 +42,10 @@ class Basis(IOAble, ABC):
         """Do things after loading or changing resolution."""
         # Also recreates any attributes not in _io_attrs on load from input file.
         # See IOAble class docstring for more info.
+        # older numpy versions can load the modes with an extra dimension of len 1,
+        # check and remove that unneeded first dimension if it is present
+        if self.modes.ndim == 3:
+            self.modes = self.modes.squeeze(axis=0)
         self._enforce_symmetry()
         self._sort_modes()
         self._create_idx()
@@ -71,10 +75,6 @@ class Basis(IOAble, ABC):
 
     def _sort_modes(self):
         """Sorts modes for use with FFT."""
-        # older numpy versions can load the modes with an extra dimension of len 1,
-        # remove that unneeded first dimension
-        if self.modes.ndim == 3:
-            self.modes = self.modes.squeeze(axis=0)
         sort_idx = np.lexsort((self.modes[:, 1], self.modes[:, 0], self.modes[:, 2]))
         self._modes = self.modes[sort_idx]
 

--- a/desc/basis.py
+++ b/desc/basis.py
@@ -43,11 +43,6 @@ class Basis(IOAble, ABC):
         # Also recreates any attributes not in _io_attrs on load from input file.
         # See IOAble class docstring for more info.
         self._enforce_symmetry()
-        # in older numpy versions, self._modes after enforce_symmetry ends up
-        # with an extra dimension of len 1,
-        # check and remove that unneeded first dimension if it is present
-        if self.modes.ndim == 3:
-            self.modes = self.modes.squeeze(axis=0)
         self._sort_modes()
         self._create_idx()
 
@@ -64,13 +59,17 @@ class Basis(IOAble, ABC):
             None,
         ], f"Unknown symmetry type {self.sym}"
         if self.sym in ["cos", "cosine"]:  # cos(m*t-n*z) symmetry
-            self._modes = self.modes[sign(self.modes[:, 1]) == sign(self.modes[:, 2])]
+            self._modes = self.modes[
+                np.asarray(sign(self.modes[:, 1]) == sign(self.modes[:, 2]))
+            ]
         elif self.sym in ["sin", "sine"]:  # sin(m*t-n*z) symmetry
-            self._modes = self.modes[sign(self.modes[:, 1]) != sign(self.modes[:, 2])]
+            self._modes = self.modes[
+                np.asarray(sign(self.modes[:, 1]) != sign(self.modes[:, 2]))
+            ]
         elif self.sym == "even":  # even powers of rho
-            self._modes = self.modes[self.modes[:, 0] % 2 == 0]
+            self._modes = self.modes[np.asarray(self.modes[:, 0] % 2 == 0)]
         elif self.sym == "cos(t)":  # cos(m*t) terms only
-            self._modes = self.modes[sign(self.modes[:, 1]) >= 0]
+            self._modes = self.modes[np.asarray(sign(self.modes[:, 1]) >= 0)]
         elif self.sym is None:
             self._sym = False
 


### PR DESCRIPTION
For older numpy versions (confirmed 1.20.3 and 1.22.3), when loading in an equilibrium you get an error
```python
eq = desc.io.load('desc/examples/ARIES-CS_output.h5')[-1]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/scratch/gpfs/pk2354/DESC_GX_2/desc/io/equilibrium_io.py", line 64, in load
    reader.read_obj(obj)
  File "/scratch/gpfs/pk2354/DESC_GX_2/desc/io/hdf5_io.py", line 145, in read_obj
    setattr(obj, attr, self.read_list(where=loc[attr]))
  File "/scratch/gpfs/pk2354/DESC_GX_2/desc/io/hdf5_io.py", line 250, in read_list
    cls.load(
  File "/scratch/gpfs/pk2354/DESC_GX_2/desc/io/equilibrium_io.py", line 199, in load
    reader.read_obj(self)
  File "/scratch/gpfs/pk2354/DESC_GX_2/desc/io/hdf5_io.py", line 155, in read_obj
    cls.load(
  File "/scratch/gpfs/pk2354/DESC_GX_2/desc/io/equilibrium_io.py", line 203, in load
    self._set_up()
  File "/scratch/gpfs/pk2354/DESC_GX_2/desc/basis.py", line 46, in _set_up
    self._sort_modes()
  File "/scratch/gpfs/pk2354/DESC_GX_2/desc/basis.py", line 75, in _sort_modes
    self._modes = self.modes[sort_idx]
IndexError: index 2 is out of bounds for axis 0 with size 1
```

Error stems from the fact that `self.modes.shape` is `(1,num_modes,3)` instead of just `(num_modes,3)` which it is for newer (1.23.1 and above at least) numpy versions. This shape change occurs during the `enforce_symmetry` call inside the `Basis` `_set_up` function call, due to the indexing of self.modes with the sign of modes

This comes from the fact that in older numpy versions, indexing an array with a non-tuple (like a list or a JAX devicearray which we do in `enforce_symmetry`) resulted in the behavior being interpreted like a tuple. `arr[tuple(seq)]` starting in newer versions, this behavior was changed to to default to an array like `arr[np.asarray(seq)]` (https://github.com/google/jax/issues/4564 has good example of this)

Fix is to just always cast the indexing sequence to a numpy array, which works for both older versions and newer versions (as it is the default behavior in newer versions anyways)
