### PR TITLE
Change parameters in cond for surface integrals for older jax versions (power9)

### DIFF
--- a/desc/compute/utils.py
+++ b/desc/compute/utils.py
@@ -827,7 +827,7 @@ def surface_integrals_map(grid, surface_label="rho", expand_out=True):
         has_endpoint_dupe,
         lambda _: put(masks, jnp.array([0, -1]), masks[0] | masks[-1]),
         lambda _: masks,
-        operand=None
+        operand=None,
     )
     spacing = jnp.prod(spacing, axis=1)
 

--- a/desc/compute/utils.py
+++ b/desc/compute/utils.py
@@ -825,8 +825,9 @@ def surface_integrals_map(grid, surface_label="rho", expand_out=True):
     # previous paragraph.
     masks = cond(
         has_endpoint_dupe,
-        lambda: put(masks, jnp.array([0, -1]), masks[0] | masks[-1]),
-        lambda: masks,
+        lambda _: put(masks, jnp.array([0, -1]), masks[0] | masks[-1]),
+        lambda _: masks,
+        operand=None
     )
     spacing = jnp.prod(spacing, axis=1)
 


### PR DESCRIPTION
The surface integrals routine have use the cond function
`    masks = cond(
        has_endpoint_dupe,
        lambda: put(masks, jnp.array([0, -1]), masks[0] | masks[-1]),
        lambda: masks,
    )
`
But in older versions of jax (like the ones used for the traverse builds), cond requires the parameter "operand" which are arguments to the functions. The resulting fix is 

`    masks = cond(
        has_endpoint_dupe,
        lambda _: put(masks, jnp.array([0, -1]), masks[0] | masks[-1]),
        lambda _: masks,
        operand=None
    )
`
Which works since both lambda functions don't take in any arguments. This also works for the newer versions of jax.