### PR TITLE
Add rotmat and shift setting to curve setup

### DIFF
--- a/desc/geometry/core.py
+++ b/desc/geometry/core.py
@@ -35,9 +35,9 @@ class Curve(IOAble, Optimizable, ABC):
         if hasattr(self, "_NFP"):
             self._NFP = int(self._NFP)
         if not hasattr(self, "_shift"):
-            self._shift = jnp.array([0, 0, 0], dtype=float)
+            self.shift
         if not hasattr(self, "_rotmat"):
-            self._rotmat = jnp.eye(3, dtype=float).flatten()
+            self.rotmat
 
     @optimizable_parameter
     @property

--- a/desc/geometry/core.py
+++ b/desc/geometry/core.py
@@ -34,6 +34,10 @@ class Curve(IOAble, Optimizable, ABC):
         """Set things after loading."""
         if hasattr(self, "_NFP"):
             self._NFP = int(self._NFP)
+        if not hasattr(self, "_shift"):
+            self._shift = jnp.array([0, 0, 0], dtype=float)
+        if not hasattr(self, "_rotmat"):
+            self._rotmat = jnp.eye(3, dtype=float).flatten()
 
     @optimizable_parameter
     @property


### PR DESCRIPTION
Right now when we load an eq whose `axis` lacks `_rotmat` or `_shift` attributes, the `_set_up` does not actually set these properties, as it only sets the default when the property is called, so if I say load and then save an equilibrium that lacks these properties, the saved equilibrium will still lack them.


This fixes the issue for curve at least, by manually calling the shift and rotmat property to trigger their setting with their default values.