### PR TITLE
Add warnings about grid resolution to objective build methods

### DIFF
--- a/desc/objectives/_bootstrap.py
+++ b/desc/objectives/_bootstrap.py
@@ -126,7 +126,7 @@ class BootstrapRedlConsistency(_Objective):
             grid = self._grid
 
         warnif(
-            grid.num_theta < 2 * eq.M,
+            (grid.num_theta * (1 + eq.sym)) < 2 * eq.M,
             RuntimeWarning,
             "BootstrapRedlConsistency objective grid requires poloidal "
             "resolution for surface averages",

--- a/desc/objectives/_bootstrap.py
+++ b/desc/objectives/_bootstrap.py
@@ -1,14 +1,12 @@
 """Objectives related to the bootstrap current profile."""
 
-import warnings
-
 import numpy as np
 
 from desc.backend import jnp
 from desc.compute import compute as compute_fun
 from desc.compute import get_profiles, get_transforms
 from desc.grid import LinearGrid
-from desc.utils import Timer
+from desc.utils import Timer, errorif, warnif
 
 from .normalization import compute_scaling_factors
 from .objective_funs import _Objective
@@ -127,57 +125,83 @@ class BootstrapRedlConsistency(_Objective):
         else:
             grid = self._grid
 
-        assert (
-            self.helicity[1] == 0 or abs(self.helicity[1]) == eq.NFP
-        ), "Helicity toroidal mode number should be 0 (QA) or +/- NFP (QH)"
+        warnif(
+            grid.num_theta < 2 * eq.M,
+            RuntimeWarning,
+            "BootstrapRedlConsistency objective grid requires poloidal "
+            "resolution for surface averages",
+        )
+        warnif(
+            grid.num_zeta < 2 * eq.N,
+            RuntimeWarning,
+            "BootstrapRedlConsistency objective grid requires toroidal "
+            "resolution for surface averages",
+        )
+
+        errorif(
+            not (self.helicity[1] == 0 or abs(self.helicity[1]) == eq.NFP),
+            ValueError,
+            "Helicity toroidal mode number should be 0 (QA) or +/- NFP (QH)",
+        )
+
         self._dim_f = grid.num_rho
         self._data_keys = ["<J*B>", "<J*B> Redl"]
 
-        if eq.electron_temperature is None:
-            raise RuntimeError(
-                "Bootstrap current calculation requires an electron temperature "
-                "profile."
-            )
-        if eq.electron_density is None:
-            raise RuntimeError(
-                "Bootstrap current calculation requires an electron density profile."
-            )
-        if eq.ion_temperature is None:
-            raise RuntimeError(
-                "Bootstrap current calculation requires an ion temperature profile."
-            )
+        errorif(
+            eq.electron_temperature is None,
+            RuntimeError,
+            "Bootstrap current calculation requires an electron temperature "
+            "profile.",
+        )
+        errorif(
+            eq.electron_density is None,
+            RuntimeError,
+            "Bootstrap current calculation requires an electron density profile.",
+        )
+        errorif(
+            eq.ion_temperature is None,
+            RuntimeError,
+            "Bootstrap current calculation requires an ion temperature profile.",
+        )
 
         # Try to catch cases in which density or temperatures are specified in the
         # wrong units. Densities should be ~ 10^20, temperatures are ~ 10^3.
         rho = eq.compute("rho", grid=grid)["rho"]
-        if jnp.any(eq.electron_density(rho) > 1e22):
-            warnings.warn(
-                "Electron density is surprisingly high. It should have units of "
-                "1/meters^3"
-            )
-        if jnp.any(eq.electron_temperature(rho) > 50e3):
-            warnings.warn(
-                "Electron temperature is surprisingly high. It should have units of eV"
-            )
-        if jnp.any(eq.ion_temperature(rho) > 50e3):
-            warnings.warn(
-                "Ion temperature is surprisingly high. It should have units of eV"
-            )
+
+        warnif(
+            jnp.any(eq.electron_density(rho) > 1e22),
+            UserWarning,
+            "Electron density is surprisingly high. It should have units of "
+            "1/meters^3",
+        )
+        warnif(
+            jnp.any(eq.electron_temperature(rho) > 50e3),
+            UserWarning,
+            "Electron temperature is surprisingly high. It should have units of eV",
+        )
+        warnif(
+            jnp.any(eq.ion_temperature(rho) > 50e3),
+            UserWarning,
+            "Ion temperature is surprisingly high. It should have units of eV",
+        )
         # Profiles may go to 0 at rho=1, so exclude the last few grid points from lower
         # bounds:
         rho = rho[rho < 0.85]
-        if jnp.any(eq.electron_density(rho) < 1e17):
-            warnings.warn(
-                "Electron density is surprisingly low. It should have units 1/meters^3"
-            )
-        if jnp.any(eq.electron_temperature(rho) < 30):
-            warnings.warn(
-                "Electron temperature is surprisingly low. It should have units of eV"
-            )
-        if jnp.any(eq.ion_temperature(rho) < 30):
-            warnings.warn(
-                "Ion temperature is surprisingly low. It should have units of eV"
-            )
+        warnif(
+            jnp.any(eq.electron_density(rho) < 1e17),
+            UserWarning,
+            "Electron density is surprisingly low. It should have units 1/meters^3",
+        )
+        warnif(
+            jnp.any(eq.electron_temperature(rho) < 30),
+            UserWarning,
+            "Electron temperature is surprisingly low. It should have units of eV",
+        )
+        warnif(
+            jnp.any(eq.ion_temperature(rho) < 30),
+            UserWarning,
+            "Ion temperature is surprisingly low. It should have units of eV",
+        )
 
         timer = Timer()
         if verbose > 0:

--- a/desc/objectives/_profiles.py
+++ b/desc/objectives/_profiles.py
@@ -5,7 +5,7 @@ import numpy as np
 from desc.compute import compute as compute_fun
 from desc.compute.utils import get_profiles, get_transforms
 from desc.grid import LinearGrid
-from desc.utils import Timer
+from desc.utils import Timer, warnif
 
 from .normalization import compute_scaling_factors
 from .objective_funs import _Objective
@@ -264,6 +264,19 @@ class RotationalTransform(_Objective):
         else:
             grid = self._grid
 
+        warnif(
+            grid.num_theta < 2 * eq.M,
+            RuntimeWarning,
+            "RotationalTransform objective grid requires poloidal "
+            "resolution for surface averages",
+        )
+        warnif(
+            grid.num_zeta < 2 * eq.N,
+            RuntimeWarning,
+            "RotationalTransform objective grid requires toroidal "
+            "resolution for surface averages",
+        )
+
         self._target, self._bounds = _parse_callable_target_bounds(
             self._target, self._bounds, grid.nodes[grid.unique_rho_idx]
         )
@@ -418,6 +431,17 @@ class Shear(_Objective):
         else:
             grid = self._grid
 
+        warnif(
+            grid.num_theta < 2 * eq.M,
+            RuntimeWarning,
+            "Shear objective grid requires poloidal " "resolution for surface averages",
+        )
+        warnif(
+            grid.num_zeta < 2 * eq.N,
+            RuntimeWarning,
+            "Shear objective grid requires toroidal " "resolution for surface averages",
+        )
+
         self._target, self._bounds = _parse_callable_target_bounds(
             self._target, self._bounds, grid.nodes[grid.unique_rho_idx]
         )
@@ -569,6 +593,19 @@ class ToroidalCurrent(_Objective):
             )
         else:
             grid = self._grid
