### PR TITLE
Allow setting M, N for surface classes at init

### DIFF
--- a/desc/geometry/surface.py
+++ b/desc/geometry/surface.py
@@ -13,7 +13,7 @@ from desc.grid import Grid, LinearGrid
 from desc.io import InputReader
 from desc.optimizable import optimizable_parameter
 from desc.transform import Transform
-from desc.utils import copy_coeffs, isposint
+from desc.utils import copy_coeffs, isposint, setdefault
 
 from .core import Surface
 
@@ -36,6 +36,9 @@ class FourierRZToroidalSurface(Surface):
     sym : bool
         whether to enforce stellarator symmetry. Default is "auto" which enforces if
         modes are symmetric. If True, non-symmetric modes will be truncated.
+    M, N: int or None
+        Maximum poloidal and toroidal mode numbers. Defaults to maximum from modes_R
+        and modes_Z.
     rho : float [0,1]
         flux surface label for the toroidal surface
     name : str
@@ -64,6 +67,8 @@ class FourierRZToroidalSurface(Surface):
         modes_Z=None,
         NFP=1,
         sym="auto",
+        M=None,
+        N=None,
         rho=1,
         name="",
         check_orientation=True,
@@ -96,8 +101,8 @@ class FourierRZToroidalSurface(Surface):
         MZ = np.max(abs(modes_Z[:, 0]))
         NZ = np.max(abs(modes_Z[:, 1]))
         self._L = 0
-        self._M = max(MR, MZ)
-        self._N = max(NR, NZ)
+        self._M = setdefault(M, max(MR, MZ))
+        self._N = setdefault(N, max(NR, NZ))
         if sym == "auto":
             if np.all(
                 R_lmn[np.where(sign(modes_R[:, 0]) != sign(modes_R[:, 1]))] == 0
@@ -109,10 +114,10 @@ class FourierRZToroidalSurface(Surface):
                 sym = False
 
         self._R_basis = DoubleFourierSeries(
-            M=MR, N=NR, NFP=NFP, sym="cos" if sym else False
+            M=self._M, N=self._N, NFP=NFP, sym="cos" if sym else False
         )
         self._Z_basis = DoubleFourierSeries(
-            M=MZ, N=NZ, NFP=NFP, sym="sin" if sym else False
+            M=self._M, N=self._N, NFP=NFP, sym="sin" if sym else False
         )
 
         self._R_lmn = copy_coeffs(R_lmn, modes_R, self.R_basis.modes[:, 1:])
@@ -432,7 +437,7 @@ class FourierRZToroidalSurface(Surface):
         theta = np.asarray(theta)
         assert (
             coords.shape[0] == theta.size
-        ), "coords first dimenson and theta must have same size"
+        ), "coords first dimension and theta must have same size"
         if zeta is None:
             zeta = coords[:, 1]
         else:
@@ -644,6 +649,9 @@ class ZernikeRZToroidalSection(Surface):
         decreasing size, ending in a diamond shape for L=2*M where
         the traditional fringe/U of Arizona indexing is recovered.
         For L > 2*M, adds chevrons to the bottom, making a hexagonal diamond
+    L, M : int or None
+        Maximum radial and poloidal mode numbers. Defaults to max from modes_R and
+        modes_Z.
     zeta : float [0,2pi)
         toroidal angle for the section.
     name : str
@@ -672,6 +680,8 @@ class ZernikeRZToroidalSection(Surface):
         modes_Z=None,
         spectral_indexing="ansi",
         sym="auto",
+        L=None,
+        M=None,
         zeta=0.0,
         name="",
         check_orientation=True,
@@ -702,8 +712,8 @@ class ZernikeRZToroidalSection(Surface):
         MR = np.max(abs(modes_R[:, 1]))
         LZ = np.max(abs(modes_Z[:, 0]))
         MZ = np.max(abs(modes_Z[:, 1]))
-        self._L = max(LR, LZ)
-        self._M = max(MR, MZ)
+        self._L = setdefault(L, max(LR, LZ))
+        self._M = setdefault(M, max(MR, MZ))
         self._N = 0
 
         if sym == "auto":
@@ -717,14 +727,14 @@ class ZernikeRZToroidalSection(Surface):
                 sym = False
 
         self._R_basis = ZernikePolynomial(
-            L=max(LR, MR),
-            M=max(LR, MR),
+            L=self._L,
+            M=self._M,
             spectral_indexing=spectral_indexing,
             sym="cos" if sym else False,
         )
         self._Z_basis = ZernikePolynomial(
-            L=max(LZ, MZ),
-            M=max(LZ, MZ),
+            L=self._L,
+            M=self._M,
             spectral_indexing=spectral_indexing,
             sym="sin" if sym else False,
         )

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -7,7 +7,7 @@ import numpy as np
 from interpax import approx_df, interp2d, interp3d
 from netCDF4 import Dataset, chartostring, stringtochar
 
