### PR TITLE
Fix small comment in W7X input file

### DIFF
--- a/desc/examples/W7-X
+++ b/desc/examples/W7-X
@@ -13,7 +13,7 @@ M_grid =  16
 N_grid =   16
 
 # continuation parameters
-# none are provided, so automatic continuation will be used
+# because we specify these and a sequence for L_rad, it will not use the automatic continuation
 bdry_ratio=1.0
 pert_order = 2
 


### PR DESCRIPTION
- remove comment line in W7X input that is not true, add that having sequences for resolution will not trigger auto continuation