### PR TITLE
Fix bug where basis vectors are converted to xyz erroneously assuming input is in rpz

### DIFF
--- a/desc/compute/_basis_vectors.py
+++ b/desc/compute/_basis_vectors.py
@@ -27,13 +27,10 @@ from .utils import cross, safediv
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["B", "|B|", "phi"],
-    basis="basis",
+    data=["B", "|B|"],
 )
 def _b(params, transforms, profiles, data, **kwargs):
     data["b"] = (data["B"].T / data["|B|"]).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["b"] = rpz2xyz_vec(data["b"], phi=data["phi"])
     return data
 
 
@@ -48,15 +45,12 @@ def _b(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_theta/sqrt(g)", "e_zeta", "phi"],
-    basis="basis",
+    data=["e_theta/sqrt(g)", "e_zeta"],
 )
 def _e_sup_rho(params, transforms, profiles, data, **kwargs):
     # At the magnetic axis, this function returns the multivalued map whose
     # image is the set { 𝐞^ρ | ρ=0 }.
     data["e^rho"] = cross(data["e_theta/sqrt(g)"], data["e_zeta"])
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^rho"] = rpz2xyz_vec(data["e^rho"], phi=data["phi"])
     return data
 
 
@@ -71,9 +65,8 @@ def _e_sup_rho(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_theta", "e_zeta", "e_theta_r", "e_zeta_r", "sqrt(g)", "sqrt(g)_r", "phi"],
+    data=["e_theta", "e_zeta", "e_theta_r", "e_zeta_r", "sqrt(g)", "sqrt(g)_r"],
     axis_limit_data=["e_theta_rr", "sqrt(g)_rr"],
-    basis="basis",
 )
 def _e_sup_rho_r(params, transforms, profiles, data, **kwargs):
     a = cross(data["e_theta_r"], data["e_zeta"])
@@ -94,8 +87,6 @@ def _e_sup_rho_r(params, transforms, profiles, data, **kwargs):
             - a.T * safediv(data["sqrt(g)_rr"], (2 * data["sqrt(g)_r"] ** 2))
         ).T,
     )
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^rho_r"] = rpz2xyz_vec(data["e^rho_r"], phi=data["phi"])
     return data
 
 
