### PR TITLE
Add explicit Jacobian of ``compute_scaled_error``

### DIFF
--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -68,9 +68,13 @@ class ObjectiveFunction(IOAble):
             self._hess = Derivative(self.compute_scalar, mode="hess")
         if self._deriv_mode == "batched":
             self._jac_scaled = Derivative(self.compute_scaled, mode="fwd")
+            self._jac_scaled_error = Derivative(self.compute_scaled_error, mode="fwd")
             self._jac_unscaled = Derivative(self.compute_unscaled, mode="fwd")
         if self._deriv_mode == "looped":
             self._jac_scaled = Derivative(self.compute_scaled, mode="looped")
+            self._jac_scaled_error = Derivative(
+                self.compute_scaled_error, mode="looped"
+            )
             self._jac_unscaled = Derivative(self.compute_unscaled, mode="looped")
         if self._deriv_mode == "blocked":
             # could also do something similar for grad and hess, but probably not
@@ -101,6 +105,7 @@ class ObjectiveFunction(IOAble):
                 return jnp.vstack(J)
 
             self._jac_scaled = partial(jac_, "jac_scaled")
+            self._jac_scaled_error = partial(jac_, "jac_scaled_error")
             self._jac_unscaled = partial(jac_, "jac_unscaled")
 
     def jit(self):  # noqa: C901
@@ -120,12 +125,15 @@ class ObjectiveFunction(IOAble):
             "compute_unscaled",
             "compute_scalar",
             "jac_scaled",
+            "jac_scaled_error",
             "jac_unscaled",
             "hess",
             "grad",
             "jvp_scaled",
+            "jvp_scaled_error",
             "jvp_unscaled",
             "vjp_scaled",
+            "vjp_scaled_error",
             "vjp_unscaled",
         ]
 
@@ -400,33 +408,55 @@ class ObjectiveFunction(IOAble):
         return jnp.concatenate(xs)
 
     def grad(self, x, constants=None):
-        """Compute gradient vector of scalar form of the objective wrt x."""
+        """Compute gradient vector of self.compute_scalar wrt x."""
         if constants is None:
             constants = self.constants
         return jnp.atleast_1d(self._grad(x, constants).squeeze())
 
     def hess(self, x, constants=None):
-        """Compute Hessian matrix of scalar form of the objective wrt x."""
+        """Compute Hessian matrix of self.compute_scalar wrt x."""
         if constants is None:
             constants = self.constants
         return jnp.atleast_2d(self._hess(x, constants).squeeze())
 
     def jac_scaled(self, x, constants=None):
-        """Compute Jacobian matrix of vector form of the objective wrt x."""
+        """Compute Jacobian matrix of self.compute_scaled wrt x."""
         if constants is None:
             constants = self.constants
         return jnp.atleast_2d(self._jac_scaled(x, constants).squeeze())
 
+    def jac_scaled_error(self, x, constants=None):
+        """Compute Jacobian matrix of self.compute_scaled_error wrt x."""
+        if constants is None:
+            constants = self.constants
+        return jnp.atleast_2d(self._jac_scaled_error(x, constants).squeeze())
+
     def jac_unscaled(self, x, constants=None):
-        """Compute Jacobian matrix of vector form of the objective wrt x, unweighted."""
+        """Compute Jacobian matrix of self.compute_unscaled wrt x."""
         if constants is None:
             constants = self.constants
         return jnp.atleast_2d(self._jac_unscaled(x, constants).squeeze())
 
