### PR TITLE
fix installation documentation for using cluster GPUs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -123,7 +123,6 @@ specific JAX GPU installation instructions, as that is the main installation dif
 
 Della and Stellar Clusters (Princeton)
 ++++++++++++++++++++++++++++++++++++++
-NOTE: For GPU jobs in Della, you should ssh into <NetID>@della-gpu.princeton.edu.
 
 **Option 1:** First, install JAX (check `this tutorial <https://github.com/PrincetonUniversity/intro_ml_libs/tree/master/jax>`__ ) for the latest version of `jaxlib` available on the Princeton clusters):
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -123,9 +123,9 @@ specific JAX GPU installation instructions, as that is the main installation dif
 
 Della and Stellar Clusters (Princeton)
 ++++++++++++++++++++++++++++++++++++++
-These instructions were tested and confirmed to work on the Della and Stellar clusters at Princeton as of 11-6-2023.
+NOTE: For GPU jobs in Della, you should ssh into <NetID>@della-gpu.princeton.edu.
 
-First, install JAX (check `this tutorial <https://github.com/PrincetonUniversity/intro_ml_libs/tree/master/jax>`__ ) for the latest version of `jaxlib` available on the Princeton clusters):
+**Option 1:** First, install JAX (check `this tutorial <https://github.com/PrincetonUniversity/intro_ml_libs/tree/master/jax>`__ ) for the latest version of `jaxlib` available on the Princeton clusters):
 
 .. code-block:: sh
 
@@ -134,15 +134,7 @@ First, install JAX (check `this tutorial <https://github.com/PrincetonUniversity
     conda activate desc-env
     pip install --upgrade "jax[cuda11_pip]<0.4.15" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
-This method may install JAX with higher CuDNN version (CuDNN 8.6) which is not supported by clusters. When you are trying to use GPU and get an error like **`Loaded runtime CuDNN library: 8.2.0 but source was compiled with: 8.6.0.`** Then, you can instead create the environment with following commands,
-
-.. code-block:: sh
-
-    module load anaconda3/2023.3
-    CONDA_OVERRIDE_CUDA="11.2" conda create --name desc-env jax "jaxlib==0.4.14=cuda112*" -c conda-forge
-    conda activate desc-env
-
-Then, install DESC:
+Then, install DESC,
 
 .. code-block:: sh
 
@@ -154,6 +146,31 @@ Then, install DESC:
     pip install --editable .
     # optionally install developer requirements (if you want to run tests)
     pip install -r devtools/dev-requirements.txt
+
+Option 1 was tested and confirmed to work on the Della and Stellar clusters at Princeton as of 11-6-2023.
+
+**Option 2:** First option may install JAX with higher CuDNN version (CuDNN 8.6) which is not supported by clusters. When you are trying to use GPU and get an error like **`Loaded runtime CuDNN library: 8.2.0 but source was compiled with: 8.6.0.`** Then, you can instead create the environment with following commands,
+
+.. code-block:: sh
+
+    module load anaconda3/2023.3
+    CONDA_OVERRIDE_CUDA="11.2" conda create --name desc-env jax "jaxlib==0.4.14=cuda112*" -c conda-forge
+    conda activate desc-env
+
+Then, install DESC,
+
+.. code-block:: sh
+
+    git clone https://github.com/PlasmaControl/DESC.git
+    cd DESC
+    # remove the jax lines from requirements.txt, as we already have installed them above
+    sed -i '/jax/d' ./requirements.txt
+    # then install as usual
+    pip install --editable .
+    # optionally install developer requirements (if you want to run tests)
+    pip install -r devtools/dev-requirements.txt
+
+Second option was tested and confirmed to work on the Della and Stellar clusters at Princeton as of 11-14-2023.
 
 On Clusters with IBM Power Architecture
 ***************************************

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -134,6 +134,14 @@ First, install JAX (check `this tutorial <https://github.com/PrincetonUniversity
     conda activate desc-env
     pip install --upgrade "jax[cuda11_pip]<0.4.15" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
+This method may install JAX with higher CuDNN version (CuDNN 8.6) which is not supported by clusters. When you are trying to use GPU and get an error like **`Loaded runtime CuDNN library: 8.2.0 but source was compiled with: 8.6.0.`** Then, you can instead create the environment with following commands,
+
+.. code-block:: sh
+
+    module load anaconda3/2023.3
+    CONDA_OVERRIDE_CUDA="11.2" conda create --name desc-env jax "jaxlib==0.4.10=cuda112*" -c conda-forge
+    conda activate desc-env
+
 Then, install DESC:
 
 .. code-block:: sh

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -139,7 +139,7 @@ This method may install JAX with higher CuDNN version (CuDNN 8.6) which is not s
 .. code-block:: sh
 
     module load anaconda3/2023.3
-    CONDA_OVERRIDE_CUDA="11.2" conda create --name desc-env jax "jaxlib==0.4.10=cuda112*" -c conda-forge
+    CONDA_OVERRIDE_CUDA="11.2" conda create --name desc-env jax "jaxlib==0.4.14=cuda112*" -c conda-forge
     conda activate desc-env
 
 Then, install DESC:


### PR DESCRIPTION
Note: This change is already on the "stable" version of the website, but that has older JAX version I guess. This one uses the command from Princeton Jax page.

"Latest" version of the installation page, for DELLA and STELLAR clusters with CPU+GPU support, tells to use 

`module load anaconda3/2023.3
conda create --name desc-env python=3.9
conda activate desc-env
pip install --upgrade "jax[cuda11_pip]<0.4.15" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html`

However, this results in following error, and the simulation only uses CPU,

` Loaded runtime CuDNN library: 8.2.0 but source was compiled with: 8.6.0.  CuDNN library needs to have matching major version and equal or higher minor version. If using a binary install, upgrade your CuDNN library.  If building from sources, make sure the library loaded at runtime is compatible with the version specified during compile configuration.`

The Princeton cluster repo for JAX suggests to use following command, and it works for using GPU,

`$ module load anaconda3/2023.9
$ CONDA_OVERRIDE_CUDA="11.2" conda create --name jax-gpu jax "jaxlib==0.4.14=cuda112*" -c conda-forge`

I added this command in addition to the previous one (because apparently for someone else this doesn't work, but I didn't understand how this can happen since the cluster has the same configuration for every user)

EDIT: The stable version command gave an error for me too. Apparently it installs older JAX and Cuda version. Maybe thats the reason. My change:
`CONDA_OVERRIDE_CUDA="11.2" conda create --name desc-env jax "jaxlib==0.4.14=cuda112*" -c conda-forge`
Stable version commanda:
`CONDA_OVERRIDE_CUDA="11.2" conda create --name desc-env jax "jaxlib==0.4.10=cuda112*" -c conda-forge`