### PR TITLE
Rc/nangrad

### DIFF
--- a/desc/compute/_basis_vectors.py
+++ b/desc/compute/_basis_vectors.py
@@ -12,7 +12,7 @@ expensive computations.
 from desc.backend import jnp
 
 from .data_index import register_compute_fun
-from .utils import cross
+from .utils import cross, safediv
 
 
 @register_compute_fun(
@@ -71,18 +71,19 @@ def _e_sup_rho_r(params, transforms, profiles, data, **kwargs):
     a = cross(data["e_theta_r"], data["e_zeta"])
     data["e^rho_r"] = transforms["grid"].replace_at_axis(
         (
-            (a + cross(data["e_theta"], data["e_zeta_r"])).T / data["sqrt(g)"]
+            safediv((a + cross(data["e_theta"], data["e_zeta_r"])).T, data["sqrt(g)"])
             - cross(data["e_theta"], data["e_zeta"]).T
-            * data["sqrt(g)_r"]
-            / data["sqrt(g)"] ** 2
+            * safediv(data["sqrt(g)_r"], data["sqrt(g)"] ** 2)
         ).T,
         lambda: (
-            (
-                cross(data["e_theta_rr"], data["e_zeta"])
-                + 2 * cross(data["e_theta_r"], data["e_zeta_r"])
-            ).T
-            / (2 * data["sqrt(g)_r"])
-            - a.T * data["sqrt(g)_rr"] / (2 * data["sqrt(g)_r"] ** 2)
+            safediv(
+                (
+                    cross(data["e_theta_rr"], data["e_zeta"])
+                    + 2 * cross(data["e_theta_r"], data["e_zeta_r"])
+                ).T,
+                (2 * data["sqrt(g)_r"]),
+            )
+            - a.T * safediv(data["sqrt(g)_rr"], (2 * data["sqrt(g)_r"] ** 2))
         ).T,
     )
     return data
@@ -265,20 +266,24 @@ def _e_sup_rho_rz(params, transforms, profiles, data, **kwargs):
 def _e_sup_rho_t(params, transforms, profiles, data, **kwargs):
     data["e^rho_t"] = transforms["grid"].replace_at_axis(
         (
-            (
-                cross(data["e_theta_t"], data["e_zeta"])
-                + cross(data["e_theta"], data["e_zeta_t"])
-            ).T
-            / data["sqrt(g)"]
-            - cross(data["e_theta"], data["e_zeta"]).T
-            * data["sqrt(g)_t"]
-            / data["sqrt(g)"] ** 2
+            safediv(
+                (
+                    cross(data["e_theta_t"], data["e_zeta"])
+                    + cross(data["e_theta"], data["e_zeta_t"])
+                ).T,
+                data["sqrt(g)"],
+            )
+            - safediv(
+                cross(data["e_theta"], data["e_zeta"]).T * data["sqrt(g)_t"],
+                data["sqrt(g)"] ** 2,
+            )
         ).T,
         lambda: (
-            cross(data["e_theta_rt"], data["e_zeta"]).T / data["sqrt(g)_r"]
-            - cross(data["e_theta_r"], data["e_zeta"]).T
-            * data["sqrt(g)_rt"]
-            / data["sqrt(g)_r"] ** 2
+            safediv(cross(data["e_theta_rt"], data["e_zeta"]).T, data["sqrt(g)_r"])
+            - safediv(
+                cross(data["e_theta_r"], data["e_zeta"]).T * data["sqrt(g)_rt"],
+                data["sqrt(g)_r"] ** 2,
+            )
         ).T,
     )
     return data
@@ -406,24 +411,26 @@ def _e_sup_rho_tz(params, transforms, profiles, data, **kwargs):
 def _e_sup_rho_z(params, transforms, profiles, data, **kwargs):
     data["e^rho_z"] = transforms["grid"].replace_at_axis(
         (
-            (
-                cross(data["e_theta_z"], data["e_zeta"])
-                + cross(data["e_theta"], data["e_zeta_z"])
-            ).T
-            / data["sqrt(g)"]
+            safediv(
+                (
+                    cross(data["e_theta_z"], data["e_zeta"])
+                    + cross(data["e_theta"], data["e_zeta_z"])
+                ).T,
+                data["sqrt(g)"],
+            )
             - cross(data["e_theta"], data["e_zeta"]).T
-            * data["sqrt(g)_z"]
-            / data["sqrt(g)"] ** 2
+            * safediv(data["sqrt(g)_z"], data["sqrt(g)"] ** 2)
         ).T,
         lambda: (
-            (
-                cross(data["e_theta_r"], data["e_zeta_z"])
-                + cross(data["e_theta_rz"], data["e_zeta"])
-            ).T
-            / data["sqrt(g)_r"]
+            safediv(
+                (
+                    cross(data["e_theta_r"], data["e_zeta_z"])
+                    + cross(data["e_theta_rz"], data["e_zeta"])
+                ).T,
+                data["sqrt(g)_r"],
+            )
             - cross(data["e_theta_r"], data["e_zeta"]).T
-            * data["sqrt(g)_rz"]
-            / data["sqrt(g)_r"] ** 2
+            * safediv(data["sqrt(g)_rz"], data["sqrt(g)_r"] ** 2)
         ).T,
     )
     return data
@@ -958,18 +965,19 @@ def _e_sup_zeta_r(params, transforms, profiles, data, **kwargs):
     b = cross(data["e_rho"], data["e_theta_r"])
     data["e^zeta_r"] = transforms["grid"].replace_at_axis(
         (
-            (cross(data["e_rho_r"], data["e_theta"]) + b).T / data["sqrt(g)"]
+            safediv((cross(data["e_rho_r"], data["e_theta"]) + b).T, data["sqrt(g)"])
             - cross(data["e_rho"], data["e_theta"]).T
-            * data["sqrt(g)_r"]
-            / data["sqrt(g)"] ** 2
+            * safediv(data["sqrt(g)_r"], data["sqrt(g)"] ** 2)
         ).T,
         lambda: (
-            (
-                2 * cross(data["e_rho_r"], data["e_theta_r"])
-                + cross(data["e_rho"], data["e_theta_rr"])
-            ).T
-            / (2 * data["sqrt(g)_r"])
-            - b.T * data["sqrt(g)_rr"] / (2 * data["sqrt(g)_r"] ** 2)
+            safediv(
+                (
+                    2 * cross(data["e_rho_r"], data["e_theta_r"])
+                    + cross(data["e_rho"], data["e_theta_rr"])
+                ).T,
+                (2 * data["sqrt(g)_r"]),
+            )
+            - b.T * safediv(data["sqrt(g)_rr"], (2 * data["sqrt(g)_r"] ** 2))
         ).T,
     )
     return data
@@ -1153,24 +1161,26 @@ def _e_sup_zeta_rz(params, transforms, profiles, data, **kwargs):
 def _e_sup_zeta_t(params, transforms, profiles, data, **kwargs):
     data["e^zeta_t"] = transforms["grid"].replace_at_axis(
         (
-            (
-                cross(data["e_rho_t"], data["e_theta"])
-                + cross(data["e_rho"], data["e_theta_t"])
-            ).T
-            / data["sqrt(g)"]
+            safediv(
+                (
+                    cross(data["e_rho_t"], data["e_theta"])
+                    + cross(data["e_rho"], data["e_theta_t"])
+                ).T,
+                data["sqrt(g)"],
+            )
             - cross(data["e_rho"], data["e_theta"]).T
-            * data["sqrt(g)_t"]
-            / data["sqrt(g)"] ** 2
+            * safediv(data["sqrt(g)_t"], data["sqrt(g)"] ** 2)
         ).T,
         lambda: (
-            (
-                cross(data["e_rho_t"], data["e_theta_r"])
-                + cross(data["e_rho"], data["e_theta_rt"])
-            ).T
-            / data["sqrt(g)_r"]
+            safediv(
+                (
+                    cross(data["e_rho_t"], data["e_theta_r"])
+                    + cross(data["e_rho"], data["e_theta_rt"])
+                ).T,
+                data["sqrt(g)_r"],
+            )
             - cross(data["e_rho"], data["e_theta_r"]).T
-            * data["sqrt(g)_rt"]
-            / data["sqrt(g)_r"] ** 2
+            * safediv(data["sqrt(g)_rt"], data["sqrt(g)_r"] ** 2)
         ).T,
     )
     return data
@@ -1299,24 +1309,26 @@ def _e_sup_zeta_tz(params, transforms, profiles, data, **kwargs):
 def _e_sup_zeta_z(params, transforms, profiles, data, **kwargs):
     data["e^zeta_z"] = transforms["grid"].replace_at_axis(
         (
-            (
-                cross(data["e_rho_z"], data["e_theta"])
-                + cross(data["e_rho"], data["e_theta_z"])
-            ).T
-            / data["sqrt(g)"]
+            safediv(
+                (
+                    cross(data["e_rho_z"], data["e_theta"])
+                    + cross(data["e_rho"], data["e_theta_z"])
+                ).T,
+                data["sqrt(g)"],
+            )
             - cross(data["e_rho"], data["e_theta"]).T
-            * data["sqrt(g)_z"]
-            / data["sqrt(g)"] ** 2
+            * safediv(data["sqrt(g)_z"], data["sqrt(g)"] ** 2)
         ).T,
         lambda: (
-            (
-                cross(data["e_rho_z"], data["e_theta_r"])
-                + cross(data["e_rho"], data["e_theta_rz"])
-            ).T
-            / data["sqrt(g)_r"]
+            safediv(
+                (
+                    cross(data["e_rho_z"], data["e_theta_r"])
+                    + cross(data["e_rho"], data["e_theta_rz"])
+                ).T,
+                data["sqrt(g)_r"],
+            )
             - cross(data["e_rho"], data["e_theta_r"]).T
-            * data["sqrt(g)_rz"]
-            / data["sqrt(g)_r"] ** 2
+            * safediv(data["sqrt(g)_rz"], data["sqrt(g)_r"] ** 2)
         ).T,
     )
     return data
@@ -2345,8 +2357,8 @@ def _e_sub_theta_over_sqrt_g(params, transforms, profiles, data, **kwargs):
     # At the magnetic axis, this function returns the multivalued map whose
     # image is the set { 𝐞_θ / √g | ρ=0 }.
     data["e_theta/sqrt(g)"] = transforms["grid"].replace_at_axis(
-        (data["e_theta"].T / data["sqrt(g)"]).T,
-        lambda: (data["e_theta_r"].T / data["sqrt(g)_r"]).T,
+        safediv(data["e_theta"].T, data["sqrt(g)"]).T,
+        lambda: safediv(data["e_theta_r"].T, data["sqrt(g)_r"]).T,
     )
     return data
 
@@ -4398,11 +4410,11 @@ def _n_rho(params, transforms, profiles, data, **kwargs):
     # Equal to 𝐞^ρ / ‖𝐞^ρ‖ but works correctly for surfaces as well that don't
     # have contravariant basis defined.
     data["n_rho"] = transforms["grid"].replace_at_axis(
-        (cross(data["e_theta"], data["e_zeta"]).T / data["|e_theta x e_zeta|"]).T,
+        safediv(cross(data["e_theta"], data["e_zeta"]).T, data["|e_theta x e_zeta|"]).T,
         # At the magnetic axis, this function returns the multivalued map whose
         # image is the set { 𝐞^ρ / ‖𝐞^ρ‖ | ρ=0 }.
-        lambda: (
-            cross(data["e_theta_r"], data["e_zeta"]).T / data["|e_theta x e_zeta|_r"]
+        lambda: safediv(
+            cross(data["e_theta_r"], data["e_zeta"]).T, data["|e_theta x e_zeta|_r"]
         ).T,
     )
     return data
@@ -4456,11 +4468,11 @@ def _n_zeta(params, transforms, profiles, data, **kwargs):
     # Equal to 𝐞^ζ / ‖𝐞^ζ‖ but works correctly for surfaces as well that don't
     # have contravariant basis defined.
     data["n_zeta"] = transforms["grid"].replace_at_axis(
-        (cross(data["e_rho"], data["e_theta"]).T / data["|e_rho x e_theta|"]).T,
+        safediv(cross(data["e_rho"], data["e_theta"]).T, data["|e_rho x e_theta|"]).T,
         # At the magnetic axis, this function returns the multivalued map whose
         # image is the set { 𝐞^ζ / ‖𝐞^ζ‖ | ρ=0 }.
-        lambda: (
-            cross(data["e_rho"], data["e_theta_r"]).T / data["|e_rho x e_theta|_r"]
+        lambda: safediv(
+            cross(data["e_rho"], data["e_theta_r"]).T, data["|e_rho x e_theta|_r"]
         ).T,
     )
     return data

--- a/desc/compute/_equil.py
+++ b/desc/compute/_equil.py
@@ -14,7 +14,7 @@ from scipy.constants import mu_0
 from desc.backend import jnp
 
 from .data_index import register_compute_fun
-from .utils import cross, dot, safenorm, surface_averages
+from .utils import cross, dot, safediv, safenorm, surface_averages
 
 
 @register_compute_fun(
@@ -39,8 +39,8 @@ def _J_sup_rho(params, transforms, profiles, data, **kwargs):
     # form 0/0 and we may compute the limit as follows.
     data["J^rho"] = (
         transforms["grid"].replace_at_axis(
-            (data["B_zeta_t"] - data["B_theta_z"]) / data["sqrt(g)"],
-            lambda: (data["B_zeta_rt"] - data["B_theta_rz"]) / data["sqrt(g)_r"],
+            safediv(data["B_zeta_t"] - data["B_theta_z"], data["sqrt(g)"]),
+            lambda: safediv(data["B_zeta_rt"] - data["B_theta_rz"], data["sqrt(g)_r"]),
         )
     ) / mu_0
     return data
@@ -104,8 +104,8 @@ def _J_sup_zeta(params, transforms, profiles, data, **kwargs):
     # form 0/0 and we may compute the limit as follows.
     data["J^zeta"] = (
         transforms["grid"].replace_at_axis(
-            (data["B_theta_r"] - data["B_rho_t"]) / data["sqrt(g)"],
-            lambda: (data["B_theta_rr"] - data["B_rho_rt"]) / data["sqrt(g)_r"],
+            safediv(data["B_theta_r"] - data["B_rho_t"], data["sqrt(g)"]),
+            lambda: safediv(data["B_theta_rr"] - data["B_rho_rt"], data["sqrt(g)_r"]),
         )
     ) / mu_0
     return data

--- a/desc/compute/_field.py
+++ b/desc/compute/_field.py
@@ -17,6 +17,7 @@ from .data_index import register_compute_fun
 from .utils import (
     cross,
     dot,
+    safediv,
     safenorm,
     surface_averages,
     surface_integrals_map,
@@ -41,8 +42,8 @@ from .utils import (
 )
 def _B0(params, transforms, profiles, data, **kwargs):
     data["B0"] = transforms["grid"].replace_at_axis(
-        data["psi_r"] / data["sqrt(g)"],
-        lambda: data["psi_rr"] / data["sqrt(g)_r"],
+        safediv(data["psi_r"], data["sqrt(g)"]),
+        lambda: safediv(data["psi_rr"], data["sqrt(g)_r"]),
     )
     return data
 
@@ -195,12 +196,14 @@ def _B_Z(params, transforms, profiles, data, **kwargs):
 )
 def _B0_r(params, transforms, profiles, data, **kwargs):
     data["B0_r"] = transforms["grid"].replace_at_axis(
-        (data["psi_rr"] * data["sqrt(g)"] - data["psi_r"] * data["sqrt(g)_r"])
-        / data["sqrt(g)"] ** 2,
-        lambda: (
-            data["psi_rrr"] * data["sqrt(g)_r"] - data["psi_rr"] * data["sqrt(g)_rr"]
-        )
-        / (2 * data["sqrt(g)_r"] ** 2),
+        safediv(
+            data["psi_rr"] * data["sqrt(g)"] - data["psi_r"] * data["sqrt(g)_r"],
+            data["sqrt(g)"] ** 2,
+        ),
+        lambda: safediv(
+            data["psi_rrr"] * data["sqrt(g)_r"] - data["psi_rr"] * data["sqrt(g)_rr"],
+            (2 * data["sqrt(g)_r"] ** 2),
+        ),
     )
     return data
 
@@ -324,8 +327,8 @@ def _B_r(params, transforms, profiles, data, **kwargs):
 )
 def _B0_t(params, transforms, profiles, data, **kwargs):
     data["B0_t"] = transforms["grid"].replace_at_axis(
-        -data["psi_r"] * data["sqrt(g)_t"] / data["sqrt(g)"] ** 2,
-        lambda: -data["psi_rr"] * data["sqrt(g)_rt"] / data["sqrt(g)_r"] ** 2,
+        safediv(-data["psi_r"] * data["sqrt(g)_t"], data["sqrt(g)"] ** 2),
+        lambda: safediv(-data["psi_rr"] * data["sqrt(g)_rt"], data["sqrt(g)_r"] ** 2),
     )
     return data
 
@@ -426,8 +429,8 @@ def _B_t(params, transforms, profiles, data, **kwargs):
 )
 def _B0_z(params, transforms, profiles, data, **kwargs):
     data["B0_z"] = transforms["grid"].replace_at_axis(
-        -data["psi_r"] * data["sqrt(g)_z"] / data["sqrt(g)"] ** 2,
-        lambda: -data["psi_rr"] * data["sqrt(g)_rz"] / data["sqrt(g)_r"] ** 2,
+        safediv(-data["psi_r"] * data["sqrt(g)_z"], data["sqrt(g)"] ** 2),
+        lambda: safediv(-data["psi_rr"] * data["sqrt(g)_rz"], data["sqrt(g)_r"] ** 2),
     )
     return data
 
@@ -528,19 +531,19 @@ def _B_z(params, transforms, profiles, data, **kwargs):
 )
 def _B0_rr(params, transforms, profiles, data, **kwargs):
     data["B0_rr"] = transforms["grid"].replace_at_axis(
-        (
+        safediv(
             data["psi_rrr"] * data["sqrt(g)"] ** 2
             - 2 * data["psi_rr"] * data["sqrt(g)_r"] * data["sqrt(g)"]
             - data["psi_r"] * data["sqrt(g)_rr"] * data["sqrt(g)"]
-            + 2 * data["psi_r"] * data["sqrt(g)_r"] ** 2
-        )
-        / data["sqrt(g)"] ** 3,
-        lambda: (
+            + 2 * data["psi_r"] * data["sqrt(g)_r"] ** 2,
+            data["sqrt(g)"] ** 3,
+        ),
+        lambda: safediv(
             3 * data["sqrt(g)_rr"] ** 2 * data["psi_rr"]
             - 2 * data["sqrt(g)_rrr"] * data["sqrt(g)_r"] * data["psi_rr"]
-            - 3 * data["psi_rrr"] * data["sqrt(g)_r"] * data["sqrt(g)_rr"]
-        )
-        / (6 * data["sqrt(g)_r"] ** 3),
+            - 3 * data["psi_rrr"] * data["sqrt(g)_r"] * data["sqrt(g)_rr"],
+            (6 * data["sqrt(g)_r"] ** 3),
+        ),
     )
     return data
 
@@ -702,12 +705,16 @@ def _B_rr(params, transforms, profiles, data, **kwargs):
 )
 def _B0_tt(params, transforms, profiles, data, **kwargs):
     data["B0_tt"] = transforms["grid"].replace_at_axis(
-        data["psi_r"]
-        * (2 * data["sqrt(g)_t"] ** 2 - data["sqrt(g)"] * data["sqrt(g)_tt"])
-        / data["sqrt(g)"] ** 3,
-        lambda: data["psi_rr"]
-        * (2 * data["sqrt(g)_rt"] ** 2 - data["sqrt(g)_r"] * data["sqrt(g)_rtt"])
-        / data["sqrt(g)_r"] ** 3,
+        safediv(
+            data["psi_r"]
+            * (2 * data["sqrt(g)_t"] ** 2 - data["sqrt(g)"] * data["sqrt(g)_tt"]),
+            data["sqrt(g)"] ** 3,
+        ),
+        lambda: safediv(
+            data["psi_rr"]
+            * (2 * data["sqrt(g)_rt"] ** 2 - data["sqrt(g)_r"] * data["sqrt(g)_rtt"]),
+            data["sqrt(g)_r"] ** 3,
+        ),
     )
     return data
 