-    def jvp_scaled(self, v, x, constants=None):
-        """Compute Jacobian-vector product of the objective function.
+    def _jvp(self, v, x, constants=None, op="compute_scaled"):
+        v = v if isinstance(v, (tuple, list)) else (v,)
 
-        Uses the scaled form of the objective.
+        fun = lambda x: getattr(self, op)(x, constants)
+        if len(v) == 1:
+            jvpfun = lambda dx: Derivative.compute_jvp(fun, 0, dx, x)
+            return jnp.vectorize(jvpfun, signature="(n)->(k)")(v[0])
+        elif len(v) == 2:
+            jvpfun = lambda dx1, dx2: Derivative.compute_jvp2(fun, 0, 0, dx1, dx2, x)
+            return jnp.vectorize(jvpfun, signature="(n),(n)->(k)")(v[0], v[1])
+        elif len(v) == 3:
+            jvpfun = lambda dx1, dx2, dx3: Derivative.compute_jvp3(
+                fun, 0, 0, 0, dx1, dx2, dx3, x
+            )
+            return jnp.vectorize(jvpfun, signature="(n),(n),(n)->(k)")(v[0], v[1], v[2])
+        else:
+            raise NotImplementedError("Cannot compute JVP higher than 3rd order.")
+
+    def jvp_scaled(self, v, x, constants=None):
+        """Compute Jacobian-vector product of self.compute_scaled.
 
         Parameters
         ----------
@@ -439,29 +469,26 @@ class ObjectiveFunction(IOAble):
             Constant parameters passed to sub-objectives.
 
         """
-        v = v if isinstance(v, (tuple, list)) else (v,)
+        return self._jvp(v, x, constants, "compute_scaled")
 
-        compute_scaled = lambda x: self.compute_scaled(x, constants)
-        if len(v) == 1:
-            jvpfun = lambda dx: Derivative.compute_jvp(compute_scaled, 0, dx, x)
-            return jnp.vectorize(jvpfun, signature="(n)->(k)")(v[0])
-        elif len(v) == 2:
-            jvpfun = lambda dx1, dx2: Derivative.compute_jvp2(
-                compute_scaled, 0, 0, dx1, dx2, x
-            )
-            return jnp.vectorize(jvpfun, signature="(n),(n)->(k)")(v[0], v[1])
-        elif len(v) == 3:
-            jvpfun = lambda dx1, dx2, dx3: Derivative.compute_jvp3(
-                compute_scaled, 0, 0, 0, dx1, dx2, dx3, x
-            )
-            return jnp.vectorize(jvpfun, signature="(n),(n),(n)->(k)")(v[0], v[1], v[2])
-        else:
-            raise NotImplementedError("Cannot compute JVP higher than 3rd order.")
+    def jvp_scaled_error(self, v, x, constants=None):
+        """Compute Jacobian-vector product of self.compute_scaled_error.
+
+        Parameters
+        ----------
+        v : tuple of ndarray
+            Vectors to right-multiply the Jacobian by.
+            The number of vectors given determines the order of derivative taken.
+        x : ndarray
+            Optimization variables.
+        constants : list
+            Constant parameters passed to sub-objectives.
+
+        """
+        return self._jvp(v, x, constants, "compute_scaled_error")
 
     def jvp_unscaled(self, v, x, constants=None):
-        """Compute Jacobian-vector product of the objective function.
-
-        Uses the unscaled form of the objective.
+        """Compute Jacobian-vector product of self.compute_unscaled.
 
         Parameters
         ----------
@@ -474,29 +501,14 @@ class ObjectiveFunction(IOAble):
             Constant parameters passed to sub-objectives.
 
         """
-        v = v if isinstance(v, (tuple, list)) else (v,)
+        return self._jvp(v, x, constants, "compute_unscaled")
 
-        compute_unscaled = lambda x: self.compute_unscaled(x, constants)
-        if len(v) == 1:
-            jvpfun = lambda dx: Derivative.compute_jvp(compute_unscaled, 0, dx, x)
-            return jnp.vectorize(jvpfun, signature="(n)->(k)")(v[0])
-        elif len(v) == 2:
-            jvpfun = lambda dx1, dx2: Derivative.compute_jvp2(
-                compute_unscaled, 0, 0, dx1, dx2, x
-            )
-            return jnp.vectorize(jvpfun, signature="(n),(n)->(k)")(v[0], v[1])
-        elif len(v) == 3:
-            jvpfun = lambda dx1, dx2, dx3: Derivative.compute_jvp3(
-                compute_unscaled, 0, 0, 0, dx1, dx2, dx3, x
-            )
-            return jnp.vectorize(jvpfun, signature="(n),(n),(n)->(k)")(v[0], v[1], v[2])
-        else:
-            raise NotImplementedError("Cannot compute JVP higher than 3rd order.")
+    def _vjp(self, v, x, constants=None, op="compute_scaled"):
+        fun = lambda x: getattr(self, op)(x, constants)
+        return Derivative.compute_vjp(fun, 0, v, x)
 
     def vjp_scaled(self, v, x, constants=None):
