### PR TITLE
Add radial weighting for near axis fit

### DIFF
--- a/desc/equilibrium/equilibrium.py
+++ b/desc/equilibrium/equilibrium.py
@@ -1586,7 +1586,15 @@ class Equilibrium(IOAble, Optimizable):
 
     @classmethod
     def from_near_axis(
-        cls, na_eq, r=0.1, L=None, M=8, N=None, ntheta=None, spectral_indexing="ansi"
+        cls,
+        na_eq,
+        r=0.1,
+        L=None,
+        M=8,
+        N=None,
+        ntheta=None,
+        spectral_indexing="ansi",
+        w=2,
     ):
         """Initialize an Equilibrium from a near-axis solution.
 
@@ -1607,6 +1615,10 @@ class Equilibrium(IOAble, Optimizable):
             Number of poloidal grid points used in the conversion. Default 2*M+1
         spectral_indexing : str (optional)
             Type of Zernike indexing scheme to use. Default ``'ansi'``
+        w : float
+            Weight exponent for fit. Surfaces are fit using a weighted least squares
+            using weight = 1/rho**w, so that points near axis are captured more
+            accurately.
 
         Returns
         -------
@@ -1679,9 +1691,17 @@ class Equilibrium(IOAble, Optimizable):
             spectral_indexing=spectral_indexing,
         )
 
-        transform_R = Transform(grid, basis_R, build_pinv=True)
-        transform_Z = Transform(grid, basis_Z, build_pinv=True)
-        transform_L = Transform(grid, basis_L, build_pinv=True)
+        transform_R = Transform(grid, basis_R, method="direct1")
+        transform_Z = Transform(grid, basis_Z, method="direct1")
+        transform_L = Transform(grid, basis_L, method="direct1")
+        A_R = transform_R.matrices["direct1"][0][0][0]
+        A_Z = transform_Z.matrices["direct1"][0][0][0]
+        A_L = transform_L.matrices["direct1"][0][0][0]
+
+        W = 1 / grid.nodes[:, 0].flatten() ** w
+        A_Rw = A_R * W[:, None]
+        A_Zw = A_Z * W[:, None]
+        A_Lw = A_L * W[:, None]
 
         R_1D = np.zeros((grid.num_nodes,))
         Z_1D = np.zeros((grid.num_nodes,))
@@ -1699,9 +1719,9 @@ class Equilibrium(IOAble, Optimizable):
             Z_1D[idx] = Z_2D.flatten(order="F")
             L_1D[idx] = nu_B.flatten(order="F") * na_eq.iota
 
-        inputs["R_lmn"] = transform_R.fit(R_1D)
-        inputs["Z_lmn"] = transform_Z.fit(Z_1D)
-        inputs["L_lmn"] = transform_L.fit(L_1D)
+        inputs["R_lmn"] = np.linalg.lstsq(A_Rw, R_1D * W, rcond=None)[0]
+        inputs["Z_lmn"] = np.linalg.lstsq(A_Zw, Z_1D * W, rcond=None)[0]
+        inputs["L_lmn"] = np.linalg.lstsq(A_Lw, L_1D * W, rcond=None)[0]
 
         eq = Equilibrium(**inputs)
         eq.surface = eq.get_surface_at(rho=1)


### PR DESCRIPTION
By construction, the near axis expansion is most accurate near the axis, so this PR adds a radial weighting when we fit an equilibrium from a near axis solution. Default is `1/rho**2` which seems to work well on a few equilibria I tried.

Resolves #798 