### PR TITLE
Allow Optimization with OptimizableCollections to Work

### DIFF
--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -475,6 +475,12 @@ class SumMagneticField(_MagneticField, MutableSequence, OptimizableCollection):
             [type(field) for field in fields]
         )
         self._fields = fields
+        offset = jnp.concatenate(
+            [jnp.array([0]), jnp.cumsum(jnp.array([s.dim_x for s in self]))[:-1]]
+        )
+        # store split indices for unpacking
+        # as a numpy array to avoid jax issues later
+        self._split_idx = np.asarray(offset)
 
     def compute_magnetic_field(self, coords, params=None, basis="rpz", grid=None):
         """Compute magnetic field at a set of points.

--- a/desc/objectives/__init__.py
+++ b/desc/objectives/__init__.py
@@ -13,6 +13,7 @@ from ._generic import GenericObjective, LinearObjectiveFromUser, ObjectiveFromUs
 from ._geometry import (
     AspectRatio,
     BScaleLength,
+    DummyFields,
     Elongation,
     GoodCoordinates,
     MeanCurvature,

--- a/desc/objectives/_geometry.py
+++ b/desc/objectives/_geometry.py
@@ -1349,7 +1349,7 @@ class DummyFields(_Objective):
     fields : MagneticField
         MagneticField object.
     eq : Equilibrium
-        eq to target iota from fields in.
+        eq to calc coords to target Bphi over BZ from fields at.
     target : {float, ndarray}, optional
         Target value(s) of the objective. Only used if bounds is None.
         Must be broadcastable to Objective.dim_f.
@@ -1374,8 +1374,10 @@ class DummyFields(_Objective):
         "auto" selects forward or reverse mode based on the size of the input and output
         of the objective. Has no effect on self.grad or self.hess which always use
         reverse mode and forward over reverse mode respectively.
-    grid : Grid, optional
+    eval_grid : Grid, optional
         Collocation grid containing the nodes to evaluate at.
+    source_grid : Grid, optional
+        Grid to discretize field objects with.
     name : str, optional
         Name of the objective function.
 
@@ -1398,7 +1400,7 @@ class DummyFields(_Objective):
         deriv_mode="auto",
         eval_grid=None,
         source_grid=None,
-        name="mag field iota",
+        name="Bphi over BZ",
     ):
         if target is None and bounds is None:
             bounds = (1, np.inf)

--- a/desc/objectives/_geometry.py
+++ b/desc/objectives/_geometry.py
@@ -1339,3 +1339,142 @@ class GoodCoordinates(_Objective):
         f = data["g_rr"]
 
         return jnp.concatenate([g, constants["sigma"] * f])
+
+
+class DummyFields(_Objective):
+    """Target a quantity at points from magnetic fields.
+
+    Parameters
+    ----------
+    fields : MagneticField
+        MagneticField object.
+    eq : Equilibrium
+        eq to target iota from fields in.
+    target : {float, ndarray}, optional
+        Target value(s) of the objective. Only used if bounds is None.
+        Must be broadcastable to Objective.dim_f.
+    bounds : tuple of {float, ndarray}, optional
+        Lower and upper bounds on the objective. Overrides target.
+        Both bounds must be broadcastable to to Objective.dim_f
+    weight : {float, ndarray}, optional
+        Weighting to apply to the Objective, relative to other Objectives.
+        Must be broadcastable to to Objective.dim_f
+    normalize : bool, optional
+        Whether to compute the error in physical units or non-dimensionalize.
+    normalize_target : bool
+        Whether target should be normalized before comparing to computed values.
+        if `normalize` is `True` and the target is in physical units, this should also
+        be set to True.
+    loss_function : {None, 'mean', 'min', 'max'}, optional
+        Loss function to apply to the objective values once computed. This loss function
+        is called on the raw compute value, before any shifting, scaling, or
+        normalization.
+    deriv_mode : {"auto", "fwd", "rev"}
+        Specify how to compute jacobian matrix, either forward mode or reverse mode AD.
+        "auto" selects forward or reverse mode based on the size of the input and output
+        of the objective. Has no effect on self.grad or self.hess which always use
+        reverse mode and forward over reverse mode respectively.
+    grid : Grid, optional
+        Collocation grid containing the nodes to evaluate at.
+    name : str, optional
+        Name of the objective function.
+
+    """
+
+    _coordinates = "rtz"
+    _units = "unitless"
+    _print_value_fmt = "Magnetic field quantity: {:10.3e} "
+
+    def __init__(
+        self,
+        field,
+        eq,
+        target=None,
+        bounds=None,
+        weight=1,
+        normalize=True,
+        normalize_target=True,
+        loss_function=None,
+        deriv_mode="auto",
+        eval_grid=None,
+        source_grid=None,
+        name="mag field iota",
+    ):
+        if target is None and bounds is None:
+            bounds = (1, np.inf)
+        self._eval_grid = eval_grid
+        self._source_grid = source_grid
+        self._eq = eq
+
+        super().__init__(
+            things=field,
+            target=target,
+            bounds=bounds,
+            weight=weight,
+            normalize=normalize,
+            normalize_target=normalize_target,
+            loss_function=loss_function,
+            deriv_mode=deriv_mode,
+            name=name,
+        )
+
+    def build(self, use_jit=True, verbose=1):
+        """Build constant arrays.
+
+        Parameters
+        ----------
+        use_jit : bool, optional
+            Whether to just-in-time compile the objective and derivatives.
+        verbose : int, optional
+            Level of output.
+
+        """
+        eq = self._eq
+        if self._eval_grid is None:
+            eval_grid = LinearGrid(M=eq.M * 2, N=eq.N * 2, NFP=eq.NFP)
+        else:
+            eval_grid = self._eval_grid
+
+        self._dim_f = eval_grid.num_nodes
+        self._data_keys = ["R", "phi", "Z", "e^theta", "e^zeta"]
+
+        timer = Timer()
+        if verbose > 0:
+            print("Precomputing transforms")
+        timer.start("Precomputing transforms")
+        data = eq.compute(self._data_keys, grid=eval_grid)
+        self._constants = {
+            "coords_rpz": np.vstack([data["R"], data["phi"], data["Z"]]).T,
+            "quad_weights": eval_grid.weights,
+        }
+
+        timer.stop("Precomputing transforms")
+        if verbose > 1:
+            timer.disp("Precomputing transforms")
+
+        super().build(use_jit=use_jit, verbose=verbose)
+
+    def compute(self, params, constants=None):
+        """Compute magnetic field scale length.
+
+        Parameters
+        ----------
+        params : dict
+            Dictionary of equilibrium degrees of freedom, eg Equilibrium.params_dict
+        constants : dict
+            Dictionary of constant data, eg transforms, profiles etc. Defaults to
+            self.constants
+
+        Returns
+        -------
+        f : ndarray
+            quantity.
+
+        """
+        if constants is None:
+            constants = self.constants
+        B = self.things[0].compute_magnetic_field(
+            constants["coords_rpz"], basis="rpz", params=params
+        )
+        # return Bphi over BZ (some random quantity we can directly control)
+        return B[:, 1] / B[:, 2]

--- a/desc/objectives/utils.py
+++ b/desc/objectives/utils.py
@@ -101,8 +101,9 @@ def factorize_linear_constraints(constraints, objective):  # noqa: C901
                 A_per_subthing = []
                 # it is an optimizable collection, loop through its sub-objects
                 for subthing in thing:
-                    if subthing in con.things:
-                        A_ = con.jac_scaled(*xz)[con.things.index(subthing)]
+                    if subthing in con._subthings:
+                        # this returns a tuple of length 1 for some reason?
+                        A_ = con.jac_scaled(*xz)[0][con._subthings.index(subthing)]
                     else:
                         A_ = {
                             arg: jnp.zeros((con.dim_f, dimx))

--- a/desc/objectives/utils.py
+++ b/desc/objectives/utils.py
@@ -178,8 +178,6 @@ def factorize_linear_constraints(constraints, objective):  # noqa: C901
     xp_ = objective.unpack_state(xp, False)
     for con in constraints:
         xpi = [xp_[i] for i, t in enumerate(objective.things) if t in con.things]
-        if not xpi:
-            continue  # if no particular solution bc things is not constrained
         y1 = con.compute_unscaled(*xpi)
         y2 = con.target
         y1, y2 = np.broadcast_arrays(y1, y2)

--- a/desc/objectives/utils.py
+++ b/desc/objectives/utils.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 
 from desc.backend import cond, jnp, logsumexp, put
+from desc.optimizable import OptimizableCollection
 from desc.utils import Index, flatten_list, svd_inv_null
 
 
@@ -81,19 +82,42 @@ def factorize_linear_constraints(constraints, objective):  # noqa: C901
         xz = _tree_zeros_like([t.params_dict for t in con.things])
         # computing A matrix for each constraint for each thing in the optimization
         for thing in objective.things:
-            if thing in con.things:
-                A_ = con.jac_scaled(*xz)[con.things.index(thing)]
+            if not isinstance(thing, OptimizableCollection):
+                if thing in con.things:
+                    A_ = con.jac_scaled(*xz)[con.things.index(thing)]
+                else:
+                    A_ = {
+                        arg: jnp.zeros((con.dim_f, dimx))
+                        for arg, dimx in thing.dimensions.items()
+                    }
+                args = (
+                    objective._args
+                    if prox_flag and isinstance(thing, Equilibrium)
+                    else thing.optimizable_params
+                )
+                A_per_thing.append(jnp.hstack([A_[arg] for arg in args]))
+
             else:
-                A_ = {
-                    arg: jnp.zeros((con.dim_f, dimx))
-                    for arg, dimx in thing.dimensions.items()
-                }
-            args = (
-                objective._args
-                if prox_flag and isinstance(thing, Equilibrium)
-                else thing.optimizable_params
-            )
-            A_per_thing.append(jnp.hstack([A_[arg] for arg in args]))
+                A_per_subthing = []
+                # it is an optimizable collection, loop through its sub-objects
+                for subthing in thing:
+                    if subthing in con.things:
+                        A_ = con.jac_scaled(*xz)[con.things.index(subthing)]
+                    else:
+                        A_ = {
+                            arg: jnp.zeros((con.dim_f, dimx))
+                            for arg, dimx in subthing.dimensions.items()
+                        }
+                    args = (
+                        objective._args
+                        if prox_flag and isinstance(subthing, Equilibrium)
+                        else subthing.optimizable_params
+                    )
+                    # form the A per each sub-object in the collection
+                    A_per_subthing.append(jnp.hstack([A_[arg] for arg in args]))
+                # the A for the full object will just be the stacking of each sub-A
+                A_per_thing.append(jnp.hstack([A__ for A__ in A_per_subthing]))
+
         # using obj.compute instead of obj.target to allow for correct scale/weight
         b_ = -con.compute_scaled_error(*xz)
         A.append(A_per_thing)
@@ -153,6 +177,8 @@ def factorize_linear_constraints(constraints, objective):  # noqa: C901
     xp_ = objective.unpack_state(xp, False)
     for con in constraints:
         xpi = [xp_[i] for i, t in enumerate(objective.things) if t in con.things]
+        if not xpi:
+            continue  # if no particular solution bc things is not constrained
         y1 = con.compute_unscaled(*xpi)
         y2 = con.target
         y1, y2 = np.broadcast_arrays(y1, y2)

--- a/desc/optimizable.py
+++ b/desc/optimizable.py
@@ -194,8 +194,17 @@ class OptimizableCollection(Optimizable):
         p : list dict
             list of dictionary of ndarray of optimizable parameters.
         """
