### PR TITLE
fix bug in PlasmaVesselDistance compute_scaled 

### DIFF
--- a/desc/objectives/_geometry.py
+++ b/desc/objectives/_geometry.py
@@ -565,10 +565,20 @@ class PlasmaVesselDistance(_Objective):
             grid=plasma_grid,
             has_axis=plasma_grid.axis.size or surface_grid.axis.size,
         )
+
+        # compute returns points on the grid of the surface
+        # (so size surface_grid.num_nodes)
+        # so set quad_weights to the surface grid
+        # to avoid it being incorrectly set to the plasma_grid size
+        # in the super build
+        w = surface_grid.weights
+        w *= jnp.sqrt(surface_grid.num_nodes)
+
         self._constants = {
             "transforms": transforms,
             "profiles": profiles,
             "surface_coords": self._surface_coords,
+            "quad_weights": w,
         }
 
         timer.stop("Precomputing transforms")

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -675,6 +675,8 @@ def test_plasma_vessel_distance():
     d = obj.compute_unscaled(*obj.xs(eq))
     assert abs(d.min() - (a_s - a_p)) < 1e-14
     assert abs(d.max() - (a_s - a_p)) < surf_grid.spacing[0, 2] * R0
+    # ensure that it works (dimension-wise) when compute_scaled is called
+    _ = obj.compute_scaled(*obj.xs(eq))
 
     grid = LinearGrid(L=3, M=3, N=3)
     eq = Equilibrium()


### PR DESCRIPTION
`PlasmaVesselDistance` has `dim_f` equal to `surface_grid.num_nodes`, but when the `quad_weights` are set in the `super().build` call, it uses the `constants["transforms"]["grid"]` to find what the weight sizes should be, and so incorrectly uses the `plasma_grid` size

this fixes the error by setting quad_weights in the `PlasmaVesselDistance` build method