### PR TITLE
Remove unneeded args from objective getters

### DIFF
--- a/desc/continuation.py
+++ b/desc/continuation.py
@@ -98,11 +98,7 @@ def _solve_axisym(
             deltas = get_deltas({"surface": surf_i}, {"surface": surf_i2})
             surf_i = surf_i2
 
-        constraints_i = get_fixed_boundary_constraints(
-            eq=eqi,
-            iota=eqi.iota,
-            kinetic=eqi.electron_temperature,
-        )
+        constraints_i = get_fixed_boundary_constraints(eq=eqi)
         objective_i = get_equilibrium_objective(eq=eqi, mode=objective)
 
         if verbose:
@@ -227,11 +223,7 @@ def _add_pressure(
         deltas["p_l"] *= pres_step
         pres_ratio += pres_step
 
-        constraints_i = get_fixed_boundary_constraints(
-            eq=eqi,
-            iota=eqi.iota,
-            kinetic=eqi.electron_temperature,
-        )
+        constraints_i = get_fixed_boundary_constraints(eq=eqi)
         objective_i = get_equilibrium_objective(eq=eqi, mode=objective)
 
         if verbose:
@@ -360,11 +352,7 @@ def _add_shaping(
             deltas["Zb_lmn"] *= bdry_step
         bdry_ratio += bdry_step
 
-        constraints_i = get_fixed_boundary_constraints(
-            eq=eqi,
-            iota=eqi.iota,
-            kinetic=eqi.electron_temperature,
-        )
+        constraints_i = get_fixed_boundary_constraints(eq=eqi)
         objective_i = get_equilibrium_objective(eq=eqi, mode=objective)
 
         if verbose:
@@ -662,11 +650,7 @@ def solve_continuation(  # noqa: C901
     if not isinstance(optimizer, Optimizer):
         optimizer = Optimizer(optimizer)
     objective_i = get_equilibrium_objective(eq=eqfam[0], mode=objective)
-    constraints_i = get_fixed_boundary_constraints(
-        eq=eqfam[0],
-        iota=objective != "vacuum" and eqfam[0].iota is not None,
-        kinetic=eqfam[0].electron_temperature is not None,
-    )
+    constraints_i = get_fixed_boundary_constraints(eq=eqfam[0])
 
     ii = 0
     nn = len(eqfam)
@@ -713,11 +697,7 @@ def solve_continuation(  # noqa: C901
             # TODO: pass Jx if available
             eqp = eqfam[ii - 1].copy()
             objective_i = get_equilibrium_objective(eq=eqp, mode=objective)
-            constraints_i = get_fixed_boundary_constraints(
-                eq=eqp,
-                iota=eqp.iota,
-                kinetic=eqp.electron_temperature,
-            )
+            constraints_i = get_fixed_boundary_constraints(eq=eqp)
             eqp.change_resolution(**eqi.resolution)
             eqp.perturb(
                 objective=objective_i,
@@ -737,11 +717,7 @@ def solve_continuation(  # noqa: C901
         if not stop:
             # TODO: add ability to rebind objectives
             objective_i = get_equilibrium_objective(eq=eqi, mode=objective)
-            constraints_i = get_fixed_boundary_constraints(
-                eq=eqi,
-                iota=eqi.iota,
-                kinetic=eqi.electron_temperature,
-            )
+            constraints_i = get_fixed_boundary_constraints(eq=eqi)
             eqi.solve(
                 optimizer=optimizer,
                 objective=objective_i,

--- a/desc/equilibrium/equilibrium.py
+++ b/desc/equilibrium/equilibrium.py
@@ -1704,11 +1704,7 @@ class Equilibrium(IOAble, Optimizable):
 
         """
         if constraints is None:
-            constraints = get_fixed_boundary_constraints(
-                eq=self,
-                iota=objective != "vacuum" and self.iota is not None,
-                kinetic=self.electron_temperature is not None,
-            )
+            constraints = get_fixed_boundary_constraints(eq=self)
         if not isinstance(objective, ObjectiveFunction):
             objective = get_equilibrium_objective(eq=self, mode=objective)
         if not isinstance(optimizer, Optimizer):
@@ -1809,11 +1805,7 @@ class Equilibrium(IOAble, Optimizable):
         if not isinstance(optimizer, Optimizer):
             optimizer = Optimizer(optimizer)
         if constraints is None:
-            constraints = get_fixed_boundary_constraints(
-                eq=self,
-                iota=self.iota is not None,
-                kinetic=self.electron_temperature is not None,
-            )
+            constraints = get_fixed_boundary_constraints(eq=self)
             constraints = (ForceBalance(eq=self), *constraints)
         if not isinstance(constraints, (list, tuple)):
             constraints = tuple([constraints])
@@ -2047,17 +2039,9 @@ class Equilibrium(IOAble, Optimizable):
             objective = get_equilibrium_objective(eq=self)
         if constraints is None:
             if "Ra_n" in deltas or "Za_n" in deltas:
-                constraints = get_fixed_axis_constraints(
-                    eq=self,
-                    iota=self.iota is not None,
-                    kinetic=self.electron_temperature is not None,
-                )
+                constraints = get_fixed_axis_constraints(eq=self)
             else:
-                constraints = get_fixed_boundary_constraints(
-                    eq=self,
-                    iota=self.iota is not None,
-                    kinetic=self.electron_temperature is not None,
-                )
+                constraints = get_fixed_boundary_constraints(eq=self)
 
         eq = perturb(
             self,

--- a/desc/objectives/getters.py
+++ b/desc/objectives/getters.py
@@ -87,9 +87,9 @@ def get_fixed_axis_constraints(eq, profiles=True, normalize=True):
     Parameters
     ----------
     eq : Equilibrium
-        Equilibrium being constrained.
+        Equilibrium to constrain.
     profiles : bool
-        Whether to also return constraints to fix input profiles.
+        If True, also include constraints to fix all profiles assigned to equilibrium.
     normalize : bool
         Whether to apply constraints in normalized units.
 
@@ -120,9 +120,9 @@ def get_fixed_boundary_constraints(eq, profiles=True, normalize=True):
     Parameters
     ----------
     eq : Equilibrium
-        Equilibrium to constraint.
+        Equilibrium to constrain.
     profiles : bool
-        Whether to also return constraints to fix input profiles.
+        If True, also include constraints to fix all profiles assigned to equilibrium.
     normalize : bool
         Whether to apply constraints in normalized units.
 
@@ -168,7 +168,7 @@ def get_NAE_constraints(
     order : int
         order (in rho) of near-axis behavior to constrain
     profiles : bool
-        Whether to also return constraints to fix input profiles.
+        If True, also include constraints to fix all profiles assigned to equilibrium.
     normalize : bool
         Whether to apply constraints in normalized units.
     N : int

--- a/desc/objectives/getters.py
+++ b/desc/objectives/getters.py
@@ -30,6 +30,17 @@ from .linear_objectives import (
 from .nae_utils import calc_zeroth_order_lambda, make_RZ_cons_1st_order
 from .objective_funs import ObjectiveFunction
 
+_PROFILE_CONSTRAINTS = {
+    "pressure": FixPressure,
+    "iota": FixIota,
+    "current": FixCurrent,
+    "electron_density": FixElectronDensity,
+    "electron_temperature": FixElectronTemperature,
+    "ion_temperature": FixIonTemperature,
+    "atomic_number": FixAtomicNumber,
+    "anisotropy": FixAnisotropy,
+}
+
 
 def get_equilibrium_objective(eq, mode="force", normalize=True):
     """Get the objective function for a typical force balance equilibrium problem.
@@ -70,9 +81,7 @@ def get_equilibrium_objective(eq, mode="force", normalize=True):
     return ObjectiveFunction(objectives)
 
 
-def get_fixed_axis_constraints(
-    eq, profiles=True, iota=True, kinetic=False, anisotropy=False, normalize=True
-):
+def get_fixed_axis_constraints(eq, profiles=True, normalize=True):
     """Get the constraints necessary for a fixed-axis equilibrium problem.
 
     Parameters
@@ -81,12 +90,6 @@ def get_fixed_axis_constraints(
         Equilibrium being constrained.
     profiles : bool
         Whether to also return constraints to fix input profiles.
-    iota : bool
-        Whether to add FixIota or FixCurrent as a constraint.
-    kinetic : bool
-        Whether to add constraints to fix kinetic profiles or pressure
-    anisotropy : bool
-        Whether to add constraint to fix anisotropic pressure.
     normalize : bool
         Whether to apply constraints in normalized units.
 
@@ -102,44 +105,16 @@ def get_fixed_axis_constraints(
         FixPsi(eq=eq, normalize=normalize, normalize_target=normalize),
     )
     if profiles:
-        if kinetic:
-            constraints += (
-                FixElectronDensity(
-                    eq=eq, normalize=normalize, normalize_target=normalize
-                ),
-                FixElectronTemperature(
-                    eq=eq, normalize=normalize, normalize_target=normalize
-                ),
-                FixIonTemperature(
-                    eq=eq, normalize=normalize, normalize_target=normalize
-                ),
-                FixAtomicNumber(eq=eq, normalize=normalize, normalize_target=normalize),
-            )
-        else:
-            constraints += (
-                FixPressure(eq=eq, normalize=normalize, normalize_target=normalize),
-            )
-            if anisotropy:
+        for name, con in _PROFILE_CONSTRAINTS.items():
+            if getattr(eq, name) is not None:
                 constraints += (
-                    FixAnisotropy(
-                        eq=eq, normalize=normalize, normalize_target=normalize
-                    ),
+                    con(eq=eq, normalize=normalize, normalize_target=normalize),
                 )
 
-        if iota:
-            constraints += (
-                FixIota(eq=eq, normalize=normalize, normalize_target=normalize),
-            )
-        else:
-            constraints += (
-                FixCurrent(eq=eq, normalize=normalize, normalize_target=normalize),
-            )
     return constraints
 
 
-def get_fixed_boundary_constraints(
-    eq, profiles=True, iota=True, kinetic=False, anisotropy=False, normalize=True
-):
+def get_fixed_boundary_constraints(eq, profiles=True, normalize=True):
     """Get the constraints necessary for a typical fixed-boundary equilibrium problem.
 
     Parameters
@@ -148,12 +123,6 @@ def get_fixed_boundary_constraints(
         Equilibrium to constraint.
     profiles : bool
         Whether to also return constraints to fix input profiles.
-    iota : bool
-        Whether to add FixIota or FixCurrent as a constraint.
-    kinetic : bool
-        Whether to also fix kinetic profiles.
-    anisotropy : bool
-        Whether to add constraint to fix anisotropic pressure.
     normalize : bool
         Whether to apply constraints in normalized units.
 
@@ -169,37 +138,12 @@ def get_fixed_boundary_constraints(
         FixPsi(eq=eq, normalize=normalize, normalize_target=normalize),
     )
     if profiles:
-        if kinetic:
-            constraints += (
-                FixElectronDensity(
-                    eq=eq, normalize=normalize, normalize_target=normalize
-                ),
-                FixElectronTemperature(
-                    eq=eq, normalize=normalize, normalize_target=normalize
-                ),
-                FixIonTemperature(
-                    eq=eq, normalize=normalize, normalize_target=normalize
-                ),
-                FixAtomicNumber(eq=eq, normalize=normalize, normalize_target=normalize),
-            )
-        else:
-            constraints += (
-                FixPressure(eq=eq, normalize=normalize, normalize_target=normalize),
-            )
-            if anisotropy:
+        for name, con in _PROFILE_CONSTRAINTS.items():
+            if getattr(eq, name) is not None:
                 constraints += (
-                    FixAnisotropy(
-                        eq=eq, normalize=normalize, normalize_target=normalize
-                    ),
+                    con(eq=eq, normalize=normalize, normalize_target=normalize),
                 )
-        if iota:
-            constraints += (
-                FixIota(eq=eq, normalize=normalize, normalize_target=normalize),
-            )
-        else:
-            constraints += (
-                FixCurrent(eq=eq, normalize=normalize, normalize_target=normalize),
-            )
+
     return constraints
 
 
@@ -208,9 +152,6 @@ def get_NAE_constraints(
     qsc_eq,
     order=1,
     profiles=True,
-    iota=False,
-    kinetic=False,
-    anisotropy=False,
     normalize=True,
     N=None,
     fix_lambda=False,
@@ -228,12 +169,6 @@ def get_NAE_constraints(
         order (in rho) of near-axis behavior to constrain
     profiles : bool
         Whether to also return constraints to fix input profiles.
-    iota : bool
-        Whether to add `FixIota` or `FixCurrent` as a constraint.
-    kinetic : bool
-        Whether to also fix kinetic profiles.
-    anisotropy : bool
-        Whether to add constraint to fix anisotropic pressure.
     normalize : bool
         Whether to apply constraints in normalized units.
     N : int
@@ -256,43 +191,14 @@ def get_NAE_constraints(
         FixAxisZ(eq=desc_eq, normalize=normalize, normalize_target=normalize),
         FixPsi(eq=desc_eq, normalize=normalize, normalize_target=normalize),
     )
+
     if profiles:
-        if kinetic:
-            constraints += (
-                FixElectronDensity(
-                    eq=desc_eq, normalize=normalize, normalize_target=normalize
-                ),
-                FixElectronTemperature(
-                    eq=desc_eq, normalize=normalize, normalize_target=normalize
-                ),
-                FixIonTemperature(
-                    eq=desc_eq, normalize=normalize, normalize_target=normalize
-                ),
-                FixAtomicNumber(
-                    eq=desc_eq, normalize=normalize, normalize_target=normalize
-                ),
-            )
-        else:
-            constraints += (
-                FixPressure(
-                    eq=desc_eq, normalize=normalize, normalize_target=normalize
-                ),
-            )
-            if anisotropy:
+        for name, con in _PROFILE_CONSTRAINTS.items():
+            if getattr(desc_eq, name) is not None:
                 constraints += (
-                    FixAnisotropy(
-                        eq=desc_eq, normalize=normalize, normalize_target=normalize
-                    ),
+                    con(eq=desc_eq, normalize=normalize, normalize_target=normalize),
                 )
 
-        if iota:
-            constraints += (
-                FixIota(eq=desc_eq, normalize=normalize, normalize_target=normalize),
-            )
-        else:
-            constraints += (
-                FixCurrent(eq=desc_eq, normalize=normalize, normalize_target=normalize),
-            )
     if fix_lambda or (fix_lambda >= 0 and type(fix_lambda) is int):
         L_axis_constraints, _, _ = calc_zeroth_order_lambda(
             qsc=qsc_eq, desc_eq=desc_eq, N=N

--- a/desc/optimize/_constraint_wrappers.py
+++ b/desc/optimize/_constraint_wrappers.py
@@ -473,11 +473,7 @@ class ProximalProjection(ObjectiveFunction):
         timer.start("Proximal projection build")
 
         self._eq = eq
-        self._linear_constraints = get_fixed_boundary_constraints(
-            eq=eq,
-            iota=self._eq.iota,
-            kinetic=self._eq.electron_temperature,
-        )
+        self._linear_constraints = get_fixed_boundary_constraints(eq=eq)
         self._linear_constraints = maybe_add_self_consistency(
             self._eq, self._linear_constraints
         )

--- a/desc/perturbations.py
+++ b/desc/perturbations.py
@@ -543,9 +543,7 @@ def optimal_perturb(  # noqa: C901 - FIXME: break this up into simpler pieces
         print("Number of objectives: {}".format(objective_g.dim_f))
 
     # FIXME: generalize to other constraints
-    constraints = get_fixed_boundary_constraints(
-        eq=eq, iota=eq.iota is not None, kinetic=eq.electron_temperature is not None
-    )
+    constraints = get_fixed_boundary_constraints(eq=eq)
     constraints = maybe_add_self_consistency(eq=eq, constraints=constraints)
     for con in constraints:
         if not con.built:

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -175,7 +175,7 @@ class VMECIO:
 
         constraints = get_fixed_axis_constraints(
             profiles=False, eq=eq
-        ) + get_fixed_boundary_constraints(iota=eq.iota, eq=eq)
+        ) + get_fixed_boundary_constraints(eq=eq)
         constraints = maybe_add_self_consistency(eq, constraints)
         objective = ObjectiveFunction(constraints, verbose=0)
         objective.build()

--- a/docs/notebooks/DESC_Fixed_Axis_NAE_Constraint.ipynb
+++ b/docs/notebooks/DESC_Fixed_Axis_NAE_Constraint.ipynb
@@ -220,7 +220,7 @@
    ],
    "source": [
     "# get the fixed-boundary constraints, which include also fixing the pressure and fixing the current profile (iota=False flag means fix current)\n",
-    "constraints = get_fixed_boundary_constraints(eq=desc_eq, iota=False)\n",
+    "constraints = get_fixed_boundary_constraints(eq=desc_eq)\n",
     "print(constraints)\n",
     "\n",
     "# solve the equilibrium\n",
@@ -554,7 +554,7 @@
     "\n",
     "eq_NAE = eq_fit.copy()\n",
     "# this has all the constraints we need, iota=False specifies we want to fix current instead of iota\n",
-    "constraints = get_NAE_constraints(eq_NAE, qsc_eq, iota=False, order=1)\n",
+    "constraints = get_NAE_constraints(eq_NAE, qsc_eq, order=1)\n",
     "\n",
     "eq_NAE.solve(\n",
     "    verbose=3,\n",

--- a/docs/notebooks/Toroidal_current_constraint.ipynb
+++ b/docs/notebooks/Toroidal_current_constraint.ipynb
@@ -203,7 +203,7 @@
    },
    "outputs": [],
    "source": [
-    "constraints = get_fixed_boundary_constraints(eq=eq, profiles=True, iota=False)"
+    "constraints = get_fixed_boundary_constraints(eq=eq, profiles=True)"
    ]
   },
   {
@@ -522,7 +522,7 @@
    "outputs": [],
    "source": [
     "objective = ObjectiveFunction(ForceBalance(eq=eq))\n",
-    "constraints = get_fixed_boundary_constraints(eq=eq, profiles=True, iota=False)"
+    "constraints = get_fixed_boundary_constraints(eq=eq, profiles=True)"
    ]
   },
   {

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1301,7 +1301,7 @@ class TestBootstrapObjectives:
         eq.solve(
             verbose=3,
             ftol=1e-8,
-            constraints=get_fixed_boundary_constraints(eq=eq, kinetic=True),
+            constraints=get_fixed_boundary_constraints(eq=eq),
             optimizer=Optimizer("lsq-exact"),
             objective=ObjectiveFunction(objectives=ForceBalance(eq=eq)),
         )
@@ -1413,7 +1413,7 @@ class TestBootstrapObjectives:
         eq.solve(
             verbose=3,
             ftol=1e-8,
-            constraints=get_fixed_boundary_constraints(eq=eq, kinetic=True, iota=False),
+            constraints=get_fixed_boundary_constraints(eq=eq),
             optimizer=Optimizer("lsq-exact"),
             objective=ObjectiveFunction(objectives=ForceBalance(eq=eq)),
         )

--- a/tests/test_compute_funs.py
+++ b/tests/test_compute_funs.py
@@ -1292,7 +1292,8 @@ def test_compute_everything():
                     np.testing.assert_allclose(
                         actual=this_branch_data[p][name],
                         desired=master_data[p][name],
-                        atol=1e-12,
+                        atol=1e-10,
+                        rtol=1e-10,
                         err_msg=f"Parameterization: {p}. Name: {name}.",
                     )
                 except AssertionError as e:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -89,7 +89,7 @@ def test_SOLOVEV_anisotropic_results(SOLOVEV):
     eq.anisotropy = anisotropy
 
     obj = ObjectiveFunction(ForceBalanceAnisotropic(eq=eq))
-    constraints = get_fixed_boundary_constraints(eq=eq, anisotropy=True)
+    constraints = get_fixed_boundary_constraints(eq=eq)
     eq.solve(obj, constraints, verbose=3)
     rho_err, theta_err = area_difference_vmec(eq, SOLOVEV["vmec_nc_path"])
 
@@ -548,12 +548,12 @@ def test_NAE_QSC_solve():
 
     # this has all the constraints we need,
     #  iota=False specifies we want to fix current instead of iota
-    cs = get_NAE_constraints(eq, qsc, iota=False, order=1, fix_lambda=False, N=eq.N)
+    cs = get_NAE_constraints(eq, qsc, order=1, fix_lambda=False, N=eq.N)
     cs_lambda_fixed_0th_order = get_NAE_constraints(
-        eq_lambda_fixed_0th_order, qsc, iota=False, order=1, fix_lambda=0, N=eq.N
+        eq_lambda_fixed_0th_order, qsc, order=1, fix_lambda=0, N=eq.N
     )
     cs_lambda_fixed_1st_order = get_NAE_constraints(
-        eq_lambda_fixed_1st_order, qsc, iota=False, order=1, fix_lambda=True, N=eq.N
+        eq_lambda_fixed_1st_order, qsc, order=1, fix_lambda=True, N=eq.N
     )
 
     for c in cs:
@@ -636,7 +636,7 @@ def test_NAE_QIC_solve():
 
     # this has all the constraints we need,
     #  iota=False specifies we want to fix current instead of iota
-    cs = get_NAE_constraints(eq, qic, iota=False, order=1)
+    cs = get_NAE_constraints(eq, qic, order=1)
 
     objectives = ForceBalance(eq=eq)
     obj = ObjectiveFunction(objectives)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -547,7 +547,6 @@ def test_NAE_QSC_solve():
     eq_lambda_fixed_1st_order = eq.copy()
 
     # this has all the constraints we need,
-    #  iota=False specifies we want to fix current instead of iota
     cs = get_NAE_constraints(eq, qsc, order=1, fix_lambda=False, N=eq.N)
     cs_lambda_fixed_0th_order = get_NAE_constraints(
         eq_lambda_fixed_0th_order, qsc, order=1, fix_lambda=0, N=eq.N
@@ -635,7 +634,6 @@ def test_NAE_QIC_solve():
     eq_fit = eq.copy()
 
     # this has all the constraints we need,
-    #  iota=False specifies we want to fix current instead of iota
     cs = get_NAE_constraints(eq, qic, order=1)
 
     objectives = ForceBalance(eq=eq)

--- a/tests/test_linear_objectives.py
+++ b/tests/test_linear_objectives.py
@@ -312,7 +312,7 @@ def test_fixed_axis_and_theta_SFL_solve():
 def test_factorize_linear_constraints_asserts():
     """Test error checking for factorize_linear_constraints."""
     eq = Equilibrium()
-    constraints = get_fixed_boundary_constraints(eq=eq, iota=False)
+    constraints = get_fixed_boundary_constraints(eq=eq)
     for con in constraints:
         con.build(verbose=0)
     constraints[3].bounds = (0, 1)  # bounds on FixPsi
@@ -824,14 +824,15 @@ def _is_any_instance(things, cls):
 def test_FixAxis_util_correct_objectives():
     """Test util for fix axis constraints."""
     eq = Equilibrium()
-    cs = get_fixed_axis_constraints(eq, iota=False)
+    cs = get_fixed_axis_constraints(eq)
     assert _is_any_instance(cs, FixAxisR)
     assert _is_any_instance(cs, FixAxisZ)
     assert _is_any_instance(cs, FixPsi)
     assert _is_any_instance(cs, FixPressure)
     assert _is_any_instance(cs, FixCurrent)
 
-    cs = get_fixed_axis_constraints(eq, iota=True, kinetic=True)
+    eq = Equilibrium(electron_temperature=1, electron_density=1, iota=1)
+    cs = get_fixed_axis_constraints(eq)
     assert _is_any_instance(cs, FixAxisR)
     assert _is_any_instance(cs, FixAxisZ)
     assert _is_any_instance(cs, FixPsi)
@@ -847,7 +848,7 @@ def test_FixNAE_util_correct_objectives():
     """Test util for fix NAE constraints."""
     eq = Equilibrium()
     qsc = Qsc.from_paper("precise QA")
-    cs = get_NAE_constraints(eq, qsc, iota=False)
+    cs = get_NAE_constraints(eq, qsc)
     assert _is_any_instance(cs, FixAxisR)
     assert _is_any_instance(cs, FixAxisZ)
     assert _is_any_instance(cs, FixPsi)
@@ -856,7 +857,8 @@ def test_FixNAE_util_correct_objectives():
     assert _is_any_instance(cs, FixPressure)
     assert _is_any_instance(cs, FixCurrent)
 
-    cs = get_NAE_constraints(eq, qsc, iota=True, kinetic=True)
+    eq = Equilibrium(electron_temperature=1, electron_density=1, iota=1)
+    cs = get_NAE_constraints(eq, qsc)
     assert _is_any_instance(cs, FixAxisR)
     assert _is_any_instance(cs, FixAxisZ)
     assert _is_any_instance(cs, FixPsi)

--- a/tests/test_perturbations.py
+++ b/tests/test_perturbations.py
@@ -106,7 +106,7 @@ def test_perturb_with_float_without_error():
     # np.concatenate cannot concatenate 0-D arrays. This test exercises the fix.
     eq = Equilibrium()
     objective = get_equilibrium_objective(eq=eq)
-    constraints = get_fixed_boundary_constraints(eq=eq, iota=False)
+    constraints = get_fixed_boundary_constraints(eq=eq)
 
     # perturb Psi with a float
     deltas = {"Psi": float(eq.Psi)}

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -396,7 +396,7 @@ class TestProfiles:
             sym=True,
         )
         eq1.solve(
-            constraints=get_fixed_boundary_constraints(eq=eq1, kinetic=False),
+            constraints=get_fixed_boundary_constraints(eq=eq1),
             objective=ObjectiveFunction(objectives=ForceBalance(eq=eq1)),
             maxiter=5,
         )
@@ -417,7 +417,7 @@ class TestProfiles:
             sym=True,
         )
         eq2.solve(
-            constraints=get_fixed_boundary_constraints(eq=eq2, kinetic=True),
+            constraints=get_fixed_boundary_constraints(eq=eq2),
             objective=ObjectiveFunction(objectives=ForceBalance(eq=eq2)),
             maxiter=5,
         )


### PR DESCRIPTION
- When using stuff like ``get_fixed_boundary_constraints`` we have to specify both whether to fix profiles, and also which profiles the equilibrium has.
- Now that ``eq`` is a required argument to the get_* functions, this now redundant, since we can just look and see what profiles the equilibrium has.
- This removes the unneeded args from all the get_* methods, so that the only things needed are the equilibrium and a bool for profiles, the specific profiles will be determined from the equilibrium.