@@ -121,9 +112,7 @@ def _e_sup_rho_r(params, transforms, profiles, data, **kwargs):
         "sqrt(g)",
         "sqrt(g)_r",
         "sqrt(g)_rr",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_rho_rr(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_theta"], data["e_zeta"])
@@ -148,8 +137,6 @@ def _e_sup_rho_rr(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_r"] * data["sqrt(g)_r"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^rho_rr"] = rpz2xyz_vec(data["e^rho_rr"], phi=data["phi"])
     return data
 
 
@@ -178,9 +165,7 @@ def _e_sup_rho_rr(params, transforms, profiles, data, **kwargs):
         "sqrt(g)_r",
         "sqrt(g)_rt",
         "sqrt(g)_t",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_rho_rt(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_theta"], data["e_zeta"])
@@ -207,8 +192,6 @@ def _e_sup_rho_rt(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_r"] * data["sqrt(g)_t"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^rho_rt"] = rpz2xyz_vec(data["e^rho_rt"], phi=data["phi"])
     return data
 
 
@@ -237,9 +220,7 @@ def _e_sup_rho_rt(params, transforms, profiles, data, **kwargs):
         "sqrt(g)_r",
         "sqrt(g)_rz",
         "sqrt(g)_z",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_rho_rz(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_theta"], data["e_zeta"])
@@ -266,8 +247,6 @@ def _e_sup_rho_rz(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_r"] * data["sqrt(g)_z"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^rho_rz"] = rpz2xyz_vec(data["e^rho_rz"], phi=data["phi"])
     return data
 
 
@@ -282,9 +261,8 @@ def _e_sup_rho_rz(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_theta", "e_zeta", "e_theta_t", "e_zeta_t", "sqrt(g)", "sqrt(g)_t", "phi"],
+    data=["e_theta", "e_zeta", "e_theta_t", "e_zeta_t", "sqrt(g)", "sqrt(g)_t"],
     axis_limit_data=["e_theta_r", "e_theta_rt", "sqrt(g)_r", "sqrt(g)_rt"],
-    basis="basis",
 )
 def _e_sup_rho_t(params, transforms, profiles, data, **kwargs):
     data["e^rho_t"] = transforms["grid"].replace_at_axis(
@@ -309,8 +287,6 @@ def _e_sup_rho_t(params, transforms, profiles, data, **kwargs):
             )
         ).T,
     )
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^rho_t"] = rpz2xyz_vec(data["e^rho_t"], phi=data["phi"])
     return data
 
 
@@ -336,9 +312,7 @@ def _e_sup_rho_t(params, transforms, profiles, data, **kwargs):
         "sqrt(g)",
         "sqrt(g)_t",
         "sqrt(g)_tt",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_rho_tt(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_theta"], data["e_zeta"])
@@ -363,8 +337,6 @@ def _e_sup_rho_tt(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_t"] * data["sqrt(g)_t"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^rho_tt"] = rpz2xyz_vec(data["e^rho_tt"], phi=data["phi"])
     return data
 
 
@@ -393,9 +365,7 @@ def _e_sup_rho_tt(params, transforms, profiles, data, **kwargs):
         "sqrt(g)_t",
         "sqrt(g)_tz",
         "sqrt(g)_z",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_rho_tz(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_theta"], data["e_zeta"])
@@ -422,8 +392,6 @@ def _e_sup_rho_tz(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_t"] * data["sqrt(g)_z"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^rho_tz"] = rpz2xyz_vec(data["e^rho_tz"], phi=data["phi"])
     return data
 
 
@@ -438,9 +406,8 @@ def _e_sup_rho_tz(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_theta", "e_zeta", "e_theta_z", "e_zeta_z", "sqrt(g)", "sqrt(g)_z", "phi"],
+    data=["e_theta", "e_zeta", "e_theta_z", "e_zeta_z", "sqrt(g)", "sqrt(g)_z"],
     axis_limit_data=["e_theta_r", "e_theta_rz", "sqrt(g)_r", "sqrt(g)_rz"],
-    basis="basis",
 )
 def _e_sup_rho_z(params, transforms, profiles, data, **kwargs):
     data["e^rho_z"] = transforms["grid"].replace_at_axis(
@@ -467,8 +434,6 @@ def _e_sup_rho_z(params, transforms, profiles, data, **kwargs):
             * safediv(data["sqrt(g)_rz"], data["sqrt(g)_r"] ** 2)
         ).T,
     )
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^rho_z"] = rpz2xyz_vec(data["e^rho_z"], phi=data["phi"])
     return data
 
 
@@ -494,9 +459,7 @@ def _e_sup_rho_z(params, transforms, profiles, data, **kwargs):
         "sqrt(g)",
         "sqrt(g)_z",
         "sqrt(g)_zz",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_rho_zz(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_theta"], data["e_zeta"])
@@ -521,8 +484,6 @@ def _e_sup_rho_zz(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_z"] * data["sqrt(g)_z"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^rho_zz"] = rpz2xyz_vec(data["e^rho_zz"], phi=data["phi"])
     return data
 
 
@@ -537,13 +498,10 @@ def _e_sup_rho_zz(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e^theta*sqrt(g)", "sqrt(g)", "phi"],
-    basis="basis",
+    data=["e^theta*sqrt(g)", "sqrt(g)"],
 )
 def _e_sup_theta(params, transforms, profiles, data, **kwargs):
     data["e^theta"] = (data["e^theta*sqrt(g)"].T / data["sqrt(g)"]).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^theta"] = rpz2xyz_vec(data["e^theta"], phi=data["phi"])
     return data
 
 
@@ -558,19 +516,16 @@ def _e_sup_theta(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_rho", "e_zeta", "phi"],
+    data=["e_rho", "e_zeta"],
     parameterization=[
         "desc.equilibrium.equilibrium.Equilibrium",
         "desc.geometry.core.Surface",
     ],
-    basis="basis",
 )
 def _e_sup_theta_times_sqrt_g(params, transforms, profiles, data, **kwargs):
     # At the magnetic axis, this function returns the multivalued map whose
     # image is the set { 𝐞^θ √g | ρ=0 }.
     data["e^theta*sqrt(g)"] = cross(data["e_zeta"], data["e_rho"])
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^theta*sqrt(g)"] = rpz2xyz_vec(data["e^theta*sqrt(g)"], phi=data["phi"])
     return data
 
 
@@ -585,8 +540,7 @@ def _e_sup_theta_times_sqrt_g(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_zeta", "e_rho", "e_zeta_r", "e_rho_r", "sqrt(g)", "sqrt(g)_r", "phi"],
-    basis="basis",
+    data=["e_zeta", "e_rho", "e_zeta_r", "e_rho_r", "sqrt(g)", "sqrt(g)_r"],
 )
 def _e_sup_theta_r(params, transforms, profiles, data, **kwargs):
     data["e^theta_r"] = (
@@ -599,8 +553,6 @@ def _e_sup_theta_r(params, transforms, profiles, data, **kwargs):
         * data["sqrt(g)_r"]
         / data["sqrt(g)"] ** 2
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^theta_r"] = rpz2xyz_vec(data["e^theta_r"], phi=data["phi"])
     return data
 
 
@@ -626,9 +578,7 @@ def _e_sup_theta_r(params, transforms, profiles, data, **kwargs):
         "sqrt(g)",
         "sqrt(g)_r",
         "sqrt(g)_rr",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_theta_rr(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_zeta"], data["e_rho"])
@@ -653,9 +603,6 @@ def _e_sup_theta_rr(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_r"] * data["sqrt(g)_r"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^theta_rr"] = rpz2xyz_vec(data["e^theta_rr"], phi=data["phi"])
-
     return data
 
 
@@ -684,9 +631,7 @@ def _e_sup_theta_rr(params, transforms, profiles, data, **kwargs):
         "sqrt(g)_r",
         "sqrt(g)_rt",
         "sqrt(g)_t",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_theta_rt(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_zeta"], data["e_rho"])
@@ -713,8 +658,6 @@ def _e_sup_theta_rt(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_r"] * data["sqrt(g)_t"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^theta_rt"] = rpz2xyz_vec(data["e^theta_rt"], phi=data["phi"])
     return data
 
 
@@ -743,9 +686,7 @@ def _e_sup_theta_rt(params, transforms, profiles, data, **kwargs):
         "sqrt(g)_r",
         "sqrt(g)_rz",
         "sqrt(g)_z",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_theta_rz(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_zeta"], data["e_rho"])
@@ -772,8 +713,6 @@ def _e_sup_theta_rz(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_r"] * data["sqrt(g)_z"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^theta_rz"] = rpz2xyz_vec(data["e^theta_rz"], phi=data["phi"])
     return data
 
 
@@ -789,8 +728,7 @@ def _e_sup_theta_rz(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_zeta", "e_rho", "e_zeta_t", "e_rho_t", "sqrt(g)", "sqrt(g)_t", "phi"],
-    basis="basis",
+    data=["e_zeta", "e_rho", "e_zeta_t", "e_rho_t", "sqrt(g)", "sqrt(g)_t"],
 )
 def _e_sup_theta_t(params, transforms, profiles, data, **kwargs):
     data["e^theta_t"] = (
@@ -803,8 +741,6 @@ def _e_sup_theta_t(params, transforms, profiles, data, **kwargs):
         * data["sqrt(g)_t"]
         / data["sqrt(g)"] ** 2
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^theta_t"] = rpz2xyz_vec(data["e^theta_t"], phi=data["phi"])
     return data
 
 
@@ -830,9 +766,7 @@ def _e_sup_theta_t(params, transforms, profiles, data, **kwargs):
         "sqrt(g)",
         "sqrt(g)_t",
         "sqrt(g)_tt",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_theta_tt(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_zeta"], data["e_rho"])
@@ -857,8 +791,6 @@ def _e_sup_theta_tt(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_t"] * data["sqrt(g)_t"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^theta_tt"] = rpz2xyz_vec(data["e^theta_tt"], phi=data["phi"])
     return data
 
 
@@ -887,9 +819,7 @@ def _e_sup_theta_tt(params, transforms, profiles, data, **kwargs):
         "sqrt(g)_t",
         "sqrt(g)_tz",
         "sqrt(g)_z",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_theta_tz(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_zeta"], data["e_rho"])
@@ -916,8 +846,6 @@ def _e_sup_theta_tz(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_t"] * data["sqrt(g)_z"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^theta_tz"] = rpz2xyz_vec(data["e^theta_tz"], phi=data["phi"])
     return data
 
 
@@ -933,8 +861,7 @@ def _e_sup_theta_tz(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_zeta", "e_rho", "e_zeta_z", "e_rho_z", "sqrt(g)", "sqrt(g)_z", "phi"],
-    basis="basis",
+    data=["e_zeta", "e_rho", "e_zeta_z", "e_rho_z", "sqrt(g)", "sqrt(g)_z"],
 )
 def _e_sup_theta_z(params, transforms, profiles, data, **kwargs):
     data["e^theta_z"] = (
@@ -947,8 +874,6 @@ def _e_sup_theta_z(params, transforms, profiles, data, **kwargs):
         * data["sqrt(g)_z"]
         / data["sqrt(g)"] ** 2
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^theta_z"] = rpz2xyz_vec(data["e^theta_z"], phi=data["phi"])
     return data
 
 
@@ -974,9 +899,7 @@ def _e_sup_theta_z(params, transforms, profiles, data, **kwargs):
         "sqrt(g)",
         "sqrt(g)_z",
         "sqrt(g)_zz",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_theta_zz(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_zeta"], data["e_rho"])
@@ -1001,8 +924,6 @@ def _e_sup_theta_zz(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_z"] * data["sqrt(g)_z"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^theta_zz"] = rpz2xyz_vec(data["e^theta_zz"], phi=data["phi"])
     return data
 
 
@@ -1017,15 +938,12 @@ def _e_sup_theta_zz(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_rho", "e_theta/sqrt(g)", "phi"],
-    basis="basis",
+    data=["e_rho", "e_theta/sqrt(g)"],
 )
 def _e_sup_zeta(params, transforms, profiles, data, **kwargs):
     # At the magnetic axis, this function returns the multivalued map whose
     # image is the set { 𝐞^ζ | ρ=0 }.
     data["e^zeta"] = cross(data["e_rho"], data["e_theta/sqrt(g)"])
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^zeta"] = rpz2xyz_vec(data["e^zeta"], phi=data["phi"])
     return data
 
 
@@ -1040,9 +958,8 @@ def _e_sup_zeta(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_rho", "e_rho_r", "e_theta", "e_theta_r", "sqrt(g)", "sqrt(g)_r", "phi"],
+    data=["e_rho", "e_rho_r", "e_theta", "e_theta_r", "sqrt(g)", "sqrt(g)_r"],
     axis_limit_data=["e_theta_rr", "sqrt(g)_rr"],
-    basis="basis",
 )
 def _e_sup_zeta_r(params, transforms, profiles, data, **kwargs):
     b = cross(data["e_rho"], data["e_theta_r"])
@@ -1063,8 +980,6 @@ def _e_sup_zeta_r(params, transforms, profiles, data, **kwargs):
             - b.T * safediv(data["sqrt(g)_rr"], (2 * data["sqrt(g)_r"] ** 2))
         ).T,
     )
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^zeta_r"] = rpz2xyz_vec(data["e^zeta_r"], phi=data["phi"])
     return data
 
 
@@ -1090,9 +1005,7 @@ def _e_sup_zeta_r(params, transforms, profiles, data, **kwargs):
         "sqrt(g)",
         "sqrt(g)_r",
         "sqrt(g)_rr",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_zeta_rr(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_rho"], data["e_theta"])
@@ -1117,8 +1030,6 @@ def _e_sup_zeta_rr(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_r"] * data["sqrt(g)_r"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^zeta_rr"] = rpz2xyz_vec(data["e^zeta_rr"], phi=data["phi"])
     return data
 
 
@@ -1147,9 +1058,7 @@ def _e_sup_zeta_rr(params, transforms, profiles, data, **kwargs):
         "sqrt(g)_r",
         "sqrt(g)_rt",
         "sqrt(g)_t",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_zeta_rt(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_rho"], data["e_theta"])
@@ -1176,8 +1085,6 @@ def _e_sup_zeta_rt(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_r"] * data["sqrt(g)_t"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^zeta_rt"] = rpz2xyz_vec(data["e^zeta_rt"], phi=data["phi"])
     return data
 
 
@@ -1206,9 +1113,7 @@ def _e_sup_zeta_rt(params, transforms, profiles, data, **kwargs):
         "sqrt(g)_r",
         "sqrt(g)_rz",
         "sqrt(g)_z",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_zeta_rz(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_rho"], data["e_theta"])
@@ -1235,8 +1140,6 @@ def _e_sup_zeta_rz(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_r"] * data["sqrt(g)_z"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^zeta_rz"] = rpz2xyz_vec(data["e^zeta_rz"], phi=data["phi"])
     return data
 
 
@@ -1252,9 +1155,8 @@ def _e_sup_zeta_rz(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_rho", "e_rho_t", "e_theta", "e_theta_t", "sqrt(g)", "sqrt(g)_t", "phi"],
+    data=["e_rho", "e_rho_t", "e_theta", "e_theta_t", "sqrt(g)", "sqrt(g)_t"],
     axis_limit_data=["e_theta_r", "e_theta_rt", "sqrt(g)_r", "sqrt(g)_rt"],
-    basis="basis",
 )
 def _e_sup_zeta_t(params, transforms, profiles, data, **kwargs):
     data["e^zeta_t"] = transforms["grid"].replace_at_axis(
@@ -1281,8 +1183,6 @@ def _e_sup_zeta_t(params, transforms, profiles, data, **kwargs):
             * safediv(data["sqrt(g)_rt"], data["sqrt(g)_r"] ** 2)
         ).T,
     )
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^zeta_t"] = rpz2xyz_vec(data["e^zeta_t"], phi=data["phi"])
     return data
 
 
@@ -1308,9 +1208,7 @@ def _e_sup_zeta_t(params, transforms, profiles, data, **kwargs):
         "sqrt(g)",
         "sqrt(g)_t",
         "sqrt(g)_tt",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_zeta_tt(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_rho"], data["e_theta"])
@@ -1335,8 +1233,6 @@ def _e_sup_zeta_tt(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_t"] * data["sqrt(g)_t"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^zeta_tt"] = rpz2xyz_vec(data["e^zeta_tt"], phi=data["phi"])
     return data
 
 
@@ -1365,9 +1261,7 @@ def _e_sup_zeta_tt(params, transforms, profiles, data, **kwargs):
         "sqrt(g)_t",
         "sqrt(g)_tz",
         "sqrt(g)_z",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_zeta_tz(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_rho"], data["e_theta"])
@@ -1394,8 +1288,6 @@ def _e_sup_zeta_tz(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_t"] * data["sqrt(g)_z"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^zeta_tz"] = rpz2xyz_vec(data["e^zeta_tz"], phi=data["phi"])
     return data
 
 
@@ -1411,9 +1303,8 @@ def _e_sup_zeta_tz(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_rho", "e_rho_z", "e_theta", "e_theta_z", "sqrt(g)", "sqrt(g)_z", "phi"],
+    data=["e_rho", "e_rho_z", "e_theta", "e_theta_z", "sqrt(g)", "sqrt(g)_z"],
     axis_limit_data=["e_theta_r", "e_theta_rz", "sqrt(g)_r", "sqrt(g)_rz"],
-    basis="basis",
 )
 def _e_sup_zeta_z(params, transforms, profiles, data, **kwargs):
     data["e^zeta_z"] = transforms["grid"].replace_at_axis(
@@ -1440,8 +1331,6 @@ def _e_sup_zeta_z(params, transforms, profiles, data, **kwargs):
             * safediv(data["sqrt(g)_rz"], data["sqrt(g)_r"] ** 2)
         ).T,
     )
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^zeta_z"] = rpz2xyz_vec(data["e^zeta_z"], phi=data["phi"])
     return data
 
 
@@ -1467,9 +1356,7 @@ def _e_sup_zeta_z(params, transforms, profiles, data, **kwargs):
         "sqrt(g)",
         "sqrt(g)_z",
         "sqrt(g)_zz",
-        "phi",
     ],
-    basis="basis",
 )
 def _e_sup_zeta_zz(params, transforms, profiles, data, **kwargs):
     temp = cross(data["e_rho"], data["e_theta"])
@@ -1494,8 +1381,6 @@ def _e_sup_zeta_zz(params, transforms, profiles, data, **kwargs):
         / data["sqrt(g)"] ** 2
         + 2 * temp.T * data["sqrt(g)_z"] * data["sqrt(g)_z"] / data["sqrt(g)"] ** 3
     ).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e^zeta_zz"] = rpz2xyz_vec(data["e^zeta_zz"], phi=data["phi"])
     return data
 
 
@@ -1510,19 +1395,15 @@ def _e_sup_zeta_zz(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_zeta", "phi_z", "phi"],
+    data=["e_zeta", "phi_z"],
     parameterization=[
         "desc.equilibrium.equilibrium.Equilibrium",
         "desc.geometry.surface.FourierRZToroidalSurface",
     ],
-    basis="basis",
 )
 def _e_sub_phi(params, transforms, profiles, data, **kwargs):
     # dX/dphi at const r,t = dX/dz * dz/dphi = dX/dz / (dphi/dz)
     data["e_phi"] = (data["e_zeta"].T / data["phi_z"]).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e_phi"] = rpz2xyz_vec(data["e_phi"], phi=data["phi"])
-    return data
 
 
 @register_compute_fun(
@@ -2580,9 +2461,8 @@ def _e_sub_theta(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_theta", "sqrt(g)", "phi"],
+    data=["e_theta", "sqrt(g)"],
     axis_limit_data=["e_theta_r", "sqrt(g)_r"],
-    basis="basis",
 )
 def _e_sub_theta_over_sqrt_g(params, transforms, profiles, data, **kwargs):
     # At the magnetic axis, this function returns the multivalued map whose
@@ -2591,8 +2471,6 @@ def _e_sub_theta_over_sqrt_g(params, transforms, profiles, data, **kwargs):
         safediv(data["e_theta"].T, data["sqrt(g)"]).T,
         lambda: safediv(data["e_theta_r"].T, data["sqrt(g)_r"]).T,
     )
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e_theta/sqrt(g)"] = rpz2xyz_vec(data["e_theta/sqrt(g)"], phi=data["phi"])
     return data
 
 

--- a/desc/compute/_basis_vectors.py
+++ b/desc/compute/_basis_vectors.py
@@ -1404,6 +1404,7 @@ def _e_sup_zeta_zz(params, transforms, profiles, data, **kwargs):
 def _e_sub_phi(params, transforms, profiles, data, **kwargs):
     # dX/dphi at const r,t = dX/dz * dz/dphi = dX/dz / (dphi/dz)
     data["e_phi"] = (data["e_zeta"].T / data["phi_z"]).T
+    return data
 
 
 @register_compute_fun(
@@ -2485,14 +2486,11 @@ def _e_sub_theta_over_sqrt_g(params, transforms, profiles, data, **kwargs):
     transforms={},
     profiles=[],
     coordinates="rtz",
-    data=["e_theta", "theta_PEST_t", "phi"],
-    basis="basis",
+    data=["e_theta", "theta_PEST_t"],
 )
 def _e_sub_theta_pest(params, transforms, profiles, data, **kwargs):
     # dX/dv at const r,z = dX/dt * dt/dv / dX/dt / dv/dt
     data["e_theta_PEST"] = (data["e_theta"].T / data["theta_PEST_t"]).T
-    if kwargs.get("basis", "rpz").lower() == "xyz":
-        data["e_theta_PEST"] = rpz2xyz_vec(data["e_theta_PEST"], phi=data["phi"])
     return data
 
 

--- a/desc/compute/_curve.py
+++ b/desc/compute/_curve.py
@@ -2,6 +2,7 @@ from interpax import interp1d
 
 from desc.backend import jnp
 
+from ..utils import errorif
 from .data_index import register_compute_fun
 from .geom_utils import rotation_matrix, rpz2xyz, rpz2xyz_vec, xyz2rpz, xyz2rpz_vec
 from .utils import cross, dot, safenormalize
@@ -156,6 +157,7 @@ def _phi_Curve(params, transforms, profiles, data, **kwargs):
     parameterization="desc.geometry.core.Curve",
 )
 def _Z_Curve(params, transforms, profiles, data, **kwargs):
+    errorif(kwargs.get("basis", "rpz").lower()[-1] != "z", NotImplementedError)
     data["Z"] = data["x"][:, 2]
     return data
 

--- a/desc/compute/_curve.py
+++ b/desc/compute/_curve.py
@@ -157,7 +157,9 @@ def _phi_Curve(params, transforms, profiles, data, **kwargs):
     parameterization="desc.geometry.core.Curve",
 )
 def _Z_Curve(params, transforms, profiles, data, **kwargs):
-    errorif(kwargs.get("basis", "rpz").lower()[-1] != "z", NotImplementedError)
+    errorif(
+        kwargs.get("basis", "rpz").lower() not in {"rpz", "xyz"}, NotImplementedError
+    )
     data["Z"] = data["x"][:, 2]
     return data
 

--- a/desc/compute/_equil.py
+++ b/desc/compute/_equil.py
@@ -270,7 +270,9 @@ def _J_phi(params, transforms, profiles, data, **kwargs):
     data=["J"],
 )
 def _J_Z(params, transforms, profiles, data, **kwargs):
-    errorif(kwargs.get("basis", "rpz").lower()[-1] != "z", NotImplementedError)
+    errorif(
+        kwargs.get("basis", "rpz").lower() not in {"rpz", "xyz"}, NotImplementedError
+    )
     data["J_Z"] = data["J"][:, 2]
     return data
 

--- a/desc/compute/_equil.py
+++ b/desc/compute/_equil.py
@@ -13,6 +13,7 @@ from scipy.constants import mu_0
 
 from desc.backend import jnp
 
+from ..utils import errorif
 from .data_index import register_compute_fun
 from .utils import cross, dot, safediv, safenorm, surface_averages
 
@@ -231,6 +232,7 @@ def _J_sqrt_g_r(params, transforms, profiles, data, **kwargs):
     data=["J"],
 )
 def _J_R(params, transforms, profiles, data, **kwargs):
+    errorif(kwargs.get("basis", "rpz").lower() != "rpz", NotImplementedError)
     data["J_R"] = data["J"][:, 0]
     return data
 
@@ -249,6 +251,7 @@ def _J_R(params, transforms, profiles, data, **kwargs):
     data=["J"],
 )
 def _J_phi(params, transforms, profiles, data, **kwargs):
+    errorif(kwargs.get("basis", "rpz").lower() != "rpz", NotImplementedError)
     data["J_phi"] = data["J"][:, 1]
     return data
 
@@ -267,6 +270,7 @@ def _J_phi(params, transforms, profiles, data, **kwargs):
     data=["J"],
 )
 def _J_Z(params, transforms, profiles, data, **kwargs):
+    errorif(kwargs.get("basis", "rpz").lower()[-1] != "z", NotImplementedError)
     data["J_Z"] = data["J"][:, 2]
     return data
 
@@ -677,6 +681,7 @@ def _W_B(params, transforms, profiles, data, **kwargs):
     data=["B", "sqrt(g)"],
 )
 def _W_Bpol(params, transforms, profiles, data, **kwargs):
+    errorif(kwargs.get("basis", "rpz").lower() != "rpz", NotImplementedError)
     data["W_Bpol"] = jnp.sum(
         dot(data["B"][:, (0, 2)], data["B"][:, (0, 2)])
         * data["sqrt(g)"]
@@ -699,6 +704,7 @@ def _W_Bpol(params, transforms, profiles, data, **kwargs):
     data=["B", "sqrt(g)"],
 )
 def _W_Btor(params, transforms, profiles, data, **kwargs):
+    errorif(kwargs.get("basis", "rpz").lower() != "rpz", NotImplementedError)
     data["W_Btor"] = jnp.sum(
         data["B"][:, 1] ** 2 * data["sqrt(g)"] * transforms["grid"].weights
     ) / (2 * mu_0)

--- a/desc/compute/_field.py
+++ b/desc/compute/_field.py
@@ -13,6 +13,7 @@ from scipy.constants import mu_0
 
 from desc.backend import jnp
 
+from ..utils import errorif
 from .data_index import register_compute_fun
 from .utils import (
     cross,
@@ -140,6 +141,7 @@ def _B(params, transforms, profiles, data, **kwargs):
     data=["B"],
 )
 def _B_R(params, transforms, profiles, data, **kwargs):
+    errorif(kwargs.get("basis", "rpz").lower() != "rpz", NotImplementedError)
     data["B_R"] = data["B"][:, 0]
     return data
 
@@ -158,6 +160,7 @@ def _B_R(params, transforms, profiles, data, **kwargs):
     data=["B"],
 )
 def _B_phi(params, transforms, profiles, data, **kwargs):
+    errorif(kwargs.get("basis", "rpz").lower() != "rpz", NotImplementedError)
     data["B_phi"] = data["B"][:, 1]
     return data
 
@@ -176,6 +179,7 @@ def _B_phi(params, transforms, profiles, data, **kwargs):
     data=["B"],
 )
 def _B_Z(params, transforms, profiles, data, **kwargs):
+    errorif(kwargs.get("basis", "rpz").lower()[-1] != "z", NotImplementedError)
     data["B_Z"] = data["B"][:, 2]
     return data
 

--- a/desc/compute/_field.py
+++ b/desc/compute/_field.py
@@ -179,7 +179,9 @@ def _B_phi(params, transforms, profiles, data, **kwargs):
     data=["B"],
 )
 def _B_Z(params, transforms, profiles, data, **kwargs):
