### PR TITLE
Don't cast np arrays to jnp arrays in put

### DIFF
--- a/desc/backend.py
+++ b/desc/backend.py
@@ -98,6 +98,9 @@ if use_jax:  # noqa: C901 - FIXME: simplify this, define globally and then assig
             Input array with vals inserted at inds.
 
         """
+        if isinstance(arr, np.ndarray):
+            arr[inds] = vals
+            return arr
         return jnp.asarray(arr).at[inds].set(vals)
 
     def sign(x):


### PR DESCRIPTION
Doing so would occasionally cause jax tracers to appear under jit where we expect concrete np arrays