### PR TITLE
Update requirements and fix conda install

### DIFF
--- a/devtools/dev-requirements_conda.yml
+++ b/devtools/dev-requirements_conda.yml
@@ -15,10 +15,9 @@ dependencies:
   - pip:
     # Conda only parses a single list of pip requirements.
     # If two pip lists are given, all but the last list is skipped.
-    - interpax >= 0.3.1
+    - interpax
     - jax[cpu] >= 0.3.2, < 0.5.0
     - nvgpu
-    - orthax
     - plotly >= 5.16, < 6.0
     - pylatexenc >= 2.0, < 3.0
     # building the docs

--- a/devtools/dev-requirements_conda.yml
+++ b/devtools/dev-requirements_conda.yml
@@ -13,24 +13,27 @@ dependencies:
   - termcolor
   - pip
   - pip:
-    - interpax
+    # Conda only parses a single list of pip requirements.
+    # If two pip lists are given, all but the last list is skipped.
+    - interpax >= 0.3.1
     - jax[cpu] >= 0.3.2, < 0.5.0
     - nvgpu
+    - orthax
     - plotly >= 5.16, < 6.0
     - pylatexenc >= 2.0, < 3.0
+    # building the docs
+    - sphinx-github-style >= 1.0, < 2.0
     # testing and benchmarking
     - qsc
     - qicna @ git+https://github.com/rogeriojorge/pyQIC/
 
   # building the docs
-  - nbsphinx > 0.8.5
+  - nbsphinx == 0.8.12
   - pandoc
   - sphinx > 3.0.0
   - sphinx-argparse
   - sphinx-copybutton
   - sphinx_rtd_theme >= 1.0, < 2.0
-  - pip:
-    - sphinx-github-style >= 1.0, < 2.0
 
   # linting
   - black = 24.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,12 @@
 colorama
 h5py >= 3.0.0, < 4.0
-interpax >= 0.3.1
+interpax
 jax[cpu] >= 0.3.2, < 0.5.0
 matplotlib >= 3.5.0, < 4.0.0
 mpmath >= 1.0.0, < 2.0
 netcdf4 >= 1.5.4, < 2.0
 numpy >= 1.20.0, < 2.0.0
 nvgpu
-orthax
 plotly >= 5.16, < 6.0
 psutil
 pylatexenc >= 2.0, < 3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
 colorama
 h5py >= 3.0.0, < 4.0
-interpax
+interpax >= 0.3.1
 jax[cpu] >= 0.3.2, < 0.5.0
 matplotlib >= 3.5.0, < 4.0.0
 mpmath >= 1.0.0, < 2.0
 netcdf4 >= 1.5.4, < 2.0
 numpy >= 1.20.0, < 2.0.0
 nvgpu
+orthax
 plotly >= 5.16, < 6.0
 psutil
 pylatexenc >= 2.0, < 3.0

--- a/requirements_conda.yml
+++ b/requirements_conda.yml
@@ -14,9 +14,8 @@ dependencies:
   - pip:
     # Conda only parses a single list of pip requirements.
     # If two pip lists are given, all but the last list is skipped.
-    - interpax >= 0.3.1
+    - interpax
     - jax[cpu] >= 0.3.2, < 0.5.0
     - nvgpu
-    - orthax
     - plotly >= 5.16, < 6.0
     - pylatexenc >= 2.0, < 3.0

--- a/requirements_conda.yml
+++ b/requirements_conda.yml
@@ -2,7 +2,7 @@ name: desc-env
 dependencies:
   # standard install
   - colorama
-  - h5py >= 3.0.0
+  - h5py >= 3.0.0, < 4.0
   - matplotlib >= 3.5.0, < 4.0.0
   - mpmath >= 1.0.0, < 2.0
   - netcdf4 >= 1.5.4, < 2.0
@@ -12,8 +12,11 @@ dependencies:
   - termcolor
   - pip
   - pip:
-    - interpax
+    # Conda only parses a single list of pip requirements.
+    # If two pip lists are given, all but the last list is skipped.
+    - interpax >= 0.3.1
     - jax[cpu] >= 0.3.2, < 0.5.0
     - nvgpu
+    - orthax
     - plotly >= 5.16, < 6.0
     - pylatexenc >= 2.0, < 3.0


### PR DESCRIPTION
There's still a dependency conflict when I add `quadax` which could be useful for effective ripple stuff.