-        """Compute vector-Jacobian product of the objective function.
-
-        Uses the scaled form of the objective.
+        """Compute vector-Jacobian product of self.compute_scaled.
 
         Parameters
         ----------
@@ -508,13 +520,25 @@ class ObjectiveFunction(IOAble):
             Constant parameters passed to sub-objectives.
 
         """
-        compute_scaled = lambda x: self.compute_scaled(x, constants)
-        return Derivative.compute_vjp(compute_scaled, 0, v, x)
+        return self._vjp(v, x, constants, "compute_scaled")
+
+    def vjp_scaled_error(self, v, x, constants=None):
+        """Compute vector-Jacobian product of self.compute_scaled_error.
+
+        Parameters
+        ----------
+        v : ndarray
+            Vector to left-multiply the Jacobian by.
+        x : ndarray
+            Optimization variables.
+        constants : list
+            Constant parameters passed to sub-objectives.
+
+        """
+        return self._vjp(v, x, constants, "compute_scaled_error")
 
     def vjp_unscaled(self, v, x, constants=None):
-        """Compute vector-Jacobian product of the objective function.
-
-        Uses the unscaled form of the objective.
+        """Compute vector-Jacobian product of self.compute_unscaled.
 
         Parameters
         ----------
@@ -526,8 +550,7 @@ class ObjectiveFunction(IOAble):
             Constant parameters passed to sub-objectives.
 
         """
-        compute_unscaled = lambda x: self.compute_unscaled(x, constants)
-        return Derivative.compute_vjp(compute_unscaled, 0, v, x)
+        return self._vjp(v, x, constants, "compute_unscaled")
 
     def compile(self, mode="auto", verbose=1):
         """Call the necessary functions to ensure the function is compiled.
@@ -806,6 +829,9 @@ class _Objective(IOAble, ABC):
         self._jac_scaled = Derivative(
             self.compute_scaled, argnums, mode=self._deriv_mode
         )
+        self._jac_scaled_error = Derivative(
+            self.compute_scaled_error, argnums, mode=self._deriv_mode
+        )
         self._jac_unscaled = Derivative(
             self.compute_unscaled, argnums, mode=self._deriv_mode
         )
@@ -820,6 +846,7 @@ class _Objective(IOAble, ABC):
             "compute_unscaled",
             "compute_scalar",
             "jac_scaled",
+            "jac_scaled_error",
             "jac_unscaled",
             "hess",
             "grad",
@@ -963,25 +990,37 @@ class _Objective(IOAble, ABC):
         return f.squeeze()
 
     def grad(self, *args, **kwargs):
-        """Compute gradient vector of scalar form of the objective wrt x."""
+        """Compute gradient vector of self.compute_scalar wrt x."""
         return self._grad(*args, **kwargs)
 
     def hess(self, *args, **kwargs):
-        """Compute Hessian matrix of scalar form of the objective wrt x."""
+        """Compute Hessian matrix of self.compute_scalar wrt x."""
         return self._hess(*args, **kwargs)
 
     def jac_scaled(self, *args, **kwargs):
-        """Compute Jacobian matrix of vector form of the objective wrt x."""
+        """Compute Jacobian matrix of self.compute_scaled wrt x."""
+        return self._jac_scaled(*args, **kwargs)
+
+    def jac_scaled_error(self, *args, **kwargs):
+        """Compute Jacobian matrix of self.compute_scaled_error wrt x."""
         return self._jac_scaled(*args, **kwargs)
 
     def jac_unscaled(self, *args, **kwargs):
-        """Compute Jacobian matrix of vector form of the objective wrt x, unweighted."""
+        """Compute Jacobian matrix of self.compute_unscaled wrt x."""
         return self._jac_unscaled(*args, **kwargs)
 
-    def jvp_scaled(self, v, x, constants=None):
-        """Compute Jacobian-vector product of the objective function.
+    def _jvp(self, v, x, constants=None, op="compute_scaled"):
+        v = v if isinstance(v, (tuple, list)) else (v,)
+        x = x if isinstance(x, (tuple, list)) else (x,)
+        assert len(x) == len(v)
 