@@ -839,12 +846,16 @@ def _B_tt(params, transforms, profiles, data, **kwargs):
 )
 def _B0_zz(params, transforms, profiles, data, **kwargs):
     data["B0_zz"] = transforms["grid"].replace_at_axis(
-        data["psi_r"]
-        * (2 * data["sqrt(g)_z"] ** 2 - data["sqrt(g)"] * data["sqrt(g)_zz"])
-        / data["sqrt(g)"] ** 3,
-        lambda: data["psi_rr"]
-        * (2 * data["sqrt(g)_rz"] ** 2 - data["sqrt(g)_r"] * data["sqrt(g)_rzz"])
-        / data["sqrt(g)_r"] ** 3,
+        safediv(
+            data["psi_r"]
+            * (2 * data["sqrt(g)_z"] ** 2 - data["sqrt(g)"] * data["sqrt(g)_zz"]),
+            data["sqrt(g)"] ** 3,
+        ),
+        lambda: safediv(
+            data["psi_rr"]
+            * (2 * data["sqrt(g)_rz"] ** 2 - data["sqrt(g)_r"] * data["sqrt(g)_rzz"]),
+            data["sqrt(g)_r"] ** 3,
+        ),
     )
     return data
 
@@ -976,21 +987,21 @@ def _B_zz(params, transforms, profiles, data, **kwargs):
 )
 def _B0_rt(params, transforms, profiles, data, **kwargs):
     data["B0_rt"] = transforms["grid"].replace_at_axis(
-        (
+        safediv(
             -data["sqrt(g)"]
             * (data["psi_rr"] * data["sqrt(g)_t"] + data["psi_r"] * data["sqrt(g)_rt"])
-            + 2 * data["psi_r"] * data["sqrt(g)_r"] * data["sqrt(g)_t"]
-        )
-        / data["sqrt(g)"] ** 3,
-        lambda: (
+            + 2 * data["psi_r"] * data["sqrt(g)_r"] * data["sqrt(g)_t"],
+            data["sqrt(g)"] ** 3,
+        ),
+        lambda: safediv(
             -data["sqrt(g)_r"]
             * (
                 data["psi_rrr"] * data["sqrt(g)_rt"]
                 + data["psi_rr"] * data["sqrt(g)_rrt"]
             )
-            + 2 * data["psi_rr"] * data["sqrt(g)_rr"] * data["sqrt(g)_rt"]
-        )
-        / (2 * data["sqrt(g)_r"] ** 3),
+            + 2 * data["psi_rr"] * data["sqrt(g)_rr"] * data["sqrt(g)_rt"],
+            (2 * data["sqrt(g)_r"] ** 3),
+        ),
     )
     return data
 