-    errorif(kwargs.get("basis", "rpz").lower()[-1] != "z", NotImplementedError)
+    errorif(
+        kwargs.get("basis", "rpz").lower() not in {"rpz", "xyz"}, NotImplementedError
+    )
     data["B_Z"] = data["B"][:, 2]
     return data
 

--- a/desc/compute/_geometry.py
+++ b/desc/compute/_geometry.py
@@ -11,6 +11,7 @@ expensive computations.
 
 from desc.backend import jnp
 
+from ..utils import errorif
 from .data_index import register_compute_fun
 from .utils import cross, dot, line_integrals, surface_integrals
 
@@ -48,6 +49,7 @@ def _V(params, transforms, profiles, data, **kwargs):
     parameterization="desc.geometry.surface.FourierRZToroidalSurface",
 )
 def _V_FourierRZToroidalSurface(params, transforms, profiles, data, **kwargs):
+    errorif(kwargs.get("basis", "rpz").lower()[-1] != "z", NotImplementedError)
     # divergence theorem: integral(dV div [0, 0, Z]) = integral(dS dot [0, 0, Z])
     data["V"] = jnp.max(  # take max in case there are multiple surfaces for some reason
         jnp.abs(
@@ -75,6 +77,7 @@ def _V_FourierRZToroidalSurface(params, transforms, profiles, data, **kwargs):
     data=["e_theta", "e_zeta", "Z"],
 )
 def _V_of_r(params, transforms, profiles, data, **kwargs):
+    errorif(kwargs.get("basis", "rpz").lower()[-1] != "z", NotImplementedError)
     # divergence theorem: integral(dV div [0, 0, Z]) = integral(dS dot [0, 0, Z])
     data["V(r)"] = jnp.abs(
         surface_integrals(
@@ -186,6 +189,7 @@ def _A_of_z(params, transforms, profiles, data, **kwargs):
     parameterization=["desc.geometry.surface.FourierRZToroidalSurface"],
 )
 def _A_of_z_FourierRZToroidalSurface(params, transforms, profiles, data, **kwargs):
+    errorif(kwargs.get("basis", "rpz").lower() != "rpz", NotImplementedError)
     # divergence theorem: integral(dA div [0, 0, Z]) = integral(ds n dot [0, 0, Z])
     # but we need only the part of n in the R,Z plane
     n = data["n_rho"]

--- a/desc/compute/_geometry.py
+++ b/desc/compute/_geometry.py
@@ -49,7 +49,9 @@ def _V(params, transforms, profiles, data, **kwargs):
     parameterization="desc.geometry.surface.FourierRZToroidalSurface",
 )
 def _V_FourierRZToroidalSurface(params, transforms, profiles, data, **kwargs):
-    errorif(kwargs.get("basis", "rpz").lower()[-1] != "z", NotImplementedError)
+    errorif(
+        kwargs.get("basis", "rpz").lower() not in {"rpz", "xyz"}, NotImplementedError
+    )
     # divergence theorem: integral(dV div [0, 0, Z]) = integral(dS dot [0, 0, Z])
     data["V"] = jnp.max(  # take max in case there are multiple surfaces for some reason
         jnp.abs(
@@ -77,7 +79,9 @@ def _V_FourierRZToroidalSurface(params, transforms, profiles, data, **kwargs):
     data=["e_theta", "e_zeta", "Z"],
 )
 def _V_of_r(params, transforms, profiles, data, **kwargs):
-    errorif(kwargs.get("basis", "rpz").lower()[-1] != "z", NotImplementedError)
+    errorif(
+        kwargs.get("basis", "rpz").lower() not in {"rpz", "xyz"}, NotImplementedError
+    )
     # divergence theorem: integral(dV div [0, 0, Z]) = integral(dS dot [0, 0, Z])
     data["V(r)"] = jnp.abs(
         surface_integrals(

--- a/desc/compute/_surface.py
+++ b/desc/compute/_surface.py
@@ -1,7 +1,10 @@
 from desc.backend import jnp
 
+from ..utils import errorif
 from .data_index import register_compute_fun
 from .geom_utils import rpz2xyz, xyz2rpz, xyz2rpz_vec
+
+# TODO: review when zeta no longer equals phi
 
 
 @register_compute_fun(
@@ -26,6 +29,7 @@ from .geom_utils import rpz2xyz, xyz2rpz, xyz2rpz_vec
 def _x_FourierRZToroidalSurface(params, transforms, profiles, data, **kwargs):
     R = transforms["R"].transform(params["R_lmn"])
     Z = transforms["Z"].transform(params["Z_lmn"])
+    # TODO: change when zeta no longer equals phi
     phi = transforms["grid"].nodes[:, 2]
     coords = jnp.stack([R, phi, Z], axis=1)
     if kwargs.get("basis", "rpz").lower() == "xyz":
@@ -217,6 +221,7 @@ def _phi_z_Surface(params, transforms, profiles, data, **kwargs):
     parameterization="desc.geometry.core.Surface",
 )
 def _Z_Surface(params, transforms, profiles, data, **kwargs):
+    errorif(kwargs.get("basis", "rpz").lower()[-1] != "z", NotImplementedError)
     data["Z"] = data["x"][:, 2]
     return data
 

--- a/desc/compute/_surface.py
+++ b/desc/compute/_surface.py
@@ -221,7 +221,9 @@ def _phi_z_Surface(params, transforms, profiles, data, **kwargs):
     parameterization="desc.geometry.core.Surface",
 )
 def _Z_Surface(params, transforms, profiles, data, **kwargs):
-    errorif(kwargs.get("basis", "rpz").lower()[-1] != "z", NotImplementedError)
+    errorif(
+        kwargs.get("basis", "rpz").lower() not in {"rpz", "xyz"}, NotImplementedError
+    )
     data["Z"] = data["x"][:, 2]
     return data
 

--- a/tests/test_compute_funs.py
+++ b/tests/test_compute_funs.py
@@ -1683,3 +1683,17 @@ def test_surface_equilibrium_geometry():
                 rtol=3e-13,
                 atol=1e-13,
             )
+
+
+@pytest.mark.unit
+def test_basis_kwarg():
+    """Test that we don't change basis to xyz erroneously assuming input is in rpz."""
+    eq = get("W7-X")
+    names = ["b", "e^rho", "e_theta_PEST", "phi"]
+    data_rpz = eq.compute(names)
+    data_xyz = eq.compute(names, basis="xyz")
+    for name in names:
+        if name != "phi":
+            np.testing.assert_allclose(
+                rpz2xyz_vec(data_rpz[name], phi=data_rpz["phi"]), data_xyz[name]
+            )

--- a/tests/test_compute_funs.py
+++ b/tests/test_compute_funs.py
@@ -1690,7 +1690,7 @@ def test_basis_kwarg():
     """Test that we don't change basis to xyz erroneously assuming input is in rpz."""
     eq = get("W7-X")
     names = ["b", "e^rho", "e_theta_PEST", "phi"]
-    data_rpz = eq.compute(names)
+    data_rpz = eq.compute(names, basis="rpz")
     data_xyz = eq.compute(names, basis="xyz")
     for name in names:
         if name != "phi":


### PR DESCRIPTION
Resolves #1088 .

We only want to do a basis conversion on quantities that directly compute a vector's contravariant components in the cylindrical coordinate system. Otherwise we'll be converting basis vectors from cylindrical to Cartesian multiple times because the dependencies are already in cartesian. The issue is that after the first conversion, we're in cartesian coordinates, yet the following conversions still assume the input is in polar basis.