-        Uses the scaled form of the objective.
+        fun = lambda *x: getattr(self, op)(*x, constants=constants)
+        jvpfun = lambda *dx: Derivative.compute_jvp(fun, tuple(range(len(x))), dx, *x)
+        sig = ",".join(f"(n{i})" for i in range(len(x))) + "->(k)"
+        return jnp.vectorize(jvpfun, signature=sig)(*v)
+
+    def jvp_scaled(self, v, x, constants=None):
+        """Compute Jacobian-vector product of self.compute_scaled.
 
         Parameters
         ----------
@@ -993,21 +1032,25 @@ class _Objective(IOAble, ABC):
             Constant parameters passed to sub-objectives.
 
         """
-        v = v if isinstance(v, (tuple, list)) else (v,)
-        x = x if isinstance(x, (tuple, list)) else (x,)
-        assert len(x) == len(v)
+        return self._jvp(v, x, constants, "compute_scaled")
 
-        compute_scaled = lambda *x: self.compute_scaled(*x, constants=constants)
-        jvpfun = lambda *dx: Derivative.compute_jvp(
-            compute_scaled, tuple(range(len(x))), dx, *x
-        )
-        sig = ",".join(f"(n{i})" for i in range(len(x))) + "->(k)"
-        return jnp.vectorize(jvpfun, signature=sig)(*v)
+    def jvp_scaled_error(self, v, x, constants=None):
+        """Compute Jacobian-vector product of self.compute_scaled_error.
+
+        Parameters
+        ----------
+        v : tuple of ndarray
+            Vectors to right-multiply the Jacobian by.
+        x : tuple of ndarray
+            Optimization variables.
+        constants : list
+            Constant parameters passed to sub-objectives.
+
+        """
+        return self._jvp(v, x, constants, "compute_scaled_error")
 
     def jvp_unscaled(self, v, x, constants=None):
-        """Compute Jacobian-vector product of the objective function.
-
-        Uses the unscaled form of the objective.
+        """Compute Jacobian-vector product of self.compute_unscaled.
 
         Parameters
         ----------
@@ -1019,16 +1062,7 @@ class _Objective(IOAble, ABC):
             Constant parameters passed to sub-objectives.
 
         """
-        v = v if isinstance(v, (tuple, list)) else (v,)
-        x = x if isinstance(x, (tuple, list)) else (x,)
-        assert len(x) == len(v)
-
-        compute_unscaled = lambda *x: self.compute_unscaled(*x, constants=constants)
-        jvpfun = lambda *dx: Derivative.compute_jvp(
-            compute_unscaled, tuple(range(len(x))), dx, *x
-        )
-        sig = ",".join(f"(n{i})" for i in range(len(x))) + "->(k)"
-        return jnp.vectorize(jvpfun, signature=sig)(*v)
+        return self._jvp(v, x, constants, "compute_unscaled")
 
     def print_value(self, *args, **kwargs):
         """Print the value of the objective."""

--- a/desc/optimize/_constraint_wrappers.py
+++ b/desc/optimize/_constraint_wrappers.py
@@ -244,7 +244,7 @@ class LinearConstraintProjection(ObjectiveFunction):
         return self._objective.compute_scalar(x, constants)
 
     def grad(self, x_reduced, constants=None):
-        """Compute gradient of the sum of squares of residuals.
+        """Compute gradient of self.compute_scalar.
 
         Parameters
         ----------
@@ -264,7 +264,7 @@ class LinearConstraintProjection(ObjectiveFunction):
         return df[self._unfixed_idx] @ self._Z
 
     def hess(self, x_reduced, constants=None):
-        """Compute Hessian of the sum of squares of residuals.
+        """Compute Hessian of self.compute_scalar.
 
         Parameters
         ----------
@@ -283,34 +283,18 @@ class LinearConstraintProjection(ObjectiveFunction):
         df = self._objective.hess(x, constants)
         return self._Z.T @ df[self._unfixed_idx, :][:, self._unfixed_idx] @ self._Z
 
-    def jac_unscaled(self, x_reduced, constants=None):
-        """Compute Jacobian of the vector objective function without weighting / bounds.
-
-        Parameters
-        ----------
-        x_reduced : ndarray
-            Reduced state vector that satisfies linear constraints.
-        constants : list
-            Constant parameters passed to sub-objectives.
-
-        Returns
-        -------
-        J : ndarray
-            Jacobian matrix.
-
-        """
+    def _jac(self, x_reduced, constants=None, op="scaled"):
         x = self.recover(x_reduced)
         if self._objective._deriv_mode == "blocked":
-            return (
-                self._objective.jac_unscaled(x, constants)[:, self._unfixed_idx]
-                @ self._Z
-            )
+            fun = getattr(self._objective, "jac_" + op)
+            return fun(x, constants)[:, self._unfixed_idx] @ self._Z
+
         v = self._unfixed_idx_mat
-        df = self._objective.jvp_unscaled(v.T, x, constants)
+        df = getattr(self._objective, "jvp_" + op)(v.T, x, constants)
         return df.T
 
     def jac_scaled(self, x_reduced, constants=None):
-        """Compute Jacobian of the vector objective function with weighting / bounds.
+        """Compute Jacobian of self.compute_scaled.
 
         Parameters
         ----------
@@ -323,20 +307,54 @@ class LinearConstraintProjection(ObjectiveFunction):
         -------
         J : ndarray
             Jacobian matrix.
+
         """
