### PR TITLE
fix bug where FourierCurrentPotentialField would not initialize Phi_mn coefficients properly

### DIFF
--- a/desc/geometry/curve.py
+++ b/desc/geometry/curve.py
@@ -72,6 +72,9 @@ class FourierRZCurve(Curve):
 
         modes_R, modes_Z = np.asarray(modes_R), np.asarray(modes_Z)
 
+        assert R_n.size == modes_R.size, "R_n size and modes_R must be the same size!"
+        assert Z_n.size == modes_Z.size, "Z_n size and modes_Z must be the same size!"
+
         assert issubclass(modes_R.dtype.type, np.integer)
         assert issubclass(modes_Z.dtype.type, np.integer)
         assert isposint(NFP)
@@ -289,6 +292,10 @@ class FourierXYZCurve(Curve):
             modes = np.asarray(modes)
 
         assert issubclass(modes.dtype.type, np.integer)
+
+        assert X_n.size == modes.size, "X_n and modes must be the same size!"
+        assert Y_n.size == modes.size, "Y_n and modes must be the same size!"
+        assert Z_n.size == modes.size, "Z_n and modes must be the same size!"
 
         N = np.max(abs(modes))
         self._X_basis = FourierSeries(N, NFP=1, sym=False)
@@ -533,6 +540,8 @@ class FourierPlanarCurve(Curve):
         else:
             modes = np.asarray(modes)
         assert issubclass(modes.dtype.type, np.integer)
+        print(modes.shape)
+        assert r_n.size == modes.size, "r_n size and modes must be the same size!"
 
         N = np.max(abs(modes))
         self._r_basis = FourierSeries(N, NFP=1, sym=False)

--- a/desc/geometry/curve.py
+++ b/desc/geometry/curve.py
@@ -72,8 +72,8 @@ class FourierRZCurve(Curve):
 
         modes_R, modes_Z = np.asarray(modes_R), np.asarray(modes_Z)
 
-        assert R_n.size == modes_R.size, "R_n size and modes_R must be the same size!"
-        assert Z_n.size == modes_Z.size, "Z_n size and modes_Z must be the same size!"
+        assert R_n.size == modes_R.size, "R_n size and modes_R must be the same size"
+        assert Z_n.size == modes_Z.size, "Z_n size and modes_Z must be the same size"
 
         assert issubclass(modes_R.dtype.type, np.integer)
         assert issubclass(modes_Z.dtype.type, np.integer)
@@ -293,9 +293,9 @@ class FourierXYZCurve(Curve):
 
         assert issubclass(modes.dtype.type, np.integer)
 
-        assert X_n.size == modes.size, "X_n and modes must be the same size!"
-        assert Y_n.size == modes.size, "Y_n and modes must be the same size!"
-        assert Z_n.size == modes.size, "Z_n and modes must be the same size!"
+        assert X_n.size == modes.size, "X_n and modes must be the same size"
+        assert Y_n.size == modes.size, "Y_n and modes must be the same size"
+        assert Z_n.size == modes.size, "Z_n and modes must be the same size"
 
         N = np.max(abs(modes))
         self._X_basis = FourierSeries(N, NFP=1, sym=False)
@@ -480,7 +480,7 @@ class FourierXYZCurve(Curve):
             errorif(
                 not np.all(np.diff(s) > 0),
                 ValueError,
-                "supplied s must be monotonically increasing!",
+                "supplied s must be monotonically increasing",
             )
             errorif(s[0] < 0, ValueError, "s must lie in [0, 2pi]")
             errorif(s[-1] > 2 * np.pi, ValueError, "s must lie in [0, 2pi]")
@@ -540,8 +540,7 @@ class FourierPlanarCurve(Curve):
         else:
             modes = np.asarray(modes)
         assert issubclass(modes.dtype.type, np.integer)
-        print(modes.shape)
-        assert r_n.size == modes.size, "r_n size and modes must be the same size!"
+        assert r_n.size == modes.size, "r_n size and modes must be the same size"
 
         N = np.max(abs(modes))
         self._r_basis = FourierSeries(N, NFP=1, sym=False)
@@ -707,7 +706,7 @@ class SplineXYZCurve(Curve):
             errorif(
                 not np.all(np.diff(knots) > 0),
                 ValueError,
-                "supplied knots must be monotonically increasing!",
+                "supplied knots must be monotonically increasing",
             )
             errorif(knots[0] < 0, ValueError, "knots must lie in [0, 2pi]")
             errorif(knots[-1] > 2 * np.pi, ValueError, "knots must lie in [0, 2pi]")