@@ -1160,18 +1171,22 @@ def _B_rt(params, transforms, profiles, data, **kwargs):
 )
 def _B0_tz(params, transforms, profiles, data, **kwargs):
     data["B0_tz"] = transforms["grid"].replace_at_axis(
-        data["psi_r"]
-        * (
-            2 * data["sqrt(g)_t"] * data["sqrt(g)_z"]
-            - data["sqrt(g)_tz"] * data["sqrt(g)"]
-        )
-        / data["sqrt(g)"] ** 3,
-        lambda: data["psi_rr"]
-        * (
-            2 * data["sqrt(g)_rt"] * data["sqrt(g)_rz"]
-            - data["sqrt(g)_rtz"] * data["sqrt(g)_r"]
-        )
-        / data["sqrt(g)_r"] ** 3,
+        safediv(
+            data["psi_r"]
+            * (
+                2 * data["sqrt(g)_t"] * data["sqrt(g)_z"]
+                - data["sqrt(g)_tz"] * data["sqrt(g)"]
+            ),
+            data["sqrt(g)"] ** 3,
+        ),
+        lambda: safediv(
+            data["psi_rr"]
+            * (
+                2 * data["sqrt(g)_rt"] * data["sqrt(g)_rz"]
+                - data["sqrt(g)_rtz"] * data["sqrt(g)_r"]
+            ),
+            data["sqrt(g)_r"] ** 3,
+        ),
     )
     return data
 
