### PR TITLE
Fixing typo in SplineProfile documentation.

### DIFF
--- a/desc/profiles.py
+++ b/desc/profiles.py
@@ -796,7 +796,7 @@ class SplineProfile(_Profile):
 
     Parameters
     ----------
-    params: array-like
+    values: array-like
         Values of the function at knot locations.
     knots : int or ndarray
         x locations to use for spline. If an integer, uses that many points linearly


### PR DESCRIPTION
The function takes arguments (values, knots). The documentation says to use (params, knots). Changing params to values in docstring.