@@ -776,7 +775,7 @@ class SplineXYZCurve(Curve):
             errorif(
                 not np.all(np.diff(knots) > 0),
                 ValueError,
-                "supplied knots must be monotonically increasing!",
+                "supplied knots must be monotonically increasing",
             )
             errorif(knots[0] < 0, ValueError, "knots must lie in [0, 2pi]")
             errorif(knots[-1] > 2 * np.pi, ValueError, "knots must lie in [0, 2pi]")

--- a/desc/geometry/surface.py
+++ b/desc/geometry/surface.py
@@ -76,6 +76,13 @@ class FourierRZToroidalSurface(Surface):
             np.asarray, (R_lmn, Z_lmn, modes_R, modes_Z)
         )
 
+        assert (
+            R_lmn.size == modes_R.shape[0]
+        ), "R_lmn size and modes_R.shape[0] must be the same size!"
+        assert (
+            Z_lmn.size == modes_Z.shape[0]
+        ), "Z_lmn size and modes_Z.shape[0] must be the same size!"
+
         assert issubclass(modes_R.dtype.type, np.integer)
         assert issubclass(modes_Z.dtype.type, np.integer)
         assert isposint(NFP)
@@ -432,6 +439,13 @@ class ZernikeRZToroidalSection(Surface):
         R_lmn, Z_lmn, modes_R, modes_Z = map(
             np.asarray, (R_lmn, Z_lmn, modes_R, modes_Z)
         )
+
+        assert (
+            R_lmn.size == modes_R.shape[0]
+        ), "R_lmn size and modes_R.shape[0] must be the same size!"
+        assert (
+            Z_lmn.size == modes_Z.shape[0]
+        ), "Z_lmn size and modes_Z.shape[0] must be the same size!"
 
         assert issubclass(modes_R.dtype.type, np.integer)
         assert issubclass(modes_Z.dtype.type, np.integer)

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -1575,8 +1575,6 @@ class FourierCurrentPotentialField(
         name="",
         check_orientation=True,
     ):
-        self._Phi_mn = Phi_mn
-
         Phi_mn, modes_Phi = map(np.asarray, (Phi_mn, modes_Phi))
 
         assert np.issubdtype(modes_Phi.dtype, np.integer)
