### PR TITLE
add knots to attrs

### DIFF
--- a/desc/coils.py
+++ b/desc/coils.py
@@ -769,7 +769,7 @@ def _check_type(coil0, coil):
         FourierRZCoil: ["R_basis", "Z_basis", "NFP", "sym"],
         FourierXYZCoil: ["X_basis", "Y_basis", "Z_basis"],
         FourierPlanarCoil: ["r_basis"],
-        SplineXYZCoil: ["method", "N"],
+        SplineXYZCoil: ["method", "N", "knots"],
     }
 
     for attr in attrs[coil0.__class__]:
@@ -780,7 +780,8 @@ def _check_type(coil0, coil):
             ValueError,
             (
                 "coils in a CoilSet must have the same parameterization, got a "
-                + f"mismatch between attr {attr}, with values {a0} and {a1}"
+                + f"mismatch between attr {attr}, with values {a0} and {a1}."
+                + " Consider using a MixedCoilSet"
             ),
         )
 


### PR DESCRIPTION
Resolves #1136 

Adds `knots` to `attrs` in `_check_type` such that there is an error if the knots are different between different coils. This way, the user has to use a `MixedCoilSet`