### PR TITLE
Fix array sizes of lagrange multipliers

### DIFF
--- a/desc/optimize/aug_lagrangian.py
+++ b/desc/optimize/aug_lagrangian.py
@@ -310,8 +310,7 @@ def fmin_auglag(  # noqa: C901 - FIXME: simplify this
         _g = grad_wrapped(z, *args)
         y = jnp.linalg.lstsq(_J.T, _g)[0]
         y = jnp.nan_to_num(y, nan=0.0, posinf=0.0, neginf=0.0)
-    mu = jnp.atleast_1d(mu)
-    y = jnp.atleast_1d(y)
+    y, mu, c = jnp.broadcast_arrays(y, mu, c)
 
     # notation following Conn & Gould, algorithm 14.4.2, but with our mu = their mu^-1
     omega = options.pop("omega", 1.0)

--- a/desc/optimize/aug_lagrangian_ls.py
+++ b/desc/optimize/aug_lagrangian_ls.py
@@ -249,8 +249,7 @@ def lsq_auglag(  # noqa: C901 - FIXME: simplify this
         _g = f @ jac_wrapped(z, *args)
         y = jnp.linalg.lstsq(_J.T, _g)[0]
         y = jnp.nan_to_num(y, nan=0.0, posinf=0.0, neginf=0.0)
-    mu = jnp.atleast_1d(mu)
-    y = jnp.atleast_1d(y)
+    y, mu, c = jnp.broadcast_arrays(y, mu, c)
 
     # notation following Conn & Gould, algorithm 14.4.2, but with our mu = their mu^-1
     omega = options.pop("omega", 1.0)


### PR DESCRIPTION
Just ensures that all the things that should be the same size are the same size.