+        return self._jac(x_reduced, constants, "scaled")
+
+    def jac_scaled_error(self, x_reduced, constants=None):
+        """Compute Jacobian of self.compute_scaled_error.
+
+        Parameters
+        ----------
+        x_reduced : ndarray
+            Reduced state vector that satisfies linear constraints.
+        constants : list
+            Constant parameters passed to sub-objectives.
+
+        Returns
+        -------
+        J : ndarray
+            Jacobian matrix.
+
+        """
+        return self._jac(x_reduced, constants, "scaled_error")
+
+    def jac_unscaled(self, x_reduced, constants=None):
+        """Compute Jacobian of self.compute_unscaled.
+
+        Parameters
+        ----------
+        x_reduced : ndarray
+            Reduced state vector that satisfies linear constraints.
+        constants : list
+            Constant parameters passed to sub-objectives.
+
+        Returns
+        -------
+        J : ndarray
+            Jacobian matrix.
+
+        """
+        return self._jac(x_reduced, constants, "unscaled")
+
+    def _jvp(self, v, x_reduced, constants=None, op="jvp_scaled"):
         x = self.recover(x_reduced)
-        if self._objective._deriv_mode == "blocked":
-            return (
-                self._objective.jac_scaled(x, constants)[:, self._unfixed_idx] @ self._Z
-            )
-        v = self._unfixed_idx_mat
-        df = self._objective.jvp_scaled(v.T, x, constants)
-        return df.T
+        v = self._unfixed_idx_mat @ v
+        df = getattr(self._objective, op)(v, x, constants)
+        return df
 
     def jvp_scaled(self, v, x_reduced, constants=None):
-        """Compute Jacobian-vector product of the objective function.
-
-        Uses the scaled form of the objective.
+        """Compute Jacobian-vector product of self.compute_scaled.
 
         Parameters
         ----------
@@ -348,15 +366,25 @@ class LinearConstraintProjection(ObjectiveFunction):
             Constant parameters passed to sub-objectives.
 
         """
-        x = self.recover(x_reduced)
-        v = self._unfixed_idx_mat @ v
-        df = self._objective.jvp_scaled(v, x, constants)
-        return df
+        return self._jvp(v, x_reduced, constants, "jvp_scaled")
+
+    def jvp_scaled_error(self, v, x_reduced, constants=None):
+        """Compute Jacobian-vector product of self.compute_scaled_error.
+
+        Parameters
+        ----------
+        v : tuple of ndarray
+            Vectors to right-multiply the Jacobian by.
+        x_reduced : ndarray
+            Optimization variables with linear constraints removed.
+        constants : list
+            Constant parameters passed to sub-objectives.
+
+        """
+        return self._jvp(v, x_reduced, constants, "jvp_scaled_error")
 
     def jvp_unscaled(self, v, x_reduced, constants=None):
-        """Compute Jacobian-vector product of the objective function.
-
-        Uses the unscaled form of the objective.
+        """Compute Jacobian-vector product of self.compute_unscaled.
 
         Parameters
         ----------
@@ -368,15 +396,15 @@ class LinearConstraintProjection(ObjectiveFunction):
             Constant parameters passed to sub-objectives.
 
         """
