### PR TITLE
Add lazy imports to top level desc module

### DIFF
--- a/desc/__init__.py
+++ b/desc/__init__.py
@@ -1,5 +1,6 @@
 """DESC: a 3D MHD equilibrium solver and stellarator optimization suite."""
 
+import importlib
 import os
 import re
 import warnings
@@ -13,6 +14,36 @@ __version__ = get_versions()["version"]
 del get_versions
 
 colorama.init()
+
+
+__all__ = [
+    "basis",
+    "coils",
+    "compute",
+    "continuation",
+    "derivatives",
+    "equilibrium",
+    "examples",
+    "geometry",
+    "grid",
+    "io",
+    "magnetic_fields",
+    "objectives",
+    "optimize",
+    "perturbations",
+    "plotting",
+    "profiles",
+    "random",
+    "transform",
+    "vmec",
+]
+
+
+def __getattr__(name):
+    if name in __all__:
+        return importlib.import_module("." + name, __name__)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 _BANNER = r"""
  ____  ____  _____   ___


### PR DESCRIPTION
Right now we have to manually import most submodules so that we don't accidentally import jax stuff before devices have been set correctly, like 
```python
import desc
desc.set_device()
from desc.equilibrium import Equilibrium
eq = Equilibrium()
```

And we can't do stuff like
```python
import desc
desc.set_device()
eq = desc.equilibrium.Equilibrium()
```

This adds a lazy importer to the top level ``desc`` module, so that things like the second example now work fine