### PR TITLE
add self_consistency constraints to test

### DIFF
--- a/tests/benchmarks/benchmark_cpu_small.py
+++ b/tests/benchmarks/benchmark_cpu_small.py
@@ -33,6 +33,9 @@ from desc.transform import Transform
 def test_build_transform_fft_lowres(benchmark):
     """Test time to build a transform (after compilation) for low resolution."""
 
+    def setup():
+        jax.clear_caches()
+
     def build():
         L = 5
         M = 5
@@ -42,13 +45,16 @@ def test_build_transform_fft_lowres(benchmark):
         transf = Transform(grid, basis, method="fft", build=False)
         transf.build()
 
-    benchmark.pedantic(build, iterations=1, rounds=50)
+    benchmark.pedantic(build, setup=setup, iterations=1, rounds=50)
 
 
 @pytest.mark.benchmark()
 def test_build_transform_fft_midres(benchmark):
     """Test time to build a transform (after compilation) for mid resolution."""
 
+    def setup():
+        jax.clear_caches()
+
     def build():
         L = 15
         M = 15
@@ -58,12 +64,15 @@ def test_build_transform_fft_midres(benchmark):
         transf = Transform(grid, basis, method="fft", build=False)
         transf.build()
 
-    benchmark.pedantic(build, iterations=1, rounds=50)
+    benchmark.pedantic(build, setup=setup, iterations=1, rounds=50)
 
 
 @pytest.mark.benchmark()
 def test_build_transform_fft_highres(benchmark):
     """Test time to build a transform (after compilation) for high resolution."""
+
+    def setup():
+        jax.clear_caches()
 
     def build():
         L = 25
@@ -74,12 +83,15 @@ def test_build_transform_fft_highres(benchmark):
         transf = Transform(grid, basis, method="fft", build=False)
         transf.build()
 
-    benchmark.pedantic(build, iterations=1, rounds=50)
+    benchmark.pedantic(build, setup=setup, iterations=1, rounds=50)
 
 
 @pytest.mark.benchmark()
 def test_equilibrium_init_lowres(benchmark):
     """Test time to create an equilibrium for low resolution."""
+
+    def setup():
+        jax.clear_caches()
 
     def build():
         L = 5
@@ -87,12 +99,15 @@ def test_equilibrium_init_lowres(benchmark):
         N = 5
         _ = Equilibrium(L=L, M=M, N=N)
 
-    benchmark.pedantic(build, iterations=1, rounds=50)
+    benchmark.pedantic(build, setup=setup, iterations=1, rounds=50)
 
 
 @pytest.mark.benchmark()
 def test_equilibrium_init_medres(benchmark):
     """Test time to create an equilibrium for medium resolution."""
+
+    def setup():
+        jax.clear_caches()
 
     def build():
         L = 15
@@ -100,12 +115,15 @@ def test_equilibrium_init_medres(benchmark):
         N = 15
         _ = Equilibrium(L=L, M=M, N=N)
 
-    benchmark.pedantic(build, iterations=1, rounds=50)
+    benchmark.pedantic(build, setup=setup, iterations=1, rounds=50)
 
 
 @pytest.mark.benchmark()
 def test_equilibrium_init_highres(benchmark):
     """Test time to create an equilibrium for high resolution."""
+
+    def setup():
+        jax.clear_caches()
 
     def build():
         L = 25
@@ -113,7 +131,7 @@ def test_equilibrium_init_highres(benchmark):
         N = 25
         _ = Equilibrium(L=L, M=M, N=N)
 
-    benchmark.pedantic(build, iterations=1, rounds=50)
+    benchmark.pedantic(build, setup=setup, iterations=1, rounds=50)
 
 
 @pytest.mark.slow

