### PR TITLE
fixing bug when building proximal projection objective

### DIFF
--- a/desc/optimize/_constraint_wrappers.py
+++ b/desc/optimize/_constraint_wrappers.py
@@ -482,12 +482,12 @@ class ProximalProjection(ObjectiveFunction):
         # with this directly, so if the user wants to manually rebuild they should
         # do it before this wrapper is created for them.
         if not self._objective.built:
-            self._objective.build(self._eq, verbose=verbose)
+            self._objective.build(use_jit=use_jit, verbose=verbose)
         if not self._constraint.built:
-            self._constraint.build(self._eq, verbose=verbose)
+            self._constraint.build(use_jit=use_jit, verbose=verbose)
 
         for constraint in self._linear_constraints:
-            constraint.build(self._eq, verbose=verbose)
+            constraint.build(use_jit=use_jit, verbose=verbose)
 
         self._objectives = combine_args(self._objective, self._constraint)
         self._set_things(self._all_things)


### PR DESCRIPTION
fixing bug when building proximal objective where eq is used as parameter instead of use_jit.

This bug only occurs when trying to use objectives like gx that don't use jit.