+
+        warnif(
+            grid.num_theta < 2 * eq.M,
+            RuntimeWarning,
+            "ToroidalCurrent objective grid requires poloidal "
+            "resolution for surface averages",
+        )
+        warnif(
+            grid.num_zeta < 2 * eq.N,
+            RuntimeWarning,
+            "ToroidalCurrent objective grid requires toroidal "
+            "resolution for surface averages",
+        )
 
         self._target, self._bounds = _parse_callable_target_bounds(
             self._target, self._bounds, grid.nodes[grid.unique_rho_idx]

--- a/desc/objectives/_profiles.py
+++ b/desc/objectives/_profiles.py
@@ -265,13 +265,13 @@ class RotationalTransform(_Objective):
             grid = self._grid
 
         warnif(
-            grid.num_theta < 2 * eq.M,
+            (eq.iota is None) and ((grid.num_theta * (1 + eq.sym)) < 2 * eq.M),
             RuntimeWarning,
             "RotationalTransform objective grid requires poloidal "
             "resolution for surface averages",
         )
         warnif(
-            grid.num_zeta < 2 * eq.N,
+            (eq.iota is None) and (grid.num_zeta < 2 * eq.N),
             RuntimeWarning,
             "RotationalTransform objective grid requires toroidal "
             "resolution for surface averages",
@@ -432,12 +432,12 @@ class Shear(_Objective):
             grid = self._grid
 
         warnif(
-            grid.num_theta < 2 * eq.M,
+            (eq.iota is None) and ((grid.num_theta * (1 + eq.sym)) < 2 * eq.M),
             RuntimeWarning,
             "Shear objective grid requires poloidal " "resolution for surface averages",
         )
         warnif(
-            grid.num_zeta < 2 * eq.N,
+            (eq.iota is None) and (grid.num_zeta < 2 * eq.N),
             RuntimeWarning,
             "Shear objective grid requires toroidal " "resolution for surface averages",
         )
@@ -595,13 +595,13 @@ class ToroidalCurrent(_Objective):
             grid = self._grid
 
         warnif(
-            grid.num_theta < 2 * eq.M,
+            (eq.current is None) and ((grid.num_theta * (1 + eq.sym)) < 2 * eq.M),
             RuntimeWarning,
             "ToroidalCurrent objective grid requires poloidal "
             "resolution for surface averages",
         )
         warnif(
-            grid.num_zeta < 2 * eq.N,
+            (eq.current is None) and (grid.num_zeta < 2 * eq.N),
             RuntimeWarning,
             "ToroidalCurrent objective grid requires toroidal "
             "resolution for surface averages",

--- a/desc/objectives/_qs.py
+++ b/desc/objectives/_qs.py
@@ -337,7 +337,7 @@ class QuasisymmetryTwoTerm(_Objective):
             grid = self._grid
 
         warnif(
-            grid.num_theta < 2 * eq.M,
+            (grid.num_theta * (1 + eq.sym)) < 2 * eq.M,
             RuntimeWarning,
             "QuasisymmetryTwoTerm objective grid requires poloidal "
             "resolution for surface averages",

--- a/desc/objectives/_qs.py
+++ b/desc/objectives/_qs.py
@@ -121,16 +121,16 @@ class QuasisymmetryBoozer(_Objective):
         else:
             grid = self._grid
 
-        QuasisymmetryBoozer(
+        warnif(
             grid.num_theta < 2 * eq.M,
             RuntimeWarning,
-            "Boozer objective grid requires poloidal "
+            "QuasisymmetryBoozer objective grid requires poloidal "
             "resolution for surface averages",
         )
-        QuasisymmetryBoozer(
+        warnif(
             grid.num_zeta < 2 * eq.N,
             RuntimeWarning,
-            "Boozer objective grid requires toroidal "
+            "QuasisymmetryBoozer objective grid requires toroidal "
             "resolution for surface averages",
         )
 

--- a/desc/objectives/_qs.py
+++ b/desc/objectives/_qs.py
@@ -121,6 +121,13 @@ class QuasisymmetryBoozer(_Objective):
         else:
             grid = self._grid
 
+        errorif(grid.sym, ValueError, "QuasisymmetryBoozer grid must be non-symmetric")
+        errorif(
+            grid.num_rho != 1,
+            ValueError,
+            "QuasisymmetryBoozer grid must be on a single surface. "
+            "To target multiple surfaces, use multiple objectives.",
+        )
         warnif(
             grid.num_theta < 2 * eq.M,
             RuntimeWarning,
@@ -135,14 +142,6 @@ class QuasisymmetryBoozer(_Objective):
         )
 
         self._data_keys = ["|B|_mn"]
-
-        errorif(grid.sym, ValueError, "QuasisymmetryBoozer grid must be non-symmetric")
-        errorif(
-            grid.num_rho != 1,
-            ValueError,
-            "QuasisymmetryBoozer grid must be on a single surface. "
-            "To target multiple surfaces, use multiple objectives.",
-        )
 
         timer = Timer()
         if verbose > 0:

--- a/desc/objectives/_qs.py
+++ b/desc/objectives/_qs.py
@@ -5,7 +5,7 @@ import warnings
 from desc.compute import compute as compute_fun
 from desc.compute import get_profiles, get_transforms
 from desc.grid import LinearGrid
-from desc.utils import Timer
+from desc.utils import Timer, errorif, warnif
 from desc.vmec_utils import ptolemy_linear_transform
 
 from .normalization import compute_scaling_factors
@@ -121,10 +121,28 @@ class QuasisymmetryBoozer(_Objective):
         else:
             grid = self._grid
 
+        QuasisymmetryBoozer(
+            grid.num_theta < 2 * eq.M,
+            RuntimeWarning,
+            "Boozer objective grid requires poloidal "
+            "resolution for surface averages",
+        )
+        QuasisymmetryBoozer(
+            grid.num_zeta < 2 * eq.N,
+            RuntimeWarning,
+            "Boozer objective grid requires toroidal "
+            "resolution for surface averages",
+        )
+
         self._data_keys = ["|B|_mn"]
 
-        assert grid.sym is False
-        assert grid.num_rho == 1
+        errorif(grid.sym, ValueError, "QuasisymmetryBoozer grid must be non-symmetric")
+        errorif(
+            grid.num_rho != 1,
+            ValueError,
+            "QuasisymmetryBoozer grid must be on a single surface. "
+            "To target multiple surfaces, use multiple objectives.",
+        )
 
         timer = Timer()
         if verbose > 0:
@@ -317,6 +335,19 @@ class QuasisymmetryTwoTerm(_Objective):
             grid = LinearGrid(M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
         else:
             grid = self._grid
+
+        warnif(
+            grid.num_theta < 2 * eq.M,
+            RuntimeWarning,
+            "QuasisymmetryTwoTerm objective grid requires poloidal "
+            "resolution for surface averages",
+        )
+        warnif(
+            grid.num_zeta < 2 * eq.N,
+            RuntimeWarning,
+            "QuasisymmetryTwoTerm objective grid requires toroidal "
+            "resolution for surface averages",
+        )
 
         self._dim_f = grid.num_nodes
         self._data_keys = ["f_C"]

--- a/desc/objectives/_stability.py
+++ b/desc/objectives/_stability.py
@@ -119,7 +119,7 @@ class MercierStability(_Objective):
             grid = self._grid
 
         warnif(
-            grid.num_theta < 2 * eq.M,
+            (grid.num_theta * (1 + eq.sym)) < 2 * eq.M,
             RuntimeWarning,
             "MercierStability objective grid requires poloidal "
             "resolution for surface averages",
@@ -295,7 +295,7 @@ class MagneticWell(_Objective):
             grid = self._grid
 
         warnif(
-            grid.num_theta < 2 * eq.M,
+            (grid.num_theta * (1 + eq.sym)) < 2 * eq.M,
             RuntimeWarning,
             "MagneticWell objective grid requires poloidal "
             "resolution for surface averages",

--- a/desc/objectives/_stability.py
+++ b/desc/objectives/_stability.py
@@ -5,7 +5,7 @@ import numpy as np
 from desc.compute import compute as compute_fun
 from desc.compute import get_profiles, get_transforms
 from desc.grid import LinearGrid
-from desc.utils import Timer
+from desc.utils import Timer, warnif
 
 from .normalization import compute_scaling_factors
 from .objective_funs import _Objective
@@ -117,6 +117,19 @@ class MercierStability(_Objective):
             )
         else:
             grid = self._grid
+
+        warnif(
+            grid.num_theta < 2 * eq.M,
+            RuntimeWarning,
+            "MercierStability objective grid requires poloidal "
+            "resolution for surface averages",
+        )
+        warnif(
+            grid.num_zeta < 2 * eq.N,
+            RuntimeWarning,
+            "MercierStability objective grid requires toroidal "
+            "resolution for surface averages",
+        )
 
         self._target, self._bounds = _parse_callable_target_bounds(
             self._target, self._bounds, grid.nodes[grid.unique_rho_idx]
@@ -280,6 +293,19 @@ class MagneticWell(_Objective):
             )
         else:
             grid = self._grid
+
+        warnif(
+            grid.num_theta < 2 * eq.M,
+            RuntimeWarning,
+            "MagneticWell objective grid requires poloidal "
+            "resolution for surface averages",
+        )
+        warnif(
+            grid.num_zeta < 2 * eq.N,
+            RuntimeWarning,
+            "MagneticWell objective grid requires toroidal "
+            "resolution for surface averages",
+        )
 
         self._target, self._bounds = _parse_callable_target_bounds(
             self._target, self._bounds, grid.nodes[grid.unique_rho_idx]

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -397,12 +397,12 @@ class TestObjectiveFunction:
 
         # symmetric grid
         grid = LinearGrid(M=eq.M, N=eq.N, NFP=eq.NFP, sym=True)
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             QuasisymmetryBoozer(eq=eq, grid=grid).build()
 
         # multiple flux surfaces
         grid = LinearGrid(M=eq.M, N=eq.N, NFP=eq.NFP, rho=[0.25, 0.5, 0.75, 1])
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             QuasisymmetryBoozer(eq=eq, grid=grid).build()
 
     @pytest.mark.unit


### PR DESCRIPTION
This is to try to prevent the footgun of users giving a grid for a profile-like objective that only has radial resolution.

I added warnings to all the objectives I could think of where it might make sense, but open to other suggestions.