### PR TITLE
Ensure things that should be ints really are

### DIFF
--- a/desc/basis.py
+++ b/desc/basis.py
@@ -38,6 +38,12 @@ class _Basis(IOAble, ABC):
         self._enforce_symmetry()
         self._sort_modes()
         self._create_idx()
+        # ensure things that should be ints are ints
+        self._L = int(self._L)
+        self._M = int(self._M)
+        self._N = int(self._N)
+        self._NFP = int(self._NFP)
+        self._modes = self._modes.astype(int)
 
     def _set_up(self):
         """Do things after loading or changing resolution."""
@@ -46,6 +52,12 @@ class _Basis(IOAble, ABC):
         self._enforce_symmetry()
         self._sort_modes()
         self._create_idx()
+        # ensure things that should be ints are ints
+        self._L = int(self._L)
+        self._M = int(self._M)
+        self._N = int(self._N)
+        self._NFP = int(self._NFP)
+        self._modes = self._modes.astype(int)
 
     def _enforce_symmetry(self):
         """Enforce stellarator symmetry."""

--- a/desc/equilibrium/equilibrium.py
+++ b/desc/equilibrium/equilibrium.py
@@ -208,7 +208,9 @@ class Equilibrium(IOAble, Optimizable):
             ValueError,
             f"NFP should be a positive integer, got {NFP}",
         )
