### PR TITLE
Hotfix for changes in `jax` version `0.4.30`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,8 +51,7 @@ filterwarnings=
     ignore:numpy.ndarray size changed:RuntimeWarning
     # ignore benign Cython warnings on ndarray size
     ignore::DeprecationWarning:(?!desc)
-    # ignore DeprecationWarning from interpax dependency
-
+    # ignore DeprecationWarnings from dependency packages
 
 [flake8]
 # Primarily ignoring whitespace, indentation, and commenting etiquette that black does not catch

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,9 @@ filterwarnings=
     # ignore benign Cython warnings on ndarray size
     ignore::DeprecationWarning:ml_dtypes.*
     # ignore benign ml_dtypes DeprecationWarning
+    ignore:jax.core.pp_eqn_rules:DeprecationWarning
+    # ignore DeprecationWarning from interpax dependency
+
 
 [flake8]
 # Primarily ignoring whitespace, indentation, and commenting etiquette that black does not catch

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,10 +48,11 @@ markers=
 filterwarnings=
     error
     ignore::pytest.PytestUnraisableExceptionWarning
-    ignore:numpy.ndarray size changed:RuntimeWarning
     # ignore benign Cython warnings on ndarray size
-    ignore::DeprecationWarning:(?!desc)
+    ignore:numpy.ndarray size changed:RuntimeWarning
     # ignore DeprecationWarnings from dependency packages
+    ignore::DeprecationWarning:(?!desc)
+
 
 [flake8]
 # Primarily ignoring whitespace, indentation, and commenting etiquette that black does not catch

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,9 +50,7 @@ filterwarnings=
     ignore::pytest.PytestUnraisableExceptionWarning
     ignore:numpy.ndarray size changed:RuntimeWarning
     # ignore benign Cython warnings on ndarray size
-    ignore::DeprecationWarning:ml_dtypes.*
-    # ignore benign ml_dtypes DeprecationWarning
-    ignore:jax.core.pp_eqn_rules:DeprecationWarning
+    ignore::DeprecationWarning:(?!desc)
     # ignore DeprecationWarning from interpax dependency
 
 


### PR DESCRIPTION
- add ignore for the specific deprecation warning from interpax