### PR TITLE
Dp/hotfix optimize multiple things

### DIFF
--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -387,7 +387,7 @@ class ObjectiveFunction(IOAble):
         """Return the full state vector from the Optimizable objects things."""
         # TODO: also check resolution etc?
         things = things or self.things
-        assert [type(t1) == type(t2) for t1, t2 in zip(things, self.things)]
+        assert all([type(t1) == type(t2) for t1, t2 in zip(things, self.things)])
         xs = [t.pack_params(t.params_dict) for t in things]
         return jnp.concatenate(xs)
 
@@ -763,7 +763,6 @@ class _Objective(IOAble, ABC):
         deriv_mode="auto",
         name=None,
     ):
-
         if self._scalar:
             assert self._coordinates == ""
         assert np.all(np.asarray(weight) > 0)

--- a/desc/optimize/optimizer.py
+++ b/desc/optimize/optimizer.py
@@ -231,8 +231,7 @@ class Optimizer(IOAble):
                     "yellow",
                 )
             )
-
-        x0 = objective.x(*things)
+        x0 = objective.x(*[things[things.index(t)] for t in objective.things])
 
         stoptol = _get_default_tols(
             method,
@@ -310,18 +309,29 @@ class Optimizer(IOAble):
 
         if verbose > 0:
             print("Start of solver")
-            objective.print_value(objective.x(*things0))
+
+            # need to check index of things bc things0 contains copies of
+            # things, so they are not the same exact Python objects
+            objective.print_value(
+                objective.x(*[things0[things.index(t)] for t in objective.things])
+            )
             for con in constraints:
-                con.print_value(
-                    *con.xs(
-                        *[t0 for (t0, t) in zip(things0, things) if t in con.things]
-                    )
-                )
+                arg_inds_for_this_con = [
+                    things.index(t) for t in things if t in con.things
+                ]
+                args_for_this_con = [things0[ind] for ind in arg_inds_for_this_con]
+                con.print_value(*con.xs(*args_for_this_con))
 
             print("End of solver")
-            objective.print_value(objective.x(*things))
+            objective.print_value(
+                objective.x(*[things[things.index(t)] for t in objective.things])
+            )
             for con in constraints:
-                con.print_value(*con.xs(*[t for t in things if t in con.things]))
+                arg_inds_for_this_con = [
+                    things.index(t) for t in things if t in con.things
+                ]
+                args_for_this_con = [things[ind] for ind in arg_inds_for_this_con]
+                con.print_value(*con.xs(*args_for_this_con))
 
         if copy:
             # need to swap things and things0, since things should be unchanged

--- a/desc/optimize/optimizer.py
+++ b/desc/optimize/optimizer.py
@@ -304,8 +304,8 @@ class Optimizer(IOAble):
             _ = result.pop(key, None)
 
         # temporarily assign new stuff for printing, might get replaced later
-        for thing, params in zip(things, result["history"][-1]):
-            thing.params_dict = params
+        for thing, params in zip(objective.things, result["history"][-1]):
+            get_instance(things, type(thing)).params_dict = params
 
         if verbose > 0:
             print("Start of solver")

--- a/desc/optimize/optimizer.py
+++ b/desc/optimize/optimizer.py
@@ -305,7 +305,8 @@ class Optimizer(IOAble):
 
         # temporarily assign new stuff for printing, might get replaced later
         for thing, params in zip(objective.things, result["history"][-1]):
-            get_instance(things, type(thing)).params_dict = params
+            ind = things.index(thing)
+            things[ind].params_dict = params
 
         if verbose > 0:
             print("Start of solver")

--- a/desc/optimize/optimizer.py
+++ b/desc/optimize/optimizer.py
@@ -231,6 +231,10 @@ class Optimizer(IOAble):
                     "yellow",
                 )
             )
+        # we have to use this cumbersome indexing in this method when passing things
+        # to objective to guard against the passed-in things having an ordering
+        # different from objective.things, to ensure the correct order is passed
+        # to the objective
         x0 = objective.x(*[things[things.index(t)] for t in objective.things])
 
         stoptol = _get_default_tols(
@@ -304,12 +308,13 @@ class Optimizer(IOAble):
 
         # temporarily assign new stuff for printing, might get replaced later
         for thing, params in zip(objective.things, result["history"][-1]):
+            # more indexing here to ensure the correct params are assigned to the
+            # correct thing, as the order of things and objective.things might differ
             ind = things.index(thing)
             things[ind].params_dict = params
 
         if verbose > 0:
             print("Start of solver")
-
             # need to check index of things bc things0 contains copies of
             # things, so they are not the same exact Python objects
             objective.print_value(


### PR DESCRIPTION
- Fix bug that occurs when `optimizer.optimize` is called with `things` in an order different than the order of `objective.things`, allowing it to run error-free and to correctly perform the optimization
- Fix bug inside of assert statement of `ObjectiveFunction.x`

Essentially, this fix works by using the ordering of `objective.things`, which was used to unpack the `x` after the optimization is done, and just finding where in `things` corresponds to the order of `objective.things`.

It also ensure that `objective.x` is called with the correct order of `things` inside of `optimize`
 - I thought about adding this logic inside of `objective.x` but we also call that function with the copy of `things`, so that would not allow us to pass in any `things` that were not the exact Python objects inside of `objective.things`
 - with the assert statement fixed this should at least ensure that the correct types are passed in now

I am unsure if there are other places where this pops up but this seems to be enough to fix the bug I was encountering with the optimization of multiple objects, I think this is the only place though as inside of `optimize` is the only time where  user-generated ordering of `things` is passed, which might differ from `objective.things`

Resolves #828 