### PR TITLE
fix plot_3d trying to connect end surfaces for zeta not 2pi cases

### DIFF
--- a/desc/plotting.py
+++ b/desc/plotting.py
@@ -854,7 +854,10 @@ def plot_3d(
 
     if grid.num_rho == 1:
         n1, n2 = grid.num_theta, grid.num_zeta
-        p1, p2 = True, True
+        if not grid.nodes[-1][2] == 2 * np.pi:
+            p1, p2 = True, False
+        else:
+            p1, p2 = True, True
     elif grid.num_theta == 1:
         n1, n2 = grid.num_rho, grid.num_zeta
         p1, p2 = False, True


### PR DESCRIPTION
![image](https://github.com/PlasmaControl/DESC/assets/102380275/4d4057ae-a39f-4adc-98b1-0ab4eaefbf41)

For zeta not up to 2pi, the plot_3d will not try to connect end surfaces together. Works the same for the 2pi case. For the issue #717 .