-        split_idx = jnp.cumsum(jnp.array([s.dim_x for s in self]))
-        xs = jnp.split(x, split_idx)
+        # want to define self._split_idx when the OptimizableCollection is created,
+        # maybe add a super init that gets called?
+        # to avoid JAX tracer complaints about having variable lengths...
+        # currently defined in init of SumMagneticField (for testing)
+        split_idx = self._split_idx
+        xf = [x[split_idx[-1] :]]
+        if len(self) > 1:
+            xs = [x[idx:idxx] for idx, idxx in zip(split_idx[0:-1], split_idx[1:])] + xf
+        else:
+            xs = xf
+
         params = [s.unpack_params(xi) for s, xi in zip(self, xs)]
         return params
 


### PR DESCRIPTION
Resolves #860 
This is an inelegant attempt to get OptimizableCollection optimization working, it currently does work for the simple test case I have in here so it could be a possible way towards implementing this?

- modified `FixParameter` to work with OptimizableCollection, though the API needs to be hammered out and still need to decide how to handle all the different cases that things may be passed into FixParameter for an OptimizableCollcetion (i.e. a list of lists of params of len(collection), or maybe just one param? I think we should enforce that it is a list of lists of length(collection) though as parsing without that assumption is hard), currently I think it should accept a list of lists of length collection, and if nothing is being fixed for a particular subthing in the collection, then that corresponding entry (say, the ith subthing) params[i] = [ ]  (an empty list). 
- Modified Factorize_linear_constraints to work with at least this one example of optimizing with OptimizableCollection
 - The jacobian calculation from the constraint seemed to return a tuple though which was weird... so I must be missing something there
