### PR TITLE
VMEC wout fixes

### DIFF
--- a/desc/magnetic_fields.py
+++ b/desc/magnetic_fields.py
@@ -469,7 +469,7 @@ class _MagneticField(IOAble, ABC):
         nfp[:] = NFP
 
         nextcur = file.createVariable("nextcur", np.int32)
-        nextcur.long_name = "Number of coils."
+        nextcur.long_name = "Number of coils (external currents)."
         nextcur[:] = 1
 
         rmin = file.createVariable("rmin", np.float64)

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -260,8 +260,7 @@ class VMECIO:
         if verbose > 0:
             print("Computing data")
 
-        # desc throws NaN for r == 0, so we use something small to approximate it
-        grid_axis = LinearGrid(M=M_nyq, N=N_nyq, rho=np.array([1e-6]), NFP=NFP)
+        grid_axis = LinearGrid(M=M_nyq, N=N_nyq, rho=np.array([0.0]), NFP=NFP)
         grid_lcfs = LinearGrid(M=M_nyq, N=N_nyq, rho=np.array([1.0]), NFP=NFP)
         grid_half = LinearGrid(M=M_nyq, N=N_nyq, NFP=NFP, rho=r_half)
         grid_full = LinearGrid(M=M_nyq, N=N_nyq, NFP=NFP, rho=r_full)

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -558,7 +558,9 @@ class VMECIO:
         buco = file.createVariable("buco", np.float64, ("radius",))
         buco.long_name = "Boozer toroidal current I, on half mesh"
         buco.units = "T*m"
-        buco[1:] = grid_half.compress(data_half["I"])
+        buco[1:] = -grid_half.compress(
+            data_half["I"]
+        )  # negative sign for negative Jacobian (opposite poloidal angle)
         buco[0] = 0
 
         bvco = file.createVariable("bvco", np.float64, ("radius",))
@@ -591,12 +593,12 @@ class VMECIO:
         jcuru = file.createVariable("jcuru", np.float64, ("radius",))
         jcuru.long_name = "flux surface average of sqrt(g)*J^theta, on full mesh"
         jcuru.units = "A/m^3"
-        jcuru[:] = surface_averages(
+        jcuru[:] = -surface_averages(
             grid_full,
             data_full["J^theta*sqrt(g)"] / (2 * data_full["rho"]),
             sqrt_g=data_full["sqrt(g)"],
             expand_out=False,
-        )
+        )  # negative sign for negative Jacobian (opposite poloidal angle)
         jcuru[0] = 0
 
         jcurv = file.createVariable("jcurv", np.float64, ("radius",))

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -271,6 +271,7 @@ class VMECIO:
             np.array([" " * 100], "S" + str(file.dimensions["dim_00100"].size))
         )  # VMEC input filename: input.[input_extension]
 