+        return self._jvp(v, x_reduced, constants, "jvp_unscaled")
+
+    def _vjp(self, v, x_reduced, constants=None, op="vjp_scaled"):
         x = self.recover(x_reduced)
-        v = self._unfixed_idx_mat @ v
-        df = self._objective.jvp_unscaled(v, x, constants)
-        return df
+        df = getattr(self._objective, op)(v, x, constants)
+        return df[self._unfixed_idx] @ self._Z
 
     def vjp_scaled(self, v, x_reduced, constants=None):
-        """Compute vector-Jacobian product of the objective function.
-
-        Uses the scaled form of the objective.
+        """Compute vector-Jacobian product of self.compute_scaled.
 
         Parameters
         ----------
@@ -388,14 +416,25 @@ class LinearConstraintProjection(ObjectiveFunction):
             Constant parameters passed to sub-objectives.
 
         """
-        x = self.recover(x_reduced)
-        df = self._objective.vjp_scaled(v, x, constants)
-        return df[self._unfixed_idx] @ self._Z
+        return self._vjp(v, x_reduced, constants, "vjp_scaled")
+
+    def vjp_scaled_error(self, v, x_reduced, constants=None):
+        """Compute vector-Jacobian product of self.compute_scaled_error.
+
+        Parameters
+        ----------
+        v : ndarray
+            Vector to left-multiply the Jacobian by.
+        x_reduced : ndarray
+            Optimization variables with linear constraints removed.
+        constants : list
+            Constant parameters passed to sub-objectives.
+
+        """
+        return self._vjp(v, x_reduced, constants, "vjp_scaled_error")
 
     def vjp_unscaled(self, v, x_reduced, constants=None):
-        """Compute vector-Jacobian product of the objective function.
-
-        Uses the unscaled form of the objective.
+        """Compute vector-Jacobian product of self.compute_unscaled.
 
         Parameters
         ----------
@@ -407,9 +446,7 @@ class LinearConstraintProjection(ObjectiveFunction):
             Constant parameters passed to sub-objectives.
 
         """
-        x = self.recover(x_reduced)
-        df = self._objective.vjp_unscaled(v, x, constants)
-        return df[self._unfixed_idx] @ self._Z
+        return self._vjp(v, x_reduced, constants, "vjp_unscaled")
 
     def __getattr__(self, name):
         """For other attributes we defer to the base objective."""
@@ -805,7 +842,7 @@ class ProximalProjection(ObjectiveFunction):
         return self._objective.compute_unscaled(xopt, constants[0])
 
     def grad(self, x, constants=None):
-        """Compute gradient of the sum of squares of residuals.
+        """Compute gradient of self.compute_scalar.
 
         Parameters
         ----------
@@ -820,49 +857,13 @@ class ProximalProjection(ObjectiveFunction):
             gradient vector.
 
         """
+        # TODO: figure out projected vjp to make this better
         f = jnp.atleast_1d(self.compute_scaled_error(x, constants))
-        J = self.jac_scaled(x, constants)
+        J = self.jac_scaled_error(x, constants)
         return f.T @ J
 
-    def jac_unscaled(self, x, constants=None):
-        """Compute Jacobian of the vector objective function without weights / bounds.
-
-        Parameters
-        ----------
-        x : ndarray
-            State vector.
-        constants : list
-            Constant parameters passed to sub-objectives.
-
-        Returns
-        -------
-        J : ndarray
-            Jacobian matrix.
-        """
-        v = jnp.eye(x.shape[0])
-        return self.jvp_unscaled(v, x, constants).T
-
-    def jac_scaled(self, x, constants=None):
-        """Compute Jacobian of the vector objective function with weights / bounds.
-
-        Parameters
-        ----------
-        x : ndarray
-            State vector.
-        constants : list
-            Constant parameters passed to sub-objectives.
-
-        Returns
-        -------
-        J : ndarray
-            Jacobian matrix.
-
-        """
-        v = jnp.eye(x.shape[0])
-        return self.jvp_scaled(v, x, constants).T
-
     def hess(self, x, constants=None):
-        """Compute Hessian of the sum of squares of residuals.
+        """Compute Hessian of self.compute_scalar.
 
         Uses the "small residual approximation" where the Hessian is replaced by
         the square of the Jacobian: H = J.T @ J
@@ -880,13 +881,67 @@ class ProximalProjection(ObjectiveFunction):
             Hessian matrix.
 
         """
