### PR TITLE
fix bug in hdf5 io where the .h5 files were not being closed after being read

### DIFF
--- a/desc/io/equilibrium_io.py
+++ b/desc/io/equilibrium_io.py
@@ -54,18 +54,21 @@ def load(load_from, file_format=None):
         with open(load_from, "rb") as f:
             obj = pickle.load(f)
     elif file_format == "hdf5":
-        f = h5py.File(load_from, "r")
-        if "__class__" in f.keys():
-            cls_name = f["__class__"][()].decode("utf-8")
-            cls = pydoc.locate(cls_name)
-            obj = cls.__new__(cls)
-            f.close()
-            reader = reader_factory(load_from, file_format)
-            reader.read_obj(obj)
-        else:
-            raise ValueError(
-                "Could not load from {}, no __class__ attribute found".format(load_from)
-            )
+        with h5py.File(load_from, "r") as f:
+            if "__class__" in f.keys():
+                cls_name = f["__class__"][()].decode("utf-8")
+                cls = pydoc.locate(cls_name)
+                obj = cls.__new__(cls)
+                f.close()
+                reader = reader_factory(load_from, file_format)
+                reader.read_obj(obj)
+                reader.close()
+            else:
+                raise ValueError(
+                    "Could not load from {}, no __class__ attribute found".format(
+                        load_from
+                    )
+                )
     else:
         raise ValueError("Unknown file format: {}".format(file_format))
     # to set other secondary stuff that wasn't saved possibly:

--- a/desc/io/equilibrium_io.py
+++ b/desc/io/equilibrium_io.py
@@ -59,7 +59,6 @@ def load(load_from, file_format=None):
                 cls_name = f["__class__"][()].decode("utf-8")
                 cls = pydoc.locate(cls_name)
                 obj = cls.__new__(cls)
-                f.close()
                 reader = reader_factory(load_from, file_format)
                 reader.read_obj(obj)
                 reader.close()

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -580,3 +580,17 @@ def test_io_SplineMagneticField(tmpdir_factory):
     for key in derivs1.keys():
         for key2 in derivs1[key].keys():
             np.testing.assert_allclose(derivs1[key][key2], derivs2[key][key2])
+
+
+@pytest.mark.unit
+def test_save_after_load(tmpdir_factory):
+    """Test saving a DESC .h5 file after loading it (see gh #871)."""
+    tmpdir = tmpdir_factory.mktemp("save_after_load_test")
+    tmp_path = tmpdir.join("save_after_load_test.h5")
+    eq = Equilibrium()
+    eq.save(tmp_path)
+    eq2 = load(tmp_path)
+    # ensure can save again without an error being thrown due
+    # to the .h5 file not being closed
+    eq2.save(tmp_path)
+    assert eq2.eq(eq)


### PR DESCRIPTION
Resolves #871 

Issue was that when `reader` is  instantiated, it opens the .h5 file again, but we never close it explicitly, so it seems like it never gets closed