### PR TITLE
Add Bounding Box to Field Line Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-- Adds a bounding box to the `field_line_integrate` defined by `bounds_R` and `bounds_Z` keyword arguments, which form a hollow cylindrical bounding box. If the field line trajectory exits these bounds, the RHS will be multiplied by `exp(-(R**2+Z**2))` to stop the trajectory and prevent tracing the field line out to infinity, which is both costly and unnecessary when making a Poincare plot, which is the principle purpose of the function.
+- Adds a bounding box to the `field_line_integrate` defined by `bounds_R` and `bounds_Z` keyword arguments, which form a hollow cylindrical bounding box. If the field line trajectory exits these bounds, the RHS will be multiplied by an exponentially decaying function of the distance to the box to stop the trajectory and prevent tracing the field line out to infinity, which is both costly and unnecessary when making a Poincare plot, the principle purpose of the function.
 
 v0.10.4
 -------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- Adds a bounding box to the `field_line_integrate` defined by `bounds_R` and `bounds_Z` keyword arguments, which form a hollow cylindrical bounding box. If the field line trajectory exits these bounds, the RHS will be multiplied by `exp(-(R**2+Z**2))` to stop the trajectory and prevent tracing the field line out to infinity, which is both costly and unnecessary when making a Poincare plot, which is the principle purpose of the function.
