### PR TITLE
instructions for installating DESC on Perlmutter

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -121,6 +121,45 @@ specific JAX GPU installation instructions, as that is the main installation dif
 
 **Note that DESC does not always test on or guarantee support of the latest version of JAX (which does not have a stable 1.0 release yet), and thus older versions of GPU-accelerated versions of JAX may need to be installed, which may in turn require lower versions of JaxLib, as well as CUDA and CuDNN.**
 
+Perlmutter (NERSC)
+++++++++++++++++++++++++++++++
+These instructions were tested and confirmed to work on the Perlmutter supercomputer at NERSC on 11-02-2023
+
+Set up the correct cuda environment for jax installation
+
+.. code-block:: sh
+
+    module load cudatoolkit/11.7
+    module load cudnn/8.9.1_cuda11
+    module load python
+
+Check that you have loaded these modules
+
+.. code-block:: sh
+
+    module list
+
+Create a conda environment for DESC
+
+.. code-block:: sh
+
+    conda create -n desc-env python=3.9
+    conda activate desc-env
+    pip install --no-cache-dir "jax[cuda11_cudnn82]==0.4.7" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+
+Clone and install DESC
+
+.. code-block:: sh
+
+    git clone https://github.com/PlasmaControl/DESC.git
+    cd DESC
+    sed -i '/jax/d' ./requirements.txt
+    # installation for users
+    pip install --editable .
+    # optionally install developer requirements (if you want to run tests)
+    pip install -r devtools/dev-requirements.txt
+
+
 Della and Stellar Clusters (Princeton)
 ++++++++++++++++++++++++++++++++++++++
 These instructions were tested and confirmed to work on the Della and Stellar clusters at Princeton as of 11-6-2023.


### PR DESCRIPTION
A lot of our potential users don't have access to the Princeton cluster but do use the Perlmutter supercomputer.
I have added instructions to install DESC on Perlmutter.