### PR TITLE
Fixes for `jax>=0.4.29` and `interpax==0.3.2`

### DIFF
--- a/desc/singularities.py
+++ b/desc/singularities.py
@@ -299,9 +299,7 @@ class DFTInterpolator(_BIESTInterpolator):
             M=source_grid.M, N=source_grid.N, NFP=source_grid.NFP
         )
         A = basis.evaluate(source_grid.nodes)
-        # TODO: eventually rcond will be deprecated in favor of rtol
-        # in jax, so must change it when that happens
-        Ainv = jnp.linalg.pinv(A, rcond=None)
+        Ainv = jnp.linalg.pinv(A)
 
         B = jnp.zeros((*theta_q.shape, basis.num_modes))
 

--- a/desc/singularities.py
+++ b/desc/singularities.py
@@ -299,6 +299,8 @@ class DFTInterpolator(_BIESTInterpolator):
             M=source_grid.M, N=source_grid.N, NFP=source_grid.NFP
         )
         A = basis.evaluate(source_grid.nodes)
+        # TODO: eventually rcond will be deprecated in favor of rtol
+        # in jax, so must change it when that happens
         Ainv = jnp.linalg.pinv(A, rcond=None)
 
         B = jnp.zeros((*theta_q.shape, basis.num_modes))

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,6 @@ filterwarnings=
     ignore::DeprecationWarning:ml_dtypes.*
     # ignore benign ml_dtypes DeprecationWarning
 
-
 [flake8]
 # Primarily ignoring whitespace, indentation, and commenting etiquette that black does not catch
 # These will be fixed in a code-cleaning branch in the future

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,9 @@ filterwarnings=
     # ignore benign Cython warnings on ndarray size
     ignore::DeprecationWarning:ml_dtypes.*
     # ignore benign ml_dtypes DeprecationWarning
+    ignore:The rcond argument for linalg.pinv:DeprecationWarning
+    # ignore rcond -> rtol deprecation warning for jax>=0.4.29
+
 
 [flake8]
 # Primarily ignoring whitespace, indentation, and commenting etiquette that black does not catch

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,8 +52,6 @@ filterwarnings=
     # ignore benign Cython warnings on ndarray size
     ignore::DeprecationWarning:ml_dtypes.*
     # ignore benign ml_dtypes DeprecationWarning
-    ignore:The rcond argument for linalg.pinv:DeprecationWarning
-    # ignore rcond -> rtol deprecation warning for jax>=0.4.29
 
 
 [flake8]

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -625,7 +625,6 @@ class TestSplineXYZCurve:
             "cubic2",
             "catmull-rom",
             "monotonic",
-            "monotonic-0",
             "cardinal",
         ]:
             R = 1


### PR DESCRIPTION
There are some tests failing due to changes in newest jax version (0.4.29) and apparently also due to the latest version of `interpax` (0.3.2 )

- Remove rcond kwarg from pinv to avoid warning in jax>= 0.4.29, the default value for rtol/rcond is None anyways so no need to explicitlt call it
- don't test `monotonic-0` in the `test_length` for `SplineXYZCurve` , as the test is for a circular curve and the zero-derivative endpoints don't make sense for this case, where the curvature is constant and nonzero for the curve.