### PR TITLE
Add docs links to github source

### DIFF
--- a/devtools/dev-requirements.txt
+++ b/devtools/dev-requirements.txt
@@ -7,6 +7,8 @@ sphinx > 3.0.0
 sphinx-argparse
 sphinx_copybutton
 sphinx-rtd-theme >= 1.0, < 2.0
+sphinx-github-style >= 1.0, <= 1.1
+
 
 # linting
 black == 22.10.0

--- a/devtools/dev-requirements_conda.yml
+++ b/devtools/dev-requirements_conda.yml
@@ -27,6 +27,8 @@ dependencies:
   - sphinx-argparse
   - sphinx-copybutton
   - sphinx_rtd_theme >= 1.0, < 2.0
+  - pip:
+    - sphinx-github-style >= 1.0, <= 1.1
 
   # linting
   - black = 22.10.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
-    "sphinx.ext.viewcode",
+    "sphinx_github_style",
     "sphinx.ext.githubpages",
     "nbsphinx",
     "sphinx.ext.napoleon",
@@ -50,6 +50,12 @@ extensions = [
     "sphinxarg.ext",
     "sphinx_copybutton",
 ]
+# options for sphinx_github_style
+top_level = "desc"
+linkcode_blob = "head"
+linkcode_url = r"https://github.com/PlasmaControl/DESC"
+linkcode_link_text = "Source"
+
 # numpydoc_class_members_toctree = False
 # Napoleon settings
 napoleon_google_docstring = False


### PR DESCRIPTION
Uses https://github.com/TDKorn/sphinx-github-style to create links to the source on github from the API docs.

Resolves #673 