--- a/tests/benchmarks/benchmark_cpu_small.py
+++ b/tests/benchmarks/benchmark_cpu_small.py
@@ -22,6 +22,7 @@ from desc.objectives import (
     QuasisymmetryTwoTerm,
     get_equilibrium_objective,
     get_fixed_boundary_constraints,
+    maybe_add_self_consistency,
 )
 from desc.optimize import LinearConstraintProjection, ProximalProjection
 from desc.perturbations import perturb
@@ -125,7 +126,9 @@ def test_objective_compile_dshape_current(benchmark):
         eq = desc.examples.get("DSHAPE_current")
         objective = LinearConstraintProjection(
             get_equilibrium_objective(eq),
-            ObjectiveFunction(get_fixed_boundary_constraints(eq)),
+            ObjectiveFunction(
+                maybe_add_self_consistency(eq, get_fixed_boundary_constraints(eq)),
+            ),
         )
         objective.build(eq)
         args = (
@@ -151,7 +154,9 @@ def test_objective_compile_atf(benchmark):
         eq = desc.examples.get("ATF")
         objective = LinearConstraintProjection(
             get_equilibrium_objective(eq),
-            ObjectiveFunction(get_fixed_boundary_constraints(eq)),
+            ObjectiveFunction(
+                maybe_add_self_consistency(eq, get_fixed_boundary_constraints(eq)),
+            ),
         )
         objective.build(eq)
         args = (objective, eq)
@@ -172,7 +177,9 @@ def test_objective_compute_dshape_current(benchmark):
     eq = desc.examples.get("DSHAPE_current")
     objective = LinearConstraintProjection(
         get_equilibrium_objective(eq),
-        ObjectiveFunction(get_fixed_boundary_constraints(eq)),
+        ObjectiveFunction(
+            maybe_add_self_consistency(eq, get_fixed_boundary_constraints(eq)),
+        ),
     )
     objective.build(eq)
     objective.compile()
@@ -192,7 +199,9 @@ def test_objective_compute_atf(benchmark):
     eq = desc.examples.get("ATF")
     objective = LinearConstraintProjection(
         get_equilibrium_objective(eq),
-        ObjectiveFunction(get_fixed_boundary_constraints(eq)),
+        ObjectiveFunction(
+            maybe_add_self_consistency(eq, get_fixed_boundary_constraints(eq)),
+        ),
     )
     objective.build(eq)
     objective.compile()
@@ -212,7 +221,9 @@ def test_objective_jac_dshape_current(benchmark):
     eq = desc.examples.get("DSHAPE_current")
     objective = LinearConstraintProjection(
         get_equilibrium_objective(eq),
-        ObjectiveFunction(get_fixed_boundary_constraints(eq)),
+        ObjectiveFunction(
+            maybe_add_self_consistency(eq, get_fixed_boundary_constraints(eq)),
+        ),
     )
     objective.build(eq)
     objective.compile()
@@ -232,7 +243,9 @@ def test_objective_jac_atf(benchmark):
     eq = desc.examples.get("ATF")
     objective = LinearConstraintProjection(
         get_equilibrium_objective(eq),
-        ObjectiveFunction(get_fixed_boundary_constraints(eq)),
+        ObjectiveFunction(
+            maybe_add_self_consistency(eq, get_fixed_boundary_constraints(eq)),
+        ),
     )
     objective.build(eq)
     objective.compile()

--- a/tests/benchmarks/benchmark_gpu_small.py
+++ b/tests/benchmarks/benchmark_gpu_small.py
@@ -33,6 +33,9 @@ from desc.transform import Transform
 def test_build_transform_fft_lowres(benchmark):
     """Test time to build a transform (after compilation) for low resolution."""
 
+    def setup():
+        jax.clear_caches()
+
     def build():
         L = 5
         M = 5
@@ -42,13 +45,16 @@ def test_build_transform_fft_lowres(benchmark):
         transf = Transform(grid, basis, method="fft", build=False)
         transf.build()
 
-    benchmark.pedantic(build, iterations=1, rounds=50)
+    benchmark.pedantic(build, setup=setup, iterations=1, rounds=50)
 
 
 @pytest.mark.benchmark()
 def test_build_transform_fft_midres(benchmark):
     """Test time to build a transform (after compilation) for mid resolution."""
 
+    def setup():
+        jax.clear_caches()
+
     def build():
         L = 15
         M = 15
@@ -58,12 +64,15 @@ def test_build_transform_fft_midres(benchmark):
         transf = Transform(grid, basis, method="fft", build=False)
         transf.build()
 
-    benchmark.pedantic(build, iterations=1, rounds=50)
+    benchmark.pedantic(build, setup=setup, iterations=1, rounds=50)
 
 
 @pytest.mark.benchmark()
 def test_build_transform_fft_highres(benchmark):
     """Test time to build a transform (after compilation) for high resolution."""
+
+    def setup():
+        jax.clear_caches()
 
     def build():
         L = 25
@@ -74,12 +83,15 @@ def test_build_transform_fft_highres(benchmark):
         transf = Transform(grid, basis, method="fft", build=False)
         transf.build()
 
-    benchmark.pedantic(build, iterations=1, rounds=50)
+    benchmark.pedantic(build, setup=setup, iterations=1, rounds=50)
 
 
 @pytest.mark.benchmark()
 def test_equilibrium_init_lowres(benchmark):
     """Test time to create an equilibrium for low resolution."""
+
+    def setup():
+        jax.clear_caches()
 
     def build():
         L = 5
@@ -87,12 +99,15 @@ def test_equilibrium_init_lowres(benchmark):
         N = 5
         _ = Equilibrium(L=L, M=M, N=N)
 
-    benchmark.pedantic(build, iterations=1, rounds=50)
+    benchmark.pedantic(build, setup=setup, iterations=1, rounds=50)
 
 
 @pytest.mark.benchmark()
 def test_equilibrium_init_medres(benchmark):
     """Test time to create an equilibrium for medium resolution."""
+
+    def setup():
+        jax.clear_caches()
 
     def build():
         L = 15
@@ -100,12 +115,15 @@ def test_equilibrium_init_medres(benchmark):
         N = 15
         _ = Equilibrium(L=L, M=M, N=N)
 
-    benchmark.pedantic(build, iterations=1, rounds=50)
+    benchmark.pedantic(build, setup=setup, iterations=1, rounds=50)
 
 
 @pytest.mark.benchmark()
 def test_equilibrium_init_highres(benchmark):
     """Test time to create an equilibrium for high resolution."""
+
+    def setup():
+        jax.clear_caches()
 
     def build():
         L = 25
@@ -113,7 +131,7 @@ def test_equilibrium_init_highres(benchmark):
         N = 25
         _ = Equilibrium(L=L, M=M, N=N)
 
-    benchmark.pedantic(build, iterations=1, rounds=50)
+    benchmark.pedantic(build, setup=setup, iterations=1, rounds=50)
 
 
 @pytest.mark.slow

--- a/tests/benchmarks/benchmark_gpu_small.py
+++ b/tests/benchmarks/benchmark_gpu_small.py
@@ -22,6 +22,7 @@ from desc.objectives import (
     QuasisymmetryTwoTerm,
     get_equilibrium_objective,
     get_fixed_boundary_constraints,
+    maybe_add_self_consistency,
 )
 from desc.optimize import LinearConstraintProjection, ProximalProjection
 from desc.perturbations import perturb
@@ -124,7 +125,10 @@ def test_objective_compile_dshape_current(benchmark):
         jax.clear_caches()
         eq = desc.examples.get("DSHAPE_current")
         objective = LinearConstraintProjection(
-            get_equilibrium_objective(eq), get_fixed_boundary_constraints(eq)
+            get_equilibrium_objective(eq),
+            ObjectiveFunction(
+                maybe_add_self_consistency(eq, get_fixed_boundary_constraints(eq)),
+            ),
         )
         objective.build(eq)
         args = (
@@ -149,7 +153,10 @@ def test_objective_compile_atf(benchmark):
         jax.clear_caches()
         eq = desc.examples.get("ATF")
         objective = LinearConstraintProjection(
-            get_equilibrium_objective(eq), get_fixed_boundary_constraints(eq)
+            get_equilibrium_objective(eq),
+            ObjectiveFunction(
+                maybe_add_self_consistency(eq, get_fixed_boundary_constraints(eq)),
+            ),
         )
         objective.build(eq)
         args = (objective, eq)
@@ -169,7 +176,10 @@ def test_objective_compute_dshape_current(benchmark):
     jax.clear_caches()
     eq = desc.examples.get("DSHAPE_current")
     objective = LinearConstraintProjection(
-        get_equilibrium_objective(eq), get_fixed_boundary_constraints(eq)
+        get_equilibrium_objective(eq),
+        ObjectiveFunction(
+            maybe_add_self_consistency(eq, get_fixed_boundary_constraints(eq)),
+        ),
     )
     objective.build(eq)
     objective.compile()
@@ -188,7 +198,10 @@ def test_objective_compute_atf(benchmark):
     jax.clear_caches()
     eq = desc.examples.get("ATF")
     objective = LinearConstraintProjection(
-        get_equilibrium_objective(eq), get_fixed_boundary_constraints(eq)
+        get_equilibrium_objective(eq),
+        ObjectiveFunction(
+            maybe_add_self_consistency(eq, get_fixed_boundary_constraints(eq)),
+        ),
     )
     objective.build(eq)
     objective.compile()
@@ -207,7 +220,10 @@ def test_objective_jac_dshape_current(benchmark):
     jax.clear_caches()
     eq = desc.examples.get("DSHAPE_current")
     objective = LinearConstraintProjection(
-        get_equilibrium_objective(eq), get_fixed_boundary_constraints(eq)
+        get_equilibrium_objective(eq),
+        ObjectiveFunction(
+            maybe_add_self_consistency(eq, get_fixed_boundary_constraints(eq)),
+        ),
     )
     objective.build(eq)
     objective.compile()
@@ -226,7 +242,10 @@ def test_objective_jac_atf(benchmark):
     jax.clear_caches()
     eq = desc.examples.get("ATF")
     objective = LinearConstraintProjection(
-        get_equilibrium_objective(eq), get_fixed_boundary_constraints(eq)
+        get_equilibrium_objective(eq),
+        ObjectiveFunction(
+            maybe_add_self_consistency(eq, get_fixed_boundary_constraints(eq)),
+        ),
     )
     objective.build(eq)
     objective.compile()
@@ -336,7 +355,7 @@ def test_proximal_freeb_compute(benchmark):
     constraint = ObjectiveFunction(ForceBalance(eq))
     prox = ProximalProjection(objective, constraint, eq)
     obj = LinearConstraintProjection(
-        prox, (FixCurrent(eq), FixPressure(eq), FixPsi(eq))
+        prox, ObjectiveFunction((FixCurrent(eq), FixPressure(eq), FixPsi(eq)))
     )
     obj.build()
     obj.compile()
@@ -360,7 +379,7 @@ def test_proximal_freeb_jac(benchmark):
     constraint = ObjectiveFunction(ForceBalance(eq))
     prox = ProximalProjection(objective, constraint, eq)
     obj = LinearConstraintProjection(
-        prox, (FixCurrent(eq), FixPressure(eq), FixPsi(eq))
+        prox, ObjectiveFunction((FixCurrent(eq), FixPressure(eq), FixPsi(eq)))
     )
     obj.build()
     obj.compile()


### PR DESCRIPTION
For the benchmark tests, we compare the jacobian calculations only using get_fixed_boundary_constraint. However, in reality, the constraint always has maybe_add_self_consistency constraints. For Poincare branch and for others which adds parameters to x vector, this results in a pseudo-slow-down for the benchmark tests.

This PR adds maybe_add_self_consistency constraints to those tests.