### PR TITLE
make elongation a function of zeta

### DIFF
--- a/desc/compute/_geometry.py
+++ b/desc/compute/_geometry.py
@@ -342,6 +342,7 @@ def _R0_over_a(params, transforms, profiles, data, **kwargs):
     profiles=[],
     coordinates="z",
     data=["rho", "sqrt(g)", "g_tt", "R"],
+    grid_type="quad",
 )
 def _a_major_over_a_minor(params, transforms, profiles, data, **kwargs):
     max_rho = jnp.max(data["rho"])

--- a/desc/compute/_geometry.py
+++ b/desc/compute/_geometry.py
@@ -335,16 +335,16 @@ def _R0_over_a(params, transforms, profiles, data, **kwargs):
     label="a_{\\mathrm{major}} / a_{\\mathrm{minor}}",
     units="~",
     units_long="None",
-    description="Maximum elongation",
-    dim=0,
+    description="Elongation at a toroidal cross-section",
+    dim=1,
     params=[],
     transforms={"grid": []},
     profiles=[],
-    coordinates="",
-    data=["sqrt(g)", "g_tt", "R"],
+    coordinates="z",
+    data=["rho", "sqrt(g)", "g_tt", "R"],
 )
 def _a_major_over_a_minor(params, transforms, profiles, data, **kwargs):
-    max_rho = transforms["grid"].nodes[transforms["grid"].unique_rho_idx[-1], 0]
+    max_rho = jnp.max(data["rho"])
     P = (  # perimeter at rho=1
         line_integrals(
             transforms["grid"],
@@ -378,7 +378,7 @@ def _a_major_over_a_minor(params, transforms, profiles, data, **kwargs):
         + 3 * P
     ) / (12 * jnp.pi)
     b = A / (jnp.pi * a)  # semi-minor radius
-    data["a_major/a_minor"] = jnp.max(a / b)
+    data["a_major/a_minor"] = transforms["grid"].expand(a / b, surface_label="zeta")
     return data
 
 

--- a/desc/compute/data_index.py
+++ b/desc/compute/data_index.py
@@ -66,6 +66,7 @@ def register_compute_fun(
     data,
     aliases=[],
     parameterization="desc.equilibrium.equilibrium.Equilibrium",
+    grid_type=None,
     axis_limit_data=None,
     **kwargs,
 ):
@@ -98,14 +99,16 @@ def register_compute_fun(
         a flux function, etc.
     data : list of str
         Names of other items in the data index needed to compute qty.
-    parameterization: str or list of str
-        Name of desc types the method is valid for. eg 'desc.geometry.FourierXYZCurve'
-        or `desc.equilibrium.Equilibrium`.
-    axis_limit_data : list of str
-        Names of other items in the data index needed to compute axis limit of qty.
     aliases : list
         Aliases of `name`. Will be stored in the data dictionary as a copy of `name`s
         data.
+    parameterization : str or list of str
+        Name of desc types the method is valid for. eg `'desc.geometry.FourierXYZCurve'`
+        or `'desc.equilibrium.Equilibrium'`.
+    grid_type : str
+        Name of grid type the quantity must be computed with. eg `'quad'`.
+    axis_limit_data : list of str
+        Names of other items in the data index needed to compute axis limit of qty.
 
     Notes
     -----
@@ -139,6 +142,7 @@ def register_compute_fun(
             "coordinates": coordinates,
             "dependencies": deps,
             "aliases": aliases,
+            "grid_type": grid_type,
         }
         for p in parameterization:
             flag = False
@@ -150,7 +154,6 @@ def register_compute_fun(
                         )
                     data_index[base_class][name] = d.copy()
                     for alias in aliases:
-
                         data_index[base_class][alias] = d.copy()
                         # assigns alias compute func to generator to be used later
                         data_index[base_class][alias]["fun"] = functools.partial(

--- a/desc/equilibrium/equilibrium.py
+++ b/desc/equilibrium/equilibrium.py
@@ -818,10 +818,15 @@ class Equilibrium(IOAble, Optimizable):
         # and compute those first on a full grid
         p = "desc.equilibrium.equilibrium.Equilibrium"
         deps = list(set(get_data_deps(names, obj=p, has_axis=grid.axis.size) + names))
+        # TODO: replace this logic with `grid_type` from data_index
         dep0d = [
             dep
             for dep in deps
-            if (data_index[p][dep]["coordinates"] == "") and (dep not in data)
+            if (
+                (data_index[p][dep]["coordinates"] == "")
+                or (data_index[p][dep]["grid_type"] == "quad")
+            )
+            and (dep not in data)
         ]
         dep1d = [
             dep

--- a/desc/objectives/_geometry.py
+++ b/desc/objectives/_geometry.py
@@ -155,7 +155,10 @@ class AspectRatio(_Objective):
 
 
 class Elongation(_Objective):
-    """Elongation = semi-major radius / semi-minor radius. Max of all toroidal angles.
+    """Elongation = semi-major radius / semi-minor radius.
+
+    Elongation is a function of the toroidal angle.
+    Default ``loss_function="max"`` returns the maximum of all toroidal angles.
 
     Parameters
     ----------
@@ -205,7 +208,7 @@ class Elongation(_Objective):
         weight=1,
         normalize=True,
         normalize_target=True,
-        loss_function=None,
+        loss_function="max",
         deriv_mode="auto",
         grid=None,
         name="elongation",
@@ -242,7 +245,7 @@ class Elongation(_Objective):
         else:
             grid = self._grid
 
-        self._dim_f = 1
+        self._dim_f = grid.num_zeta
         self._data_keys = ["a_major/a_minor"]
 
         timer = Timer()
@@ -289,7 +292,9 @@ class Elongation(_Objective):
             transforms=constants["transforms"],
             profiles=constants["profiles"],
         )
-        return data["a_major/a_minor"]
+        return self._constants["transforms"]["grid"].compress(
+            data["a_major/a_minor"], surface_label="zeta"
+        )
 
 
 class Volume(_Objective):

--- a/tests/test_axis_limits.py
+++ b/tests/test_axis_limits.py
@@ -228,8 +228,11 @@ def assert_is_continuous(
             continue
         else:
             assert np.isfinite(data[name]).all(), name
-        if data_index[p][name]["coordinates"] == "":
-            # can't check continuity of global scalar
+        if (
+            data_index[p][name]["coordinates"] == ""
+            or data_index[p][name]["coordinates"] == "z"
+        ):
+            # can't check continuity of global scalar or function of toroidal angle
             continue
         # make single variable function of rho
         if data_index[p][name]["coordinates"] == "r":


### PR DESCRIPTION
Elongation `"a_major/a_minor"` is a function of the toroidal angle, since we compute it using the perimeter and area at each cross-section. Previously, our compute and objective functions only returned the maximum elongation of all toroidal angles in the grid. 

This PR generalizes it to return the values as a function of zeta. The advantage is that now we can target either the mean or max elongation with the Objective's `loss_function`. The default is still to return the maximum value for backwards compatibility. 