- modified `OptimizableCollection.unpack_params` to work with `jit`, I think the best solution would be to have the init of an `OptimizableCollection` subclass (or really, it should be in the `init` of the `OptimizableColleciton` itself) create the `self._split_idx` array as a numpy array (to be considered static by JAX during the jit and thus allowed to be used as indexing in `unpack_params`, currently I have this attribute created in the `SumMagneticField` init which feels not the neatest way, as it really only needs to know about `OptimizableCollection` stuff. 

I have a dummy objective that just takes in a sum of fields in this PR as every other PR with a sensible objective is not yet in master.

Some of the issues to be addressed (feel free to add to these)
- factorize_linear_constraints the `A` matrix construction assumes things.dimensions is not a list
- How to use `FixParameter` objects when `thing` is actually an `OptimizableCollection`? Should it be passed the `thing` then for the params a list of the usual argument for each `subthing` in `things` e.g. `FixParameter(sumfield,params=[["B0",R0"], ["Phi_mn"]])` for `sumfield` being a `SumMagneticField` of a `ToroidalMagneticField` and a `FourierCurrentPotentialField`?
  - And fixing anywhere that assumes FixParameter is not acting on a list of things
  - Or making a new objective for fixing collections of objects?
- `unpack_params` for `OptimizableCollection` as implementing in master currently is not jittable, I think there is a way around it but we'd need to define the `split_idx` in the init of the `OptimizableCollection` objects as an `np.array` so JAX treats as static array when it is jitted


@f0uriest @ddudt I am not claiming this entirely as my own PR, just wanted to get the conversation started and see if I could make any progress