@@ -1317,21 +1332,21 @@ def _B_tz(params, transforms, profiles, data, **kwargs):
 )
 def _B0_rz(params, transforms, profiles, data, **kwargs):
     data["B0_rz"] = transforms["grid"].replace_at_axis(
-        (
+        safediv(
             -data["sqrt(g)"]
             * (data["psi_rr"] * data["sqrt(g)_z"] + data["psi_r"] * data["sqrt(g)_rz"])
-            + 2 * data["psi_r"] * data["sqrt(g)_r"] * data["sqrt(g)_z"]
-        )
-        / data["sqrt(g)"] ** 3,
-        lambda: (
+            + 2 * data["psi_r"] * data["sqrt(g)_r"] * data["sqrt(g)_z"],
+            data["sqrt(g)"] ** 3,
+        ),
+        lambda: safediv(
             -data["sqrt(g)_r"]
             * (
                 data["psi_rrr"] * data["sqrt(g)_rz"]
                 + data["psi_rr"] * data["sqrt(g)_rrz"]
             )
-            + 2 * data["psi_rr"] * data["sqrt(g)_rr"] * data["sqrt(g)_rz"]
-        )
-        / (2 * data["sqrt(g)_r"] ** 3),
+            + 2 * data["psi_rr"] * data["sqrt(g)_rr"] * data["sqrt(g)_rz"],
+            (2 * data["sqrt(g)_r"] ** 3),
+        ),
     )
     return data
 