-        J = self.jac_scaled(x, constants)
+        J = self.jac_scaled_error(x, constants)
         return J.T @ J
 
-    def jvp_scaled(self, v, x, constants=None):
-        """Compute Jacobian-vector product of the objective function.
+    def jac_scaled(self, x, constants=None):
+        """Compute Jacobian of self.compute_scaled.
 
-        Uses the scaled form of the objective.
+        Parameters
+        ----------
+        x : ndarray
+            State vector.
+        constants : list
+            Constant parameters passed to sub-objectives.
+
+        Returns
+        -------
+        J : ndarray
+            Jacobian matrix.
+
+        """
+        v = jnp.eye(x.shape[0])
+        return self.jvp_scaled(v, x, constants).T
+
+    def jac_scaled_error(self, x, constants=None):
+        """Compute Jacobian of self.compute_scaled_error.
+
+        Parameters
+        ----------
+        x : ndarray
+            State vector.
+        constants : list
+            Constant parameters passed to sub-objectives.
+
+        Returns
+        -------
+        J : ndarray
+            Jacobian matrix.
+
+        """
+        v = jnp.eye(x.shape[0])
+        return self.jvp_scaled_error(v, x, constants).T
+
+    def jac_unscaled(self, x, constants=None):
+        """Compute Jacobian of self.compute_unscaled.
+
+        Parameters
+        ----------
+        x : ndarray
+            State vector.
+        constants : list
+            Constant parameters passed to sub-objectives.
+
+        Returns
+        -------
+        J : ndarray
+            Jacobian matrix.
+        """
+        v = jnp.eye(x.shape[0])
+        return self.jvp_unscaled(v, x, constants).T
+
+    def jvp_scaled(self, v, x, constants=None):
+        """Compute Jacobian-vector product of self.compute_scaled.
 
         Parameters
         ----------
@@ -905,10 +960,28 @@ class ProximalProjection(ObjectiveFunction):
         jvpfun = lambda u: self._jvp(u, xf, xg, constants, op="scaled")
         return jnp.vectorize(jvpfun, signature="(n)->(k)")(v)
 
-    def jvp_unscaled(self, v, x, constants=None):
-        """Compute Jacobian-vector product of the objective function.
+    def jvp_scaled_error(self, v, x, constants=None):
+        """Compute Jacobian-vector product of self.compute_scaled_error.
 
-        Uses the unscaled form of the objective.
+        Parameters
+        ----------
+        v : ndarray or tuple of ndarray
+            Vectors to right-multiply the Jacobian by.
+            This method only works for first order jvps.
+        x : ndarray
+            Optimization variables.
+        constants : list
+            Constant parameters passed to sub-objectives.
+
+        """
+        v = v[0] if isinstance(v, (tuple, list)) else v
+        constants = setdefault(constants, self.constants)
+        xg, xf = self._update_equilibrium(x, store=True)
+        jvpfun = lambda u: self._jvp(u, xf, xg, constants, op="scaled_error")
+        return jnp.vectorize(jvpfun, signature="(n)->(k)")(v)
+
+    def jvp_unscaled(self, v, x, constants=None):
+        """Compute Jacobian-vector product of self.compute_unscaled.
 
         Parameters
         ----------

