### PR TITLE
Allow MixedCoilSet.from_symmetry to work when the given coils are not CoilSet-compatible

### DIFF
--- a/desc/coils.py
+++ b/desc/coils.py
@@ -1153,9 +1153,15 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
 
         """
         if not isinstance(coils, CoilSet):
-            coils = CoilSet(coils)
-
-        [_check_type(coil, coils[0]) for coil in coils]
+            try:
+                coils = CoilSet(coils)
+            except (TypeError, ValueError):
+                # likely there are multiple coil types,
+                # so make a MixedCoilSet
+                coils = MixedCoilSet(coils)
+        if not isinstance(coils, MixedCoilSet):
+            # only need to check this for a CoilSet, not MixedCoilSet
+            [_check_type(coil, coils[0]) for coil in coils]
 
         # check toroidal extent of coils to be repeated
         maxphi = 2 * np.pi / NFP / (sym + 1)

--- a/tests/test_coils.py
+++ b/tests/test_coils.py
@@ -294,6 +294,19 @@ class TestCoilSet:
         )[0]
         np.testing.assert_allclose(B_true, B_approx, rtol=1e-3, atol=1e-10)
 
+        # With a MixedCoilSet as the base coils and only rotation
+        coil = FourierPlanarCoil(I)
+        coils = [coil] + [FourierXYZCoil(I) for i in range(N // 4 - 1)]
+        for i, c in enumerate(coils[1:]):
+            c.rotate(angle=2 * np.pi / N * (i + 1))
+        coils = MixedCoilSet.from_symmetry(coils, NFP=4)
+        grid = LinearGrid(N=32, endpoint=False)
+        transforms = get_transforms(["x", "x_s", "ds"], coil, grid=grid)
+        B_approx = coils.compute_magnetic_field(
+            [10, 0, 0], basis="rpz", source_grid=grid
+        )[0]
+        np.testing.assert_allclose(B_true, B_approx, rtol=1e-3, atol=1e-10)
+
     @pytest.mark.unit
     def test_properties(self):
         """Test getting/setting of CoilSet attributes."""


### PR DESCRIPTION
- Fixes bug that can occur when trying to call `MixedCoilSet.from_symmetry()` with a group of coils which are not `CoilSet` compatible (that is, they are not all the same type, or they are the same type but have differing parameterizations like different number of spline points or different Fourier resolutions)
  - `MixedCoilSet.from_symmetry` should work in these cases, as it is just doing rotation and reflection operations, it is perfectly valid for a diverse set of unique coils.