-        self._NFP = setdefault(NFP, getattr(surface, "NFP", getattr(axis, "NFP", 1)))
+        self._NFP = int(
+            setdefault(NFP, getattr(surface, "NFP", getattr(axis, "NFP", 1)))
+        )
 
         # stellarator symmetry for bases
         errorif(
@@ -540,13 +542,13 @@ class Equilibrium(IOAble, Optimizable):
             Whether to enforce stellarator symmetry.
 
         """
-        self._L = setdefault(L, self.L)
-        self._M = setdefault(M, self.M)
-        self._N = setdefault(N, self.N)
-        self._L_grid = setdefault(L_grid, self.L_grid)
-        self._M_grid = setdefault(M_grid, self.M_grid)
-        self._N_grid = setdefault(N_grid, self.N_grid)
-        self._NFP = setdefault(NFP, self.NFP)
+        self._L = int(setdefault(L, self.L))
+        self._M = int(setdefault(M, self.M))
+        self._N = int(setdefault(N, self.N))
+        self._L_grid = int(setdefault(L_grid, self.L_grid))
+        self._M_grid = int(setdefault(M_grid, self.M_grid))
+        self._N_grid = int(setdefault(N_grid, self.N_grid))
+        self._NFP = int(setdefault(NFP, self.NFP))
         self._sym = setdefault(sym, self.sym)
 
         old_modes_R = self.R_basis.modes

--- a/desc/geometry/core.py
+++ b/desc/geometry/core.py
@@ -26,8 +26,8 @@ class Curve(IOAble, Optimizable, ABC):
     _io_attrs_ = ["_name", "shift", "rotmat"]
 
     def __init__(self, name=""):
-        self.shift = jnp.array([0, 0, 0])
-        self.rotmat = jnp.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        self.shift = jnp.array([0, 0, 0]).astype(float)
+        self.rotmat = jnp.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]).astype(float)
         self.name = name
 
     @property

--- a/desc/geometry/curve.py
+++ b/desc/geometry/curve.py
@@ -11,7 +11,7 @@ from desc.grid import LinearGrid
 from desc.io import InputReader
 from desc.optimizable import optimizable_parameter
 from desc.transform import Transform
-from desc.utils import copy_coeffs, errorif
+from desc.utils import copy_coeffs, errorif, isposint
 
 from .core import Curve
 
@@ -74,6 +74,7 @@ class FourierRZCurve(Curve):
 
         assert issubclass(modes_R.dtype.type, np.integer)
         assert issubclass(modes_Z.dtype.type, np.integer)
+        assert isposint(NFP)
 
         if sym == "auto":
             if np.all(R_n[modes_R < 0] == 0) and np.all(Z_n[modes_Z >= 0] == 0):
@@ -84,9 +85,9 @@ class FourierRZCurve(Curve):
         NR = np.max(abs(modes_R))
         NZ = np.max(abs(modes_Z))
         N = max(NR, NZ)
-        self._NFP = NFP
-        self._R_basis = FourierSeries(N, NFP, sym="cos" if sym else False)
-        self._Z_basis = FourierSeries(N, NFP, sym="sin" if sym else False)
+        self._NFP = int(NFP)
+        self._R_basis = FourierSeries(N, int(NFP), sym="cos" if sym else False)
+        self._Z_basis = FourierSeries(N, int(NFP), sym="sin" if sym else False)
 
         self._R_n = copy_coeffs(R_n, modes_R, self.R_basis.modes[:, 2])
         self._Z_n = copy_coeffs(Z_n, modes_Z, self.Z_basis.modes[:, 2])
@@ -131,9 +132,9 @@ class FourierRZCurve(Curve):
             or (sym is not None)
             and (sym != self.sym)
         ):
-            self._NFP = NFP if NFP is not None else self.NFP
+            self._NFP = int(NFP if NFP is not None else self.NFP)
             self._sym = sym if sym is not None else self.sym
-            N = N if N is not None else self.N
+            N = int(N if N is not None else self.N)
             R_modes_old = self.R_basis.modes
             Z_modes_old = self.Z_basis.modes
             self.R_basis.change_resolution(
@@ -320,6 +321,7 @@ class FourierXYZCurve(Curve):
     def change_resolution(self, N=None):
         """Change the maximum angular resolution."""
         if (N is not None) and (N != self.N):
+            N = int(N)
             Xmodes_old = self.X_basis.modes
             Ymodes_old = self.Y_basis.modes
             Zmodes_old = self.Z_basis.modes
@@ -552,6 +554,7 @@ class FourierPlanarCurve(Curve):
     def change_resolution(self, N=None):
         """Change the maximum angular resolution."""
         if (N is not None) and (N != self.N):
+            N = int(N)
             modes_old = self.r_basis.modes
             self.r_basis.change_resolution(N=N)
             self.r_n = copy_coeffs(self.r_n, modes_old, self.r_basis.modes)

--- a/desc/geometry/surface.py
+++ b/desc/geometry/surface.py
@@ -9,7 +9,7 @@ from desc.backend import jnp, put, sign
 from desc.basis import DoubleFourierSeries, ZernikePolynomial
 from desc.io import InputReader
 from desc.optimizable import optimizable_parameter
-from desc.utils import copy_coeffs
+from desc.utils import copy_coeffs, isposint
 
 from .core import Surface
 
@@ -78,7 +78,8 @@ class FourierRZToroidalSurface(Surface):
 
         assert issubclass(modes_R.dtype.type, np.integer)
         assert issubclass(modes_Z.dtype.type, np.integer)
-
+        assert isposint(NFP)
+        NFP = int(NFP)
         MR = np.max(abs(modes_R[:, 0]))
         NR = np.max(abs(modes_R[:, 1]))
         MZ = np.max(abs(modes_Z[:, 0]))
@@ -159,7 +160,7 @@ class FourierRZToroidalSurface(Surface):
         NFP = kwargs.pop("NFP", None)
         sym = kwargs.pop("sym", None)
         assert len(kwargs) == 0, "change_resolution got unexpected kwarg: {kwargs}"
-        self._NFP = NFP if NFP is not None else self.NFP
+        self._NFP = int(NFP if NFP is not None else self.NFP)
         self._sym = sym if sym is not None else self.sym
         if L is not None:
             warnings.warn(
@@ -175,8 +176,8 @@ class FourierRZToroidalSurface(Surface):
             or ((M is not None) and (M != self.M))
             or (NFP is not None)
         ):
-            M = M if M is not None else self.M
-            N = N if N is not None else self.N
+            M = int(M if M is not None else self.M)
+            N = int(N if N is not None else self.N)
             R_modes_old = self.R_basis.modes
             Z_modes_old = self.Z_basis.modes
             self.R_basis.change_resolution(
@@ -525,8 +526,8 @@ class ZernikeRZToroidalSection(Surface):
             L, M, N = args
 
         if ((L is not None) and (L != self.L)) or ((M is not None) and (M != self.M)):
-            L = L if L is not None else self.L
-            M = M if M is not None else self.M
+            L = int(L if L is not None else self.L)
+            M = int(M if M is not None else self.M)
             R_modes_old = self.R_basis.modes
             Z_modes_old = self.Z_basis.modes
             self.R_basis.change_resolution(


### PR DESCRIPTION
I've run into several bugs and errors doing free boundary stuff related to things that we assume are integers actually being floats, which messes with some jax stuff (ints are considered static args to jitted functions etc)

This attempts to fix the most common sources of these issues by ensuring that mode numbers etc are really ints.

It also enforces that NFP is an integer. I know for the umbilic stuff we considered making it a float but I think it's better to introduce some new parameter for that that multiplies `n` and keep NFP an integer since its used as a loop bound parameter for free boundary stuff.