### PR TITLE
Move InputReader out of desc.io to allow GPU to initialize correctly

### DIFF
--- a/desc/__main__.py
+++ b/desc/__main__.py
@@ -2,7 +2,7 @@
 
 import sys
 
-from desc.io import InputReader
+from desc.input_reader import InputReader
 
 
 def main(cl_args=sys.argv[1:]):

--- a/desc/input_reader.py
+++ b/desc/input_reader.py
@@ -13,7 +13,9 @@ from termcolor import colored
 
 from desc import set_device
 
-from .equilibrium_io import load
+# shouldn't import anything else from DESC here, since that will initialize JAX
+# before we have a chance to parse user inputs to see if they want to use GPU
+# instead, do local imports where needed.
 
 
 class InputReader:
@@ -818,6 +820,8 @@ class InputReader:
         f = open(outfile, "w+")
 
         f.seek(0)
+
+        from desc.io.equilibrium_io import load
 
         eq = load(infile)
         try:

--- a/desc/io/__init__.py
+++ b/desc/io/__init__.py
@@ -1,9 +1,14 @@
 """Functions and classes for reading and writing DESC data."""
 
+# InputReader lives outside this module for import ordering reasons, so we can
+# import InputReader in __main__ without importing equilibrium_io which imports JAX
+# stuff potentially before we've set the GPU correctly.
+# We include a link to it here for backwards compatibility
+from desc.input_reader import InputReader
+
 from .ascii_io import read_ascii, write_ascii
 from .equilibrium_io import IOAble, load
 from .hdf5_io import hdf5Reader, hdf5Writer
-from .input_reader import InputReader
 from .pickle_io import PickleReader, PickleWriter
 
 __all__ = ["InputReader", "load"]

--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -5,7 +5,7 @@ Command Line Interface
 DESC is executed with the following command line syntax:
 
 .. argparse::
-   :module: desc.io.input_reader
+   :module: desc.input_reader
    :func: get_parser
    :prog: desc
    :nodefault:


### PR DESCRIPTION
Resolves #663 

Tested it manually on della, there's not really any way to test it automatically.