@@ -1603,6 +1601,7 @@ class FourierCurrentPotentialField(
                 sym_Phi = "cos"
         self._sym_Phi = sym_Phi
         self._Phi_basis = DoubleFourierSeries(M=M_Phi, N=N_Phi, NFP=NFP, sym=sym_Phi)
+        self._Phi_mn = copy_coeffs(Phi_mn, modes_Phi, self._Phi_basis.modes[:, 1:])
 
         assert np.isscalar(I) or np.asarray(I).size == 1, "I must be a scalar"
         assert np.isscalar(G) or np.asarray(G).size == 1, "G must be a scalar"

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -1576,6 +1576,9 @@ class FourierCurrentPotentialField(
         check_orientation=True,
     ):
         Phi_mn, modes_Phi = map(np.asarray, (Phi_mn, modes_Phi))
+        assert (
+            Phi_mn.size == modes_Phi.shape[0]
+        ), "Phi_mn size and modes_Phi.shape[0] must be the same size!"
 
         assert np.issubdtype(modes_Phi.dtype, np.integer)
 

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -131,6 +131,10 @@ class TestRZCurve:
         """Test error checking when creating FourierRZCurve."""
         with pytest.raises(ValueError):
             _ = FourierRZCurve(R_n=[])
+        with pytest.raises(AssertionError):
+            _ = FourierRZCurve(R_n=[1], modes_R=[1, 2])
+        with pytest.raises(AssertionError):
+            _ = FourierRZCurve(Z_n=[1], modes_Z=[1, 2])
 
     @pytest.mark.unit
     def test_to_FourierXYZCurve(self):
@@ -363,6 +367,16 @@ class TestFourierXYZCurve:
         with pytest.raises(ValueError):
             c.Z_n = s.Z_n
 
+    @pytest.mark.unit
+    def test_asserts(self):
+        """Test error checking when creating FourierXYZCurve."""
+        with pytest.raises(AssertionError):
+            _ = FourierXYZCurve(X_n=[1], modes=[1, 2])
+        with pytest.raises(AssertionError):
+            _ = FourierXYZCurve(Y_n=[1], modes=[1, 2])
+        with pytest.raises(AssertionError):
+            _ = FourierXYZCurve(Z_n=[1], modes=[1, 2])
+
 
 class TestPlanarCurve:
     """Tests for FourierPlanarCurve class."""
@@ -477,6 +491,8 @@ class TestPlanarCurve:
             c.center = [4]
         with pytest.raises(ValueError):
             c.normal = [4]
+        with pytest.raises(AssertionError):
+            _ = FourierPlanarCurve(r_n=[1], modes=[1, 2])
 
 
 class TestSplineXYZCurve:

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -493,6 +493,21 @@ class TestMagneticFields:
         with pytest.raises(AssertionError):
             field.G = np.array([1, 2])
 
+        # check that we cant initialize with different size
+        # Phi_mn and Phi_modes arrays
+        with pytest.raises(AssertionError):
+            field = FourierCurrentPotentialField(
+                Phi_mn=phi_mn[0:-1],  # too short by 1
+                modes_Phi=basis.modes[:, 1:],
+                I=0,
+                G=-G,
+                R_lmn=surface.R_lmn,
+                Z_lmn=surface.Z_lmn,
+                modes_R=surface._R_basis.modes[:, 1:],
+                modes_Z=surface._Z_basis.modes[:, 1:],
+                NFP=10,
+            )
+
     def test_change_Phi_basis_fourier_current_field(self):
         """Test that change_Phi_resolution works for FourierCurrentPotentialField."""
         surface = FourierRZToroidalSurface(

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -548,6 +548,29 @@ class TestMagneticFields:
         np.testing.assert_allclose(field.Phi_basis.modes, basis.modes)
         assert field.Phi_basis.sym == "sin"
 
+    def test_init_Phi_mn_fourier_current_field(self):
+        """Test initial Phi_mn size is correct for FourierCurrentPotentialField."""
+        surface = FourierRZToroidalSurface(
+            R_lmn=jnp.array([10, 1]),
+            Z_lmn=jnp.array([0, -1]),
+            modes_R=jnp.array([[0, 0], [1, 0]]),
+            modes_Z=jnp.array([[0, 0], [-1, 0]]),
+            NFP=10,
+        )
+
+        field = FourierCurrentPotentialField(
+            Phi_mn=np.array([1, 1]),
+            modes_Phi=np.array([[1, 1], [3, 3]]),
+            R_lmn=surface.R_lmn,
+            Z_lmn=surface.Z_lmn,
+            modes_R=surface._R_basis.modes[:, 1:],
+            modes_Z=surface._Z_basis.modes[:, 1:],
+            NFP=10,
+        )
+        assert field.Phi_mn.size == field.Phi_basis.num_modes
+        # ensure can compute field at a point without incompatible size error
+        field.compute_magnetic_field([10.0, 0, 0])
+
     @pytest.mark.slow
     @pytest.mark.unit
     def test_spline_field(self):

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -557,10 +557,12 @@ class TestMagneticFields:
             modes_Z=jnp.array([[0, 0], [-1, 0]]),
             NFP=10,
         )
+        init_modes = np.array([[1, 1], [3, 3]])
+        init_coeffs = np.array([1, 1])
 
         field = FourierCurrentPotentialField(
-            Phi_mn=np.array([1, 1]),
-            modes_Phi=np.array([[1, 1], [3, 3]]),
+            Phi_mn=init_coeffs,
+            modes_Phi=init_modes,
             R_lmn=surface.R_lmn,
             Z_lmn=surface.Z_lmn,
             modes_R=surface._R_basis.modes[:, 1:],
@@ -568,6 +570,13 @@ class TestMagneticFields:
             NFP=10,
         )
         assert field.Phi_mn.size == field.Phi_basis.num_modes
+        inds_nonzero = []
+        for coef, modes in zip(init_coeffs, init_modes):
+            ind = field.Phi_basis.get_idx(M=modes[0], N=modes[1])
+            assert coef == field.Phi_mn[ind]
+            inds_nonzero.append(ind)
+        inds_zero = np.setdiff1d(np.arange(field.Phi_basis.num_modes), inds_nonzero)
+        np.testing.assert_allclose(field.Phi_mn[inds_zero], 0)
         # ensure can compute field at a point without incompatible size error
         field.compute_magnetic_field([10.0, 0, 0])
 

--- a/tests/test_surfaces.py
+++ b/tests/test_surfaces.py
@@ -72,6 +72,16 @@ class TestFourierRZToroidalSurface:
         assert c.R_basis.NFP == 3
         assert c.Z_basis.NFP == 3
 
+        # test assert statement for array sizes matching
+        with pytest.raises(AssertionError):
+            c = FourierRZToroidalSurface(
+                R_lmn=np.array([1, 2, 3]), modes_R=np.array([[0, 0], [1, 0]])
+            )
+        with pytest.raises(AssertionError):
+            c = FourierRZToroidalSurface(
+                Z_lmn=np.array([1, 2, 3]), modes_Z=np.array([[0, 0], [1, 0]])
+            )
+
     @pytest.mark.unit
     def test_from_input_file(self):
         """Test reading a surface from a vmec or desc input file."""


### PR DESCRIPTION
- also adds asserts to ensure passed-in modes match the coefficients size to `FourierCurrentPotentialField` and `FourierRZToroidalSurface`