@@ -2562,7 +2577,8 @@ def _grad_B(params, transforms, profiles, data, **kwargs):
     data["grad(|B|)"] = (
         data["|B|_r"] * data["e^rho"].T
         + transforms["grid"].replace_at_axis(
-            data["|B|_t"] / data["sqrt(g)"], lambda: data["|B|_rt"] / data["sqrt(g)_r"]
+            safediv(data["|B|_t"], data["sqrt(g)"]),
+            lambda: safediv(data["|B|_rt"], data["sqrt(g)_r"]),
         )
         * data["e^theta*sqrt(g)"].T
         + data["|B|_z"] * data["e^zeta"].T
@@ -2706,13 +2722,13 @@ def _B2_fsa_r(params, transforms, profiles, data, **kwargs):
     num = integrate(data["sqrt(g)"] * data["|B|^2"])
     num_r = integrate(data["sqrt(g)_r"] * data["|B|^2"] + data["sqrt(g)"] * B2_r)
     data["<|B|^2>_r"] = transforms["grid"].replace_at_axis(
-        (num_r * data["V_r(r)"] - num * data["V_rr(r)"]) / data["V_r(r)"] ** 2,
-        lambda: (
+        safediv(num_r * data["V_r(r)"] - num * data["V_rr(r)"], data["V_r(r)"] ** 2),
+        lambda: safediv(
             integrate(data["sqrt(g)_rr"] * data["|B|^2"] + 2 * data["sqrt(g)_r"] * B2_r)
             * data["V_rr(r)"]
-            - num_r * data["V_rrr(r)"]
-        )
-        / (2 * data["V_rr(r)"] ** 2),
+            - num_r * data["V_rrr(r)"],
+            (2 * data["V_rr(r)"] ** 2),
+        ),
     )
     return data
 
@@ -3323,8 +3339,8 @@ def _kappa_g(params, transforms, profiles, data, **kwargs):
 )
 def _grad_B_vec(params, transforms, profiles, data, **kwargs):
     B_t_over_sqrt_g = transforms["grid"].replace_at_axis(
-        (data["B_t"].T / data["sqrt(g)"]).T,
-        lambda: (data["B_rt"].T / data["sqrt(g)_r"]).T,
+        safediv(data["B_t"].T, data["sqrt(g)"]).T,
+        lambda: safediv(data["B_rt"].T, data["sqrt(g)_r"]).T,
     )
     data["grad(B)"] = (
         (data["B_r"][:, jnp.newaxis, :] * data["e^rho"][:, :, jnp.newaxis])

--- a/desc/compute/utils.py
+++ b/desc/compute/utils.py
@@ -513,6 +513,24 @@ def safenorm(x, ord=None, axis=None, fill=0, threshold=0):
     return n
 
 
+def safediv(a, b, fill=0, threshold=0):
+    """Divide a/b with guards for division by zero.
+
+    Parameters
+    ----------
+    a, b : ndarray
+        Numerator and denominator.
+    fill : float, ndarray, optional
+        Value to return where b is zero.
+    threshold : float >= 0
+        How small is b allowed to be.
+    """
+    mask = jnp.abs(b) <= threshold
+    num = jnp.where(mask, fill, a)
+    den = jnp.where(mask, 1, b)
+    return num / den
+
+
 def cumtrapz(y, x=None, dx=1.0, axis=-1, initial=None):
     """Cumulatively integrate y(x) using the composite trapezoidal rule.
 

--- a/desc/objectives/_generic.py
+++ b/desc/objectives/_generic.py
@@ -3,6 +3,8 @@
 import inspect
 import re
 
+import numpy as np
+
 from desc.backend import jnp
 from desc.compute import compute as compute_fun
 from desc.compute import data_index
@@ -304,7 +306,7 @@ class GenericObjective(_Objective):
         elif data_index[p][self.f]["coordinates"] == "r":
             self._dim_f = grid.num_rho
         else:
-            self._dim_f = grid.num_nodes * data_index[p][self.f]["dim"]
+            self._dim_f = grid.num_nodes * np.prod(data_index[p][self.f]["dim"])
         profiles = get_profiles(self.f, obj=eq, grid=grid)
         transforms = get_transforms(self.f, obj=eq, grid=grid)
         self._constants = {

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -859,9 +859,7 @@ class _Objective(IOAble, ABC):
 
         # set quadrature weights if they haven't been
         if hasattr(self, "_constants") and ("quad_weights" not in self._constants):
-            if self._coordinates == "":
-                w = jnp.ones((self.dim_f,))
-            elif self._coordinates == "rtz":
+            if self._coordinates == "rtz":
                 w = self._constants["transforms"]["grid"].weights
                 w *= jnp.sqrt(self._constants["transforms"]["grid"].num_nodes)
             elif self._coordinates == "r":
@@ -870,6 +868,8 @@ class _Objective(IOAble, ABC):
                     surface_label="rho",
                 )
                 w = jnp.sqrt(w)
+            else:
+                w = jnp.ones((self.dim_f,))
             if w.size:
                 w = jnp.tile(w, self.dim_f // w.size)
             self._constants["quad_weights"] = w

--- a/tests/test_axis_limits.py
+++ b/tests/test_axis_limits.py
@@ -5,6 +5,9 @@ If a new quantity is added to the compute functions whose limit is not finite
 If the limit has yet to be derived, add it to the ``not_implemented_limits`` set.
 """
 
+import functools
+import inspect
+
 import numpy as np
 import pytest
 
@@ -13,6 +16,7 @@ from desc.compute.utils import dot, surface_integrals_map
 from desc.equilibrium import Equilibrium
 from desc.examples import get
 from desc.grid import LinearGrid
+from desc.objectives import GenericObjective, ObjectiveFunction
 
 # Unless mentioned in the source code of the compute function, the assumptions
 # made to compute the magnetic axis limit can be reduced to assuming that these
@@ -332,3 +336,57 @@ class TestAxisLimits:
 
         test(get("W7-X"))
         test(get("NCSX"))
+
+
+def _reverse_mode_unsafe_names():
+    names = data_index["desc.equilibrium.equilibrium.Equilibrium"].keys()
+    eq = get("ESTELL")
+
+    def isalias(name):
+        return isinstance(
+            data_index["desc.equilibrium.equilibrium.Equilibrium"][name]["fun"],
+            functools.partial,
+        )
+
+    def get_source(name):
+        return "".join(
+            inspect.getsource(
+                data_index["desc.equilibrium.equilibrium.Equilibrium"][name]["fun"]
+            ).split("def ")[1:]
+        )
+
+    names = [
+        name
+        for name in names
+        if not (
+            "Boozer" in name
+            or "_mn" in name
+            or name == "B modes"
+            or _skip_this(eq, name)
+            or name in not_finite_limits
+            or isalias(name)
+        )
+    ]
+
+    unsafe_names = []  # things that might have nan gradient but shouldn't
+    for name in names:
+        source = get_source(name)
+        if "replace_at_axis" in source:
+            unsafe_names.append(name)
+
+    unsafe_names = sorted(unsafe_names)
+    print("Unsafe names: ", unsafe_names)
+    return unsafe_names
+
+
+@pytest.mark.parametrize("name", _reverse_mode_unsafe_names())
+def test_reverse_mode_ad_axis(name):
+    """Asserts that the rho=0 axis limits are reverse mode differentiable."""
+    eq = get("ESTELL")
+    grid = LinearGrid(rho=0.0, M=2, N=2, NFP=eq.NFP, sym=eq.sym)
+    eq.change_resolution(2, 2, 2, 4, 4, 4)
+
+    obj = ObjectiveFunction(GenericObjective(name, eq, grid=grid), verbose=0)
+    obj.build(verbose=0)
+    g = obj.grad(obj.x())
+    assert not np.any(np.isnan(g))


### PR DESCRIPTION
Fixes to prevent NaNs in reverse mode differentiation for qtys at the axis.

The issue is that stuff like this
```python
jnp.where(b==0, a_r/b_r, a/b)
```
is not reverse mode differentiable, since you end up propagating a NaN adjoint variable.

This switches stuff like the above to be more like
```python
mask = b==0
jnp.where(mask, a_r, a)/jnp.where(mask, b_r, b)  
```
Side effect: some qtys that are sort of undefined for surface classes that used to evaluates to NaN now evaluate to zero.

Resolves #738 (again)