### PR TITLE
Increase radial resolution of default grid for stability objectives

### DIFF
--- a/desc/objectives/_stability.py
+++ b/desc/objectives/_stability.py
@@ -94,11 +94,12 @@ class MercierStability(_Objective):
         eq = eq or self._eq
         if self._grid is None:
             grid = LinearGrid(
+                L=eq.L_grid,
                 M=eq.M_grid,
                 N=eq.N_grid,
                 NFP=eq.NFP,
                 sym=eq.sym,
-                rho=np.linspace(1 / 5, 1, 5),
+                axis=False,
             )
         else:
             grid = self._grid
@@ -296,11 +297,12 @@ class MagneticWell(_Objective):
         eq = eq or self._eq
         if self._grid is None:
             grid = LinearGrid(
+                L=eq.L_grid,
                 M=eq.M_grid,
                 N=eq.N_grid,
                 NFP=eq.NFP,
                 sym=eq.sym,
-                rho=np.linspace(1 / 5, 1, 5),
+                axis=False,
             )
         else:
             grid = self._grid

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -874,7 +874,6 @@ def test_constrained_AL_lsq():
 
     constraints = (
         FixBoundaryR(eq=eq, modes=[0, 0, 0]),  # fix specified major axis position
-        FixBoundaryZ(eq=eq),  # fix Z shape but not R
         FixPressure(eq=eq),  # fix pressure profile
         FixIota(eq=eq),  # fix rotational transform profile
         FixPsi(eq=eq),  # fix total toroidal magnetic flux
@@ -917,7 +916,6 @@ def test_constrained_AL_lsq():
 
 @pytest.mark.slow
 @pytest.mark.regression
-@pytest.mark.xfail
 def test_constrained_AL_scalar():
     """Tests that the augmented Lagrangian constrained optimizer does something."""
     eq = desc.examples.get("SOLOVEV")


### PR DESCRIPTION
Previously we only used 5 points regardless of the equilibrium resolution, and in my optimizations I'm often finding that's way too low, with the magnetic well dipping below 0 in between the nodes.