### PR TITLE
bug fix for `CoilCurrentLength`

### DIFF
--- a/desc/objectives/_coils.py
+++ b/desc/objectives/_coils.py
@@ -695,8 +695,8 @@ class CoilCurrentLength(CoilLength):
         """
         lengths = super().compute(params, constants=constants)
         params = tree_leaves(params, is_leaf=lambda x: isinstance(x, dict))
-        currents = [param["current"] for param in params]
-        out = jnp.asarray(lengths) * jnp.asarray(currents)
+        currents = jnp.concatenate([param["current"] for param in params])
+        out = jnp.atleast_1d(lengths * currents)
         return out
 
 

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -803,7 +803,7 @@ class TestObjectiveFunction:
             obj.build()
             f = obj.compute(params=coil.params_dict)
             np.testing.assert_allclose(f, 4 * np.pi, rtol=1e-8)
-            assert len(f) == obj.dim_f
+            assert f.shape == (obj.dim_f,)
 
         coil = FourierPlanarCoil(r_n=2, basis="rpz")
         coils = CoilSet.linspaced_linear(coil, n=3, displacement=[0, 3, 0])


### PR DESCRIPTION
The output of `CoilCurrentLength` is a 2D array of shape `(dim_f, dim_f)`, this corrects it to be a 1D array of shape `(dim_f,)`. 