+
 v0.10.4
 -------
 

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -1433,6 +1433,7 @@ def field_line_integrate(
     """
     r0, z0, phis = map(jnp.asarray, (r0, z0, phis))
     assert r0.shape == z0.shape, "r0 and z0 must have the same shape"
+    assert decay_accel > 0, "decay_accel must be positive"
     rshape = r0.shape
     r0 = r0.flatten()
     z0 = z0.flatten()
@@ -1458,8 +1459,8 @@ def field_line_integrate(
             ),
             jnp.array(
                 [
-                    # we mult by 1e6 to accelerate the decay so that the integration
-                    # is stopped soon after the bounds are exited.
+                    # we mult by decay_accel to accelerate the decay so that the
+                    # integration is stopped soon after the bounds are exited.
                     jnp.exp(-(decay_accel * (r - bounds_R[0]) ** 2)),
                     jnp.exp(-(decay_accel * (r - bounds_R[1]) ** 2)),
                     jnp.exp(-(decay_accel * (z - bounds_Z[0]) ** 2)),

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -1452,12 +1452,12 @@ def field_line_integrate(
             ),
             jnp.array(
                 [
-                    # we mult by 1e-1 to accelerate the decay so that the integration
+                    # we mult by 1e6 to accelerate the decay so that the integration
                     # is stopped soon after the bounds are exited.
-                    jnp.exp(-(1e1 * (r - bounds_R[0]) ** 2)),
-                    jnp.exp(-(1e1 * (r - bounds_R[1]) ** 2)),
-                    jnp.exp(-(1e1 * (z - bounds_Z[0]) ** 2)),
-                    jnp.exp(-(1e1 * (z - bounds_Z[1]) ** 2)),
+                    jnp.exp(-(1e6 * (r - bounds_R[0]) ** 2)),
+                    jnp.exp(-(1e6 * (r - bounds_R[1]) ** 2)),
+                    jnp.exp(-(1e6 * (z - bounds_Z[0]) ** 2)),
+                    jnp.exp(-(1e6 * (z - bounds_Z[1]) ** 2)),
                 ]
             ),
             1.0,

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -1409,12 +1409,14 @@ def field_line_integrate(
         multipled by exp(-r) where r is the distance from the origin,
         this is meant to prevent the field lines which escape to infinity from
         slowing the integration down by being traced to infinity.
+        defaults to (0,np.inf)
     bounds_Z : tuple of (float,float), optional
         Z bounds for field line integration bounding box.
         If supplied, the RHS of the field line equations will be
         multipled by exp(-r) where r is the distance from the origin,
         this is meant to prevent the field lines which escape to infinity from
         slowing the integration down by being traced to infinity.
+        Defaults to (-np.inf,np.inf)
 
 
     Returns
@@ -1435,6 +1437,10 @@ def field_line_integrate(
         rpz = rpz.reshape((3, -1)).T
         r = rpz[:, 0]
         z = rpz[:, 2]
+        # if bounds are given, will decay the magnetic field line eqn
+        # RHS if the trajectory is outside of bounds to avoid
+        # integrating the field line to infinity, which is costly
+        # and not useful in most cases
         decay_factor = jnp.where(
             jnp.any(
                 jnp.array(

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -1450,22 +1450,21 @@ def field_line_integrate(
                     jnp.greater(z, bounds_Z[1]),
                 ]
             ),
-            1e-2
-            * jnp.array(
+            jnp.array(
                 [
-                    # we mult by 1e-2 to accelerate the decay so that the integration
+                    # we mult by 1e-1 to accelerate the decay so that the integration
                     # is stopped soon after the bounds are exited.
-                    jnp.exp(-((r - bounds_R[0]) ** 2)),
-                    jnp.exp(-((r - bounds_R[1]) ** 2)),
-                    jnp.exp(-((z - bounds_Z[0]) ** 2)),
-                    jnp.exp(-((z - bounds_Z[1]) ** 2)),
+                    jnp.exp(-(1e1 * (r - bounds_R[0]) ** 2)),
+                    jnp.exp(-(1e1 * (r - bounds_R[1]) ** 2)),
+                    jnp.exp(-(1e1 * (z - bounds_Z[0]) ** 2)),
+                    jnp.exp(-(1e1 * (z - bounds_Z[1]) ** 2)),
                 ]
             ),
             1.0,
         )
         # multiply all together, the conditions that are not violated
         # are just one while the violated ones are continous decaying exponentials
-        decay_factor = jnp.prod(decay_factor)
+        decay_factor = jnp.prod(decay_factor, axis=0)
 
         br, bp, bz = field.compute_magnetic_field(
             rpz, params, basis="rpz", source_grid=source_grid

--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -1382,6 +1382,7 @@ def field_line_integrate(
     maxstep=1000,
     bounds_R=(0, np.inf),
     bounds_Z=(-np.inf, np.inf),
+    decay_accel=1e6,
 ):
     """Trace field lines by integration.
 
@@ -1406,17 +1407,22 @@ def field_line_integrate(
     bounds_R : tuple of (float,float), optional
         R bounds for field line integration bounding box.
         If supplied, the RHS of the field line equations will be
-        multipled by exp(-r) where r is the distance from the origin,
+        multipled by exp(-r) where r is the distance to the bounding box,
         this is meant to prevent the field lines which escape to infinity from
         slowing the integration down by being traced to infinity.
         defaults to (0,np.inf)
     bounds_Z : tuple of (float,float), optional
         Z bounds for field line integration bounding box.
         If supplied, the RHS of the field line equations will be
-        multipled by exp(-r) where r is the distance from the origin,
+        multipled by exp(-r) where r is the distance to the bounding box,
         this is meant to prevent the field lines which escape to infinity from
         slowing the integration down by being traced to infinity.
         Defaults to (-np.inf,np.inf)
+    decay_accel : float, optional
+        An extra factor to the exponential that decays the RHS, i.e.
+        the RHS is multiplied by exp(-r * decay_accel), this is to
+        accelerate the decay of the RHS and stop the integration sooner
+        after exiting the bounds. Defaults to 1e6
 
 
     Returns
@@ -1454,10 +1460,10 @@ def field_line_integrate(
                 [
                     # we mult by 1e6 to accelerate the decay so that the integration
                     # is stopped soon after the bounds are exited.
-                    jnp.exp(-(1e6 * (r - bounds_R[0]) ** 2)),
-                    jnp.exp(-(1e6 * (r - bounds_R[1]) ** 2)),
-                    jnp.exp(-(1e6 * (z - bounds_Z[0]) ** 2)),
-                    jnp.exp(-(1e6 * (z - bounds_Z[1]) ** 2)),
+                    jnp.exp(-(decay_accel * (r - bounds_R[0]) ** 2)),
+                    jnp.exp(-(decay_accel * (r - bounds_R[1]) ** 2)),
+                    jnp.exp(-(decay_accel * (z - bounds_Z[0]) ** 2)),
+                    jnp.exp(-(decay_accel * (z - bounds_Z[1]) ** 2)),
                 ]
             ),
             1.0,

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -678,6 +678,12 @@ class TestMagneticFields:
         r, z = field_line_integrate(r0, z0, phis, field)
         np.testing.assert_allclose(r[-1], 10, rtol=1e-6, atol=1e-6)
         np.testing.assert_allclose(z[-1], 0.001, rtol=1e-6, atol=1e-6)
+        # test that bounds work correctly, and stop integration when trajectory
+        # hits the bounds
+        r, z = field_line_integrate(r0, z0, phis, field, bounds_R=(10.05, np.inf))
+        np.testing.assert_allclose(r[-1], 10.05, rtol=1e-6)
+        r, z = field_line_integrate(r0, z0, phis, field, bounds_Z=(-np.inf, 0.05))
+        np.testing.assert_allclose(z[-1], 0.05, rtol=1e-6)
 
     @pytest.mark.unit
     def test_Bnormal_calculation(self):

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -680,6 +680,8 @@ class TestMagneticFields:
         np.testing.assert_allclose(z[-1], 0.001, rtol=1e-6, atol=1e-6)
         # test that bounds work correctly, and stop integration when trajectory
         # hits the bounds
+        r0 = [10.1]
+        z0 = [0.0]
         r, z = field_line_integrate(r0, z0, phis, field, bounds_R=(10.05, np.inf))
         np.testing.assert_allclose(r[-1], 10.05, rtol=1e-6)
         r, z = field_line_integrate(r0, z0, phis, field, bounds_Z=(-np.inf, 0.05))

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -678,18 +678,6 @@ class TestMagneticFields:
         r, z = field_line_integrate(r0, z0, phis, field)
         np.testing.assert_allclose(r[-1], 10, rtol=1e-6, atol=1e-6)
         np.testing.assert_allclose(z[-1], 0.001, rtol=1e-6, atol=1e-6)
-        # test that bounds work correctly, and stop integration when trajectory
-        # hits the bounds
-        r0 = [10.1]
-        z0 = [0.0]
-        # this will hit the R bound
-        # (there is no Z bound, and R would go to 10.0 if not bounded)
-        r, z = field_line_integrate(r0, z0, phis, field, bounds_R=(10.05, np.inf))
-        np.testing.assert_allclose(r[-1], 10.05, rtol=3e-4)
-        # this will hit the Z bound
-        # (there is no R bound, and Z would go to 0.1 if not bounded)
-        r, z = field_line_integrate(r0, z0, phis, field, bounds_Z=(-np.inf, 0.05))
-        np.testing.assert_allclose(z[-1], 0.05, atol=3e-3)
 
     @pytest.mark.unit
     def test_field_line_integrate_bounds(self):

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -692,6 +692,26 @@ class TestMagneticFields:
         np.testing.assert_allclose(z[-1], 0.05, atol=3e-3)
 
     @pytest.mark.unit
+    def test_field_line_integrate_bounds(self):
+        """Test field line integration with bounding box."""
+        # q=4, field line should rotate 1/4 turn after 1 toroidal transit
+        # from outboard midplane to top center
+        field = ToroidalMagneticField(2, 10) + PoloidalMagneticField(2, 10, 0.25)
+        # test that bounds work correctly, and stop integration when trajectory
+        # hits the bounds
+        r0 = [10.1]
+        z0 = [0.0]
+        phis = [0, 2 * np.pi]
+        # this will hit the R bound
+        # (there is no Z bound, and R would go to 10.0 if not bounded)
+        r, z = field_line_integrate(r0, z0, phis, field, bounds_R=(10.05, np.inf))
+        np.testing.assert_allclose(r[-1], 10.05, rtol=3e-4)
+        # this will hit the Z bound
+        # (there is no R bound, and Z would go to 0.1 if not bounded)
+        r, z = field_line_integrate(r0, z0, phis, field, bounds_Z=(-np.inf, 0.05))
+        np.testing.assert_allclose(z[-1], 0.05, atol=3e-3)
+
+    @pytest.mark.unit
     def test_Bnormal_calculation(self):
         """Tests Bnormal calculation for simple toroidal field."""
         tfield = ToroidalMagneticField(2, 1)

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -682,8 +682,12 @@ class TestMagneticFields:
         # hits the bounds
         r0 = [10.1]
         z0 = [0.0]
+        # this will hit the R bound
+        # (there is no Z bound, and R would go to 10.1 if not bounded)
         r, z = field_line_integrate(r0, z0, phis, field, bounds_R=(10.05, np.inf))
         np.testing.assert_allclose(r[-1], 10.05, rtol=1e-6)
+        # this will hit the Z bound
+        # (there is no R bound, and Z would go to 0.1 if not bounded)
         r, z = field_line_integrate(r0, z0, phis, field, bounds_Z=(-np.inf, 0.05))
         np.testing.assert_allclose(z[-1], 0.05, rtol=1e-6)
 

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -683,13 +683,13 @@ class TestMagneticFields:
         r0 = [10.1]
         z0 = [0.0]
         # this will hit the R bound
-        # (there is no Z bound, and R would go to 10.1 if not bounded)
+        # (there is no Z bound, and R would go to 10.0 if not bounded)
         r, z = field_line_integrate(r0, z0, phis, field, bounds_R=(10.05, np.inf))
-        np.testing.assert_allclose(r[-1], 10.05, rtol=1e-4)
+        np.testing.assert_allclose(r[-1], 10.05, rtol=3e-4)
         # this will hit the Z bound
         # (there is no R bound, and Z would go to 0.1 if not bounded)
         r, z = field_line_integrate(r0, z0, phis, field, bounds_Z=(-np.inf, 0.05))
-        np.testing.assert_allclose(z[-1], 0.05, atol=1e-3)
+        np.testing.assert_allclose(z[-1], 0.05, atol=3e-3)
 
     @pytest.mark.unit
     def test_Bnormal_calculation(self):

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -685,11 +685,11 @@ class TestMagneticFields:
         # this will hit the R bound
         # (there is no Z bound, and R would go to 10.1 if not bounded)
         r, z = field_line_integrate(r0, z0, phis, field, bounds_R=(10.05, np.inf))
-        np.testing.assert_allclose(r[-1], 10.05, rtol=1e-6)
+        np.testing.assert_allclose(r[-1], 10.05, rtol=1e-4)
         # this will hit the Z bound
         # (there is no R bound, and Z would go to 0.1 if not bounded)
         r, z = field_line_integrate(r0, z0, phis, field, bounds_Z=(-np.inf, 0.05))
-        np.testing.assert_allclose(z[-1], 0.05, rtol=1e-6)
+        np.testing.assert_allclose(z[-1], 0.05, atol=1e-3)
 
     @pytest.mark.unit
     def test_Bnormal_calculation(self):


### PR DESCRIPTION
- Adds a bounding box to the `field_line_integrate` defined by `bounds_R` and `bounds_Z` keyword arguments, which form a hollow cylindrical bounding box. If the field line trajectory exits these bounds, the RHS will be multiplied by `exp(-(R**2+Z**2))` to stop the trajectory and prevent tracing the field line out to infinity, which is both costly and unnecessary when making a Poincare plot, which is the principle purpose of the function.

In one example I had when tracing the precise_QA with a coilset that had some diverging field lines, it took 1/3 of the time compared to without using bounds, so seems to work fine. Defaults to no bounds.

@ddudt this PR is not addressing anything that happens when a SplineMagneticField is used and the field lines exit its domain of validity when `extrap=False` unless you specify the bounding box to lie within its domain of validity, in which case it should stop the integration soon after it exits the bounding box and possibly before it exits the field's interpolation domain. If there are ideas of how to treat that then we can make an issue and a separate PR