### PR TITLE
Dp/sum magnetic field grids

### DIFF
--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -451,7 +451,7 @@ class SumMagneticField(_MagneticField):
             one entry for each component field.
         basis : {"rpz", "xyz"}
             basis for input coordinates and returned magnetic field
-        grid : Grid, int or None
+        grid : list or tuple of Grid, int or None, optional
             Grid used to discretize MagneticField object if calculating
             B from biot savart. If an integer, uses that many equally spaced
             points.
@@ -465,10 +465,15 @@ class SumMagneticField(_MagneticField):
             params = [None] * len(self._fields)
         if isinstance(params, dict):
             params = [params]
+        if grid is None:
+            grid = [None] * len(self._fields)
+        if not isinstance(grid, (list, tuple)):
+            grid = [grid]
+
         B = 0
-        for i, field in enumerate(self._fields):
+        for i, field, g in enumerate(self._fields, grid):
             B += field.compute_magnetic_field(
-                coords, params[i % len(params)], basis, grid=grid
+                coords, params[i % len(params)], basis, grid=g
             )
 
         return B
@@ -1559,7 +1564,7 @@ class FourierCurrentPotentialField(_MagneticField, FourierRZToroidalSurface):
 
         """
         grid = grid or LinearGrid(
-            M=self._M_Phi * 3 + 1, N=self._N_Phi * 3 + 1, NFP=self.NFP
+            M=self._M_Phi * 4 + 1, N=self._N_Phi * 4 + 1, NFP=self.NFP
         )
         return _compute_magnetic_field_from_CurrentPotentialField(
             field=self, coords=coords, params=params, basis=basis, grid=grid

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -471,7 +471,7 @@ class SumMagneticField(_MagneticField):
             grid = [grid]
 
         B = 0
-        for i, field, g in enumerate(self._fields, grid):
+        for i, (field, g) in enumerate(zip(self._fields, grid)):
             B += field.compute_magnetic_field(
                 coords, params[i % len(params)], basis, grid=g
             )

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -469,6 +469,11 @@ class SumMagneticField(_MagneticField):
             grid = [None] * len(self._fields)
         if not isinstance(grid, (list, tuple)):
             grid = [grid]
+        if len(grid) != len(self._fields):
+            # ensure that if grid is shorter, that
+            # it is simply repeated so that zip
+            # does not terminate early
+            grid = grid * len(self._fields)
 
         B = 0
         for i, (field, g) in enumerate(zip(self._fields, grid)):

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -161,6 +161,27 @@ class TestMagneticFields:
             rtol=1e-8,
         )
 
+        # add a ToroidalField and check passing in/not passing in
+
+        B_TF = ToroidalMagneticField(1, 10)
+        sumfield = B_TF + field
+
+        np.testing.assert_allclose(
+            sumfield.compute_magnetic_field([10.0, 0, 0]),
+            correct_field(10.0, 0, 0) + B_TF([10.0, 0, 0]),
+            atol=1e-16,
+            rtol=1e-8,
+        )
+
+        np.testing.assert_allclose(
+            sumfield.compute_magnetic_field(
+                [10.0, 0, 0], grid=[None, LinearGrid(M=30, N=30, NFP=surface.NFP)]
+            ),
+            correct_field(10.0, 0, 0) + B_TF([10.0, 0, 0]),
+            atol=1e-16,
+            rtol=1e-8,
+        )
+
         with pytest.raises(IOError):
             field.save("test_field.h5")
         with pytest.warns(UserWarning):


### PR DESCRIPTION
`SumMagneticField` may contain fields which have disparate grid requirements (e.g. a coilset and a `FourierCurrentPotentialField`)

this allows its compute function to accept a list of grids, which can then be used to e.g. pass in a 1d grid for a coilset and a 2d grid for a surface current field like in the above example