+        # TODO: instead of hard-coding for fixed-boundary, allow for free-boundary?
         mgrid_mode = file.createVariable("mgrid_mode", "S1", ("dim_00001",))
         mgrid_mode[:] = stringtochar(
             np.array([""], "S" + str(file.dimensions["dim_00001"].size))
@@ -480,7 +481,7 @@ class VMECIO:
         chipf.long_name = "d(chi)/ds: poloidal flux derivative"
         chipf[:] = phipf[:] * iotaf[:]
 
-        # scalars on Quadrature grid
+        # scalars computed on a Quadrature grid
         data = eq.compute(
             ["R0/a", "V", "<|B|>_rms", "<beta>_vol", "<beta_pol>_vol", "<beta_tor>_vol"]
         )
@@ -525,7 +526,7 @@ class VMECIO:
         betator.units = "None"
         betator[:] = data["<beta_tor>_vol"]
 
-        # scalars at last closed flux surface
+        # scalars computed at the last closed flux surface
         grid = LinearGrid(M=eq.M_grid, N=eq.N_grid, rho=[1.0], NFP=NFP)
         data = eq.compute(["G", "I"], grid=grid)
 
@@ -539,7 +540,7 @@ class VMECIO:
         rbtor.units = "T*m"
         rbtor[:] = data["G"][0]
 
-        # scalars at the magnetic axis
+        # scalars computed at the magnetic axis
         grid = LinearGrid(M=eq.M_grid, N=eq.N_grid, rho=ONAXIS, NFP=NFP)
         data = eq.compute(["G", "p", "R", "<|B|^2>"], grid=grid)
 

--- a/tests/test_vmec.py
+++ b/tests/test_vmec.py
@@ -515,11 +515,6 @@ def test_vmec_save_1(VMEC_save):
         vmec.variables["b0"][:], desc.variables["b0"][:], rtol=5e-5
     )
     np.testing.assert_allclose(
-        np.abs(vmec.variables["bdotb"][20:100]),
-        np.abs(desc.variables["bdotb"][20:100]),
-        rtol=1e-6,
-    )
-    np.testing.assert_allclose(
         np.abs(vmec.variables["buco"][20:100]),
         np.abs(desc.variables["buco"][20:100]),
         rtol=1e-5,
@@ -528,6 +523,16 @@ def test_vmec_save_1(VMEC_save):
         np.abs(vmec.variables["bvco"][20:100]),
         np.abs(desc.variables["bvco"][20:100]),
         rtol=1e-5,
+    )
+    np.testing.assert_allclose(
+        np.abs(vmec.variables["vp"][20:100]),
+        np.abs(desc.variables["vp"][20:100]),
+        rtol=1e-6,
+    )
+    np.testing.assert_allclose(
+        np.abs(vmec.variables["bdotb"][20:100]),
+        np.abs(desc.variables["bdotb"][20:100]),
+        rtol=1e-6,
     )
     np.testing.assert_allclose(
         np.abs(vmec.variables["jdotb"][20:100]),

--- a/tests/test_vmec.py
+++ b/tests/test_vmec.py
@@ -515,39 +515,25 @@ def test_vmec_save_1(VMEC_save):
         vmec.variables["b0"][:], desc.variables["b0"][:], rtol=5e-5
     )
     np.testing.assert_allclose(
-        np.abs(vmec.variables["buco"][20:100]),
-        np.abs(desc.variables["buco"][20:100]),
-        rtol=1e-5,
+        vmec.variables["buco"][20:100], desc.variables["buco"][20:100], rtol=1e-5
     )
     np.testing.assert_allclose(
-        np.abs(vmec.variables["bvco"][20:100]),
-        np.abs(desc.variables["bvco"][20:100]),
-        rtol=1e-5,
+        vmec.variables["bvco"][20:100], desc.variables["bvco"][20:100], rtol=1e-5
     )
     np.testing.assert_allclose(
-        np.abs(vmec.variables["vp"][20:100]),
-        np.abs(desc.variables["vp"][20:100]),
-        rtol=1e-6,
+        vmec.variables["vp"][20:100], desc.variables["vp"][20:100], rtol=1e-6
     )
     np.testing.assert_allclose(
-        np.abs(vmec.variables["bdotb"][20:100]),
-        np.abs(desc.variables["bdotb"][20:100]),
-        rtol=1e-6,
+        vmec.variables["bdotb"][20:100], desc.variables["bdotb"][20:100], rtol=1e-6
     )
     np.testing.assert_allclose(
-        np.abs(vmec.variables["jdotb"][20:100]),
-        np.abs(desc.variables["jdotb"][20:100]),
-        rtol=1e-5,
+        vmec.variables["jdotb"][20:100], desc.variables["jdotb"][20:100], rtol=1e-5
     )
     np.testing.assert_allclose(
-        np.abs(vmec.variables["jcuru"][20:100]),
-        np.abs(desc.variables["jcuru"][20:100]),
-        rtol=1e-2,
+        vmec.variables["jcuru"][20:100], desc.variables["jcuru"][20:100], rtol=1e-2
     )
     np.testing.assert_allclose(
-        np.abs(vmec.variables["jcurv"][20:100]),
-        np.abs(desc.variables["jcurv"][20:100]),
-        rtol=3e-2,
+        vmec.variables["jcurv"][20:100], desc.variables["jcurv"][20:100], rtol=3e-2
     )
     np.testing.assert_allclose(
         vmec.variables["DShear"][20:100], desc.variables["DShear"][20:100], rtol=1e-2

--- a/tests/test_vmec.py
+++ b/tests/test_vmec.py
@@ -430,6 +430,7 @@ def test_vmec_save_1(VMEC_save):
     np.testing.assert_allclose(vmec.variables["xn_nyq"][:], desc.variables["xn_nyq"][:])
     assert vmec.variables["signgs"][:] == desc.variables["signgs"][:]
     assert vmec.variables["gamma"][:] == desc.variables["gamma"][:]
+    assert vmec.variables["nextcur"][:] == desc.variables["nextcur"][:]
     assert np.all(
         np.char.compare_chararrays(
             vmec.variables["pmass_type"][:],


### PR DESCRIPTION
1. Resolves #915 by flipping the sign of `buco`
2. Also flips the sign of `jcuru` (same issue as above)
3. Adds the quantity `vp`, which is dV/ds / 4pi^2 [as documented here](https://github.com/PrincetonUniversity/STELLOPT/blob/2d7b671d6abb80b06fe93e4c2afa39cbae79a057/THRIFT/Sources/thrift_load_vmec.f90#L189)
4. Adds the quantity `nextcur` for the number of coils, which is hard-coded to 0 for fixed-boundary solutions
5. Refactors some of the scalar computations to make it more efficient and save compute time

`VMECIO.save` assumes the equilibrium was a fixed-boundary solution (we hard-code some outputs to their fixed-boundary values). But now that we have free-boundary working we could think about accommodating those free-boundary values (in a future PR). I think we would need to pass in the MagneticField that was used in addition to the Equilibrium. 