-from desc.backend import fori_loop, jit, jnp, odeint, sign
+from desc.backend import fori_loop, jit, jnp, odeint
 from desc.basis import DoubleFourierSeries
 from desc.compute import rpz2xyz, rpz2xyz_vec, xyz2rpz, xyz2rpz_vec
 from desc.derivatives import Derivative
@@ -1727,10 +1727,9 @@ class FourierCurrentPotentialField(
         and increasing when going in the clockwise direction, which with the
         convention n x grad(phi) will result in a toroidal field in the negative
         toroidal direction.
-    sym_Phi :  {"auto","cos","sin",False}
+    sym_Phi :  {False,"cos","sin"}
         whether to enforce a given symmetry for the DoubleFourierSeries part of the
-        current potential. Default is "auto" which enforces if modes are symmetric.
-        If True, non-symmetric modes will be truncated.
+        current potential.
     M_Phi, N_Phi: int or None
         Maximum poloidal and toroidal mode numbers for the single valued part of the
         current potential.
@@ -1770,7 +1769,7 @@ class FourierCurrentPotentialField(
         modes_Phi=np.array([[0, 0]]),
         I=0,
         G=0,
-        sym_Phi="auto",
+        sym_Phi=False,
         M_Phi=None,
         N_Phi=None,
         R_lmn=None,
@@ -1797,20 +1796,6 @@ class FourierCurrentPotentialField(
         self._M_Phi = M_Phi
         self._N_Phi = N_Phi
 
-        if sym_Phi == "auto":
-            if np.all(
-                Phi_mn[np.where(sign(modes_Phi[:, 0]) == sign(modes_Phi[:, 1]))] == 0
-            ):
-                sym_Phi = "sin"
-            elif np.all(
-                Phi_mn[np.where(sign(modes_Phi[:, 0]) != sign(modes_Phi[:, 1]))] == 0
-            ):
-                sym_Phi = "cos"
-            else:
-                sym_Phi = False
-            # catch case where only (0,0) mode is given as 0
-            if np.all(Phi_mn == 0.0) and np.all(modes_Phi == 0):
-                sym_Phi = "cos"
         self._sym_Phi = sym_Phi
         self._Phi_basis = DoubleFourierSeries(M=M_Phi, N=N_Phi, NFP=NFP, sym=sym_Phi)
         self._Phi_mn = copy_coeffs(Phi_mn, modes_Phi, self._Phi_basis.modes[:, 1:])
@@ -1972,7 +1957,7 @@ class FourierCurrentPotentialField(
         modes_Phi=np.array([[0, 0]]),
         I=0,
         G=0,
-        sym_Phi="auto",
+        sym_Phi=False,
         M_Phi=None,
         N_Phi=None,
     ):
@@ -2000,10 +1985,9 @@ class FourierCurrentPotentialField(
             and increasing when going in the clockwise direction, which with the
             convention n x grad(phi) will result in a toroidal field in the negative
             toroidal direction.
-        sym_Phi :  {"auto","cos","sin",False}
+        sym_Phi :  {False,"cos","sin"}
             whether to enforce a given symmetry for the DoubleFourierSeries part of the
-            current potential. Default is "auto" which enforces if modes are symmetric.
-            If True, non-symmetric modes will be truncated.
+            current potential.
         M_Phi, N_Phi: int or None
             Maximum poloidal and toroidal mode numbers for the single valued part of the
             current potential.
@@ -2027,7 +2011,7 @@ class FourierCurrentPotentialField(
             modes_Phi=modes_Phi,
             I=I,
             G=G,
-            sym__Phi=sym_Phi,
+            sym_Phi=sym_Phi,
             M_Phi=M_Phi,
             N_Phi=N_Phi,
             R_lmn=R_lmn,

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -298,6 +298,7 @@ class TestMagneticFields:
             modes_Phi=basis.modes[:, 1:],
             I=0,
             G=-G,
+            sym_Phi="sin",
             R_lmn=surface.R_lmn,
             Z_lmn=surface.Z_lmn,
             modes_R=surface._R_basis.modes[:, 1:],
@@ -396,6 +397,7 @@ class TestMagneticFields:
         field = FourierCurrentPotentialField(
             Phi_mn=phi_mn,
             modes_Phi=basis.modes[:, 1:],
+            sym_Phi="cos",
             R_lmn=surface.R_lmn,
             Z_lmn=surface.Z_lmn,
             modes_R=surface._R_basis.modes[:, 1:],
@@ -529,6 +531,7 @@ class TestMagneticFields:
         field = FourierCurrentPotentialField(
             Phi_mn=phi_mn,
             modes_Phi=basis.modes[:, 1:],
+            sym_Phi="cos",
             R_lmn=surface.R_lmn,
             Z_lmn=surface.Z_lmn,
             modes_R=surface._R_basis.modes[:, 1:],


### PR DESCRIPTION
Also removes `sym_Phi="auto"` option from `FourierCurrentPotentialField` since it's not entirely clear that it does what we want. IE, when should the potential be symmetric? Better to default to no symmetry or have the user give it explicitly.