--- a/desc/optimize/_desc_wrappers.py
+++ b/desc/optimize/_desc_wrappers.py
@@ -187,7 +187,7 @@ def _optimize_desc_aug_lagrangian_least_squares(
     result = lsq_auglag(
         lambda x, *c: objective.compute_scaled_error(x, c[0]),
         x0=x0,
-        jac=lambda x, *c: objective.jac_scaled(x, c[0]),
+        jac=lambda x, *c: objective.jac_scaled_error(x, c[0]),
         bounds=(-jnp.inf, jnp.inf),
         constraint=constraint_wrapped,
         args=(objective.constants, constraint.constants if constraint else None),
@@ -270,7 +270,7 @@ def _optimize_desc_least_squares(
     result = lsqtr(
         objective.compute_scaled_error,
         x0=x0,
-        jac=objective.jac_scaled,
+        jac=objective.jac_scaled_error,
         args=(objective.constants,),
         x_scale=x_scale,
         ftol=stoptol["ftol"],

--- a/desc/optimize/_scipy_wrappers.py
+++ b/desc/optimize/_scipy_wrappers.py
@@ -353,7 +353,7 @@ def _optimize_scipy_least_squares(  # noqa: C901 - FIXME: simplify this
     assert constraint is None, f"method {method} doesn't support constraints"
     options = {} if options is None else options
     x_scale = "jac" if x_scale == "auto" else x_scale
-    fun, jac = objective.compute_scaled_error, objective.jac_scaled
+    fun, jac = objective.compute_scaled_error, objective.jac_scaled_error
     # need to use some "global" variables here
     fun_allx = []
     fun_allf = []

--- a/desc/perturbations.py
+++ b/desc/perturbations.py
@@ -290,7 +290,7 @@ def perturb(  # noqa: C901 - FIXME: break this up into simpler pieces
         if verbose > 0:
             print("Computing df")
         timer.start("df computation")
-        Jx = objective.jac_scaled(x)
+        Jx = objective.jac_scaled_error(x)
         Jx_reduced = Jx[:, unfixed_idx] @ Z @ scale
         RHS1 = objective.jvp_scaled(tangents, x)
         if include_f:
@@ -597,7 +597,7 @@ def optimal_perturb(  # noqa: C901 - FIXME: break this up into simpler pieces
         if verbose > 0:
             print("Computing df")
         timer.start("df computation")
-        Fx = objective_f.jac_scaled(xf)
+        Fx = objective_f.jac_scaled_error(xf)
         timer.stop("df computation")
         if verbose > 1:
             timer.disp("df computation")
@@ -606,7 +606,7 @@ def optimal_perturb(  # noqa: C901 - FIXME: break this up into simpler pieces
         if verbose > 0:
             print("Computing dg")
         timer.start("dg computation")
-        Gx = objective_g.jac_scaled(xg)
+        Gx = objective_g.jac_scaled_error(xg)
         timer.stop("dg computation")
         if verbose > 1:
             timer.disp("dg computation")

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -355,9 +355,9 @@ def test_overstepping():
     np.random.seed(0)
     objective = ObjectiveFunction(DummyObjective(things=eq), use_jit=False)
     # make gradient super noisy so it stalls
-    objective.jac_scaled = lambda x, *args: objective._jac_scaled(x) + 1e2 * (
-        np.random.random((objective._dim_f, x.size)) - 0.5
-    )
+    objective.jac_scaled_error = lambda x, *args: objective._jac_scaled_error(
+        x
+    ) + 1e2 * (np.random.random((objective._dim_f, x.size)) - 0.5)
 
     n = 10
     R_modes = np.vstack(


### PR DESCRIPTION
The difference between ``compute_scaled`` and ``compute_scaled_error`` is that ``compute_scaled_error`` also subtracts the target or applies bounds. If bounds aren't used, then this is a simple affine transformation, so in theory ``jac_scaled`` and ``jac_scaled_error`` are identical in that case. However, if bounds are used than its non-trivial to map ``jac_scaled`` into ``jac_scaled_error``, so this PR adds a new method specifically for ``jac_scaled_error``. This is generally the one that should be used in 90% of cases (and is now the one that gets used in standard least squares optimization).

``jac_scaled`` is mainly used when an objective is used as a nonlinear inequality constraint, in which case we want to consider the bounds separately, rather than baked into the objective evaluation (since we need to know distance from the bounds).

Also refactors some stuff to reduce code duplication in jvp/vjp methods.

Resolves #945