### PR TITLE
`CoilSet.to_FourierRZ` and `CoilSet.to_FourierPlanar`

### DIFF
--- a/desc/coils.py
+++ b/desc/coils.py
@@ -362,10 +362,9 @@ class _Coil(_MagneticField, Optimizable, ABC):
             Number of field periods, the coil will have a discrete toroidal symmetry
             according to NFP.
         sym : bool, optional
-            whether the curve is stellarator-symmetric or not. Default
-            is False.
+            Whether the curve is stellarator-symmetric or not. Default is False.
         name : str
-            name for this coil
+            Name for this coil.
 
         Returns
         -------
@@ -398,14 +397,13 @@ class _Coil(_MagneticField, Optimizable, ABC):
         basis : {'xyz', 'rpz'}
             Coordinate system for center and normal vectors. Default = 'xyz'.
         name : str
-            name for this coil
+            Name for this coil.
 
         Returns
         -------
         coil : FourierPlanarCoil
-            New representation of the coil parameterized by Fourier series for
-            minor radius r in a plane specified by a center position and normal
-            vector.
+            New representation of the coil parameterized by Fourier series for minor
+            radius r in a plane specified by a center position and normal vector.
 
         """
         if grid is None:
@@ -1598,6 +1596,64 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
             lines[real_end_ind] = lines[real_end_ind].strip("\n") + f" {name}\n"
         with open(coilsFilename, "w") as f:
             f.writelines(lines)
+
+    def to_FourierPlanar(self, N=10, grid=None, basis="xyz", name=""):
+        """Convert all coils to FourierPlanarCoil.
+
+        Note that some types of coils may not be representable in this basis.
+        In this case, a least-squares fit will be done to find the
+        planar coil that best represents the coil.
+
+        Parameters
+        ----------
+        N : int
+            Fourier resolution of the new FourierPlanarCoil representation.
+        grid : Grid, int or None
+            Grid used to evaluate curve coordinates on to fit with FourierPlanarCoil.
+            If an integer, uses that many equally spaced points.
+        basis : {'xyz', 'rpz'}
+            Coordinate system for center and normal vectors. Default = 'xyz'.
+        name : str
+            Name for this coilset.
+
+        Returns
+        -------
+        coilset : CoilSet
+            New representation of the coilset parameterized by a Fourier series for
+            minor radius r in a plane specified by a center position and normal vector.
+
+        """
+        coils = [coil.to_FourierPlanar(N=N, grid=grid, basis=basis) for coil in self]
+        return self.__class__(*coils, NFP=self.NFP, sym=self.sym, name=name)
+
+    def to_FourierRZ(self, N=10, grid=None, NFP=None, sym=False, name=""):
+        """Convert all coils to FourierRZCoil.
+
+        Note that some types of coils may not be representable in this basis.
+
+        Parameters
+        ----------
+        N : int
+            Fourier resolution of the new R,Z representation.
+        grid : Grid, int or None
+            Grid used to evaluate curve coordinates on to fit with FourierRZCoil.
+            If an integer, uses that many equally spaced points.
+        NFP : int
+            Number of field periods, the coil will have a discrete toroidal symmetry
+            according to NFP.
+        sym : bool, optional
+            Whether the curve is stellarator-symmetric or not. Default is False.
+        name : str
+            Name for this coilset.
+
+        Returns
+        -------
+        coilset : CoilSet
+            New representation of the coilset parameterized by a Fourier series for R,Z.
+
+        """
+        coils = [coil.to_FourierRZ(N=N, grid=grid, NFP=NFP, sym=sym) for coil in self]
+        return self.__class__(*coils, NFP=self.NFP, sym=self.sym, name=name)
 
     def to_FourierXYZ(self, N=10, grid=None, s=None, name=""):
         """Convert all coils to FourierXYZCoil representation.

--- a/desc/coils.py
+++ b/desc/coils.py
@@ -138,7 +138,7 @@ class _Coil(_MagneticField, Optimizable, ABC):
     Parameters
     ----------
     current : float
-        current passing through the coil, in Amperes
+        Current through the coil, in Amperes.
     """
 
     _io_attrs_ = _MagneticField._io_attrs_ + ["_current"]
@@ -1237,22 +1237,22 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
     def linspaced_angular(
         cls, coil, current=None, axis=[0, 0, 1], angle=2 * np.pi, n=10, endpoint=False
     ):
-        """Create a coil set by repeating a coil n times rotationally.
+        """Create a CoilSet by repeating a coil at equal spacing around the torus.
 
         Parameters
         ----------
         coil : Coil
-            base coil to repeat
+            Base coil to repeat.
         current : float or array-like, shape(n,)
-            current in (each) coil, overrides coil.current
+            Current through (each) coil, in Amperes. Overrides coil.current.
         axis : array-like, shape(3,)
-            axis to rotate about
+            Axis to rotate about, in X,Y,Z coordinates.
         angle : float
-            total rotational extent of coil set
+            Total rotational extent of the final coil, in radians.
         n : int
-            number of copies of original coil
+            Number of copies of original coil.
         endpoint : bool
-            whether to include a coil at final angle
+            Whether to include a coil at final rotation angle. Default = False.
 
         """
         assert isinstance(coil, _Coil) and not isinstance(coil, CoilSet)
@@ -1272,20 +1272,21 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
     def linspaced_linear(
         cls, coil, current=None, displacement=[2, 0, 0], n=4, endpoint=False
     ):
-        """Create a coil group by repeating a coil n times in a straight line.
+        """Create a CoilSet by repeating a coil at equal spacing in a straight line.
 
         Parameters
         ----------
         coil : Coil
-            base coil to repeat
+            Base coil to repeat.
         current : float or array-like, shape(n,)
-            current in (each) coil
+            Current through (each) coil, in Amperes. Overrides coil.current.
         displacement : array-like, shape(3,)
-            total displacement of the final coil
+            Total displacement of the final coil, relative to the initial coil position,
+            in X,Y,Z coordinates.
         n : int
-            number of copies of original coil
+            Number of copies of original coil.
         endpoint : bool
-            whether to include a coil at final point
+            Whether to include a coil at final displacement location. Default = False.
 
         """
         assert isinstance(coil, _Coil) and not isinstance(coil, CoilSet)
@@ -1468,14 +1469,12 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
 
         try:
             return cls(*coils)
-        except ValueError as e:  # can't load as a CoilSet if any of the coils have
-            # different length of knots, tell user to load as MixedCoilSet instead
+        except ValueError as e:
             errorif(
                 True,
                 ValueError,
-                "Unable to create CoilSet with the coils in the file,"
-                f" got error {e}."
-                "Likely the issue is differing numbers of knots for the coils,"
+                f"Unable to create CoilSet with the coils in the file, got error {e}."
+                + "The issue is likely differing numbers of knots for the coils, "
                 "try using a MixedCoilSet instead of a CoilSet.",
             )
 
@@ -1627,7 +1626,7 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
         return self.__class__(*coils, NFP=self.NFP, sym=self.sym, name=name)
 
     def to_FourierRZ(self, N=10, grid=None, NFP=None, sym=False, name=""):
-        """Convert all coils to FourierRZCoil.
+        """Convert all coils to FourierRZCoil representaion.
 
         Note that some types of coils may not be representable in this basis.
 
@@ -1666,33 +1665,33 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
             Grid used to evaluate curve coordinates on to fit with FourierXYZCoil.
             If an integer, uses that many equally spaced points.
         s : ndarray
-            arbitrary curve parameter to use for the fitting. if None, defaults to
-            normalized arclength
+            Arbitrary curve parameter to use for the fitting. If None, defaults to
+            normalized arclength.
         name : str
-            name for the new CoilSet
+            Name for the new CoilSet.
 
         Returns
         -------
         coilset : CoilSet
-            New representation of the coilset parameterized by Fourier series for X,Y,Z.
+            New representation of the coil set parameterized by a Fourier series for
+            X,Y,Z.
 
         """
         coils = [coil.to_FourierXYZ(N, grid, s) for coil in self]
         return self.__class__(*coils, NFP=self.NFP, sym=self.sym, name=name)
 
     def to_SplineXYZ(self, knots=None, grid=None, method="cubic", name=""):
-        """Convert all coils to SplineXYZCoil.
+        """Convert all coils to SplineXYZCoil representation.
 
         Parameters
         ----------
         knots : ndarray
-            arbitrary curve parameter values to use for spline knots,
+            Arbitrary curve parameter values to use for spline knots,
             should be an 1D ndarray of same length as the input.
-            (input length in this case is determined by grid argument, since
-            the input coordinates come from
-            Coil.compute("x",grid=grid))
-            If None, defaults to using an equal-arclength angle as the knots
-            If supplied, will be rescaled to lie in [0,2pi]
+            (Input length in this case is determined by grid argument, since
+            the input coordinates come from Coil.compute("x",grid=grid))
+            If None, defaults to using an equal-arclength angle as the knots.
+            If supplied, will be rescaled to the range [0,2pi].
         grid : Grid, int or None
             Grid used to evaluate curve coordinates on to fit with SplineXYZCoil.
             If an integer, uses that many equally spaced points.
@@ -1704,7 +1703,7 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
             - `'cubic2'`: C2 cubic splines (aka natural splines)
             - `'catmull-rom'`: C1 cubic centripetal "tension" splines
         name : str
-            name for the new CoilSet
+            Name for the new CoilSet.
 
         Returns
         -------
@@ -2002,6 +2001,64 @@ class MixedCoilSet(CoilSet):
 
         return B
 
+    def to_FourierPlanar(self, N=10, grid=None, basis="xyz", name=""):
+        """Convert all coils to FourierPlanarCoil representation.
+
+        Note that some types of coils may not be representable in this basis.
+        In this case, a least-squares fit will be done to find the
+        planar coil that best represents the coil.
+
+        Parameters
+        ----------
+        N : int
+            Fourier resolution of the new FourierPlanarCoil representation.
+        grid : Grid, int or None
+            Grid used to evaluate curve coordinates on to fit with FourierPlanarCoil.
+            If an integer, uses that many equally spaced points.
+        basis : {'xyz', 'rpz'}
+            Coordinate system for center and normal vectors. Default = 'xyz'.
+        name : str
+            Name for the new MixedCoilSet.
+
+        Returns
+        -------
+        coilset : MixedCoilSet
+            New representation of the coilset parameterized by a Fourier series for
+            minor radius r in a plane specified by a center position and normal vector.
+
+        """
+        coils = [coil.to_FourierPlanar(N=N, grid=grid, basis=basis) for coil in self]
+        return self.__class__(*coils, name=name)
+
+    def to_FourierRZ(self, N=10, grid=None, NFP=None, sym=False, name=""):
+        """Convert all coils to FourierRZCoil representation.
+
+        Note that some types of coils may not be representable in this basis.
+
+        Parameters
+        ----------
+        N : int
+            Fourier resolution of the new R,Z representation.
+        grid : Grid, int or None
+            Grid used to evaluate curve coordinates on to fit with FourierRZCoil.
+            If an integer, uses that many equally spaced points.
+        NFP : int
+            Number of field periods, the coil will have a discrete toroidal symmetry
+            according to NFP.
+        sym : bool, optional
+            Whether the curve is stellarator-symmetric or not. Default is False.
+        name : str
+            Name for the new MixedCoilSet.
+
+        Returns
+        -------
+        coilset : MixedCoilSet
+            New representation of the coilset parameterized by a Fourier series for R,Z.
+
+        """
+        coils = [coil.to_FourierRZ(N=N, grid=grid, NFP=NFP, sym=sym) for coil in self]
+        return self.__class__(*coils, name=name)
+
     def to_FourierXYZ(self, N=10, grid=None, s=None, name=""):
         """Convert all coils to FourierXYZCoil representation.
 
@@ -2013,33 +2070,33 @@ class MixedCoilSet(CoilSet):
             Grid used to evaluate curve coordinates on to fit with FourierXYZCoil.
             If an integer, uses that many equally spaced points.
         s : ndarray
-            arbitrary curve parameter to use for the fitting. if None, defaults to
-            normalized arclength
+            Arbitrary curve parameter to use for the fitting. If None, defaults to
+            normalized arclength.
         name : str
-            name for the new CoilSet
+            Name for the new MixedCoilSet.
 
         Returns
         -------
-        coilset : CoilSet
-            New representation of the coilset parameterized by Fourier series for X,Y,Z.
+        coilset : MixedCoilSet
+            New representation of the coil set parameterized by a Fourier series for
+            X,Y,Z.
 
         """
         coils = [coil.to_FourierXYZ(N, grid, s) for coil in self]
         return self.__class__(*coils, name=name)
 
     def to_SplineXYZ(self, knots=None, grid=None, method="cubic", name=""):
-        """Convert all coils to SplineXYZCoil.
+        """Convert all coils to SplineXYZCoil representation.
 
         Parameters
         ----------
         knots : ndarray
-            arbitrary curve parameter values to use for spline knots,
+            Arbitrary curve parameter values to use for spline knots,
             should be an 1D ndarray of same length as the input.
-            (input length in this case is determined by grid argument, since
-            the input coordinates come from
-            Coil.compute("x",grid=grid))
-            If None, defaults to using an equal-arclength angle as the knots
-            If supplied, will be rescaled to lie in [0,2pi]
+            (Input length in this case is determined by grid argument, since
+            the input coordinates come from Coil.compute("x",grid=grid))
+            If None, defaults to using an equal-arclength angle as the knots.
+            If supplied, will be rescaled to the range [0,2pi].
         grid : Grid, int or None
             Grid used to evaluate curve coordinates on to fit with SplineXYZCoil.
             If an integer, uses that many equally spaced points.
@@ -2051,11 +2108,11 @@ class MixedCoilSet(CoilSet):
             - `'cubic2'`: C2 cubic splines (aka natural splines)
             - `'catmull-rom'`: C1 cubic centripetal "tension" splines
         name : str
-            name for the new CoilSet
+            Name for the new MixedCoilSet.
 
         Returns
         -------
-        coilset : CoilSet
+        coilset : MixedCoilSet
             New representation of the coilset parameterized by a spline for X,Y,Z.
 
         """

--- a/tests/test_coils.py
+++ b/tests/test_coils.py
@@ -16,7 +16,7 @@ from desc.coils import (
 from desc.compute import get_params, get_transforms, xyz2rpz, xyz2rpz_vec
 from desc.examples import get
 from desc.geometry import FourierRZCurve, FourierRZToroidalSurface
-from desc.grid import LinearGrid
+from desc.grid import Grid, LinearGrid
 from desc.io import load
 from desc.magnetic_fields import SumMagneticField, VerticalMagneticField
 
@@ -206,7 +206,7 @@ class TestCoil:
             )
 
     @pytest.mark.unit
-    def test_converting_coil_types(self):
+    def test_convert_type(self):
         """Test conversions between coil representations."""
         s = np.linspace(0, 2 * np.pi, 100, endpoint=False)
         coil1 = FourierRZCoil(1e6, [0, 10, 1], [0, 0, 0])
@@ -220,10 +220,12 @@ class TestCoil:
         x2 = coil2.compute("x", grid=grid, basis="xyz")["x"]
         x3 = coil3.compute("x", grid=grid, basis="xyz")["x"]
         x4 = coil4.compute("x", grid=grid, basis="xyz")["x"]
-        grid = LinearGrid(
-            zeta=np.arctan2(x1[:, 1] - coil5.center[1], x1[:, 0] - coil5.center[0])
-        )  # zeta = arctan angle instead of s for the planar coil for the same points
-        x5 = coil5.compute("x", grid=grid, basis="xyz")["x"]
+        zeta = np.arctan2(  # zeta = polar angle for planar coil for same points
+            x1[:, 1] - coil5.center[1],
+            x1[:, 0] - coil5.center[0],
+        )  # use Grid instead of LinearGrid to prevent node sorting
+        grid_planar = Grid(np.array([np.zeros_like(zeta), np.zeros_like(zeta), zeta]).T)
+        x5 = coil5.compute("x", grid=grid_planar, basis="xyz")["x"]
 
         B1 = coil1.compute_magnetic_field(
             np.zeros((1, 3)), source_grid=grid, basis="xyz"
@@ -533,37 +535,85 @@ class TestCoilSet:
             coils2.insert(4, coil2)
 
     @pytest.mark.unit
-    def test_coilset_convert(self):
+    def test_convert_type(self):
         """Test converting coilsets between different representations."""
         grid = LinearGrid(N=20)
-        coil1 = FourierXYZCoil(current=1e6)
-        coil2 = coil1.to_SplineXYZ(grid=grid)
+        coil = FourierRZCoil(1e6, [0, 10, 1], [0, 0, 0])
 
-        coils1 = MixedCoilSet.linspaced_angular(coil1, n=12)
+        # MixedCoilSet
+        coils1 = MixedCoilSet.linspaced_linear(coil, displacement=[0, 0, 2.5], n=4)
         coils2 = coils1.to_SplineXYZ(grid=grid)
+        coils3 = coils1.to_FourierXYZ(grid=grid)
+        coils4 = coils1.to_FourierPlanar(grid=grid)
         assert isinstance(coils2, MixedCoilSet)
+        assert isinstance(coils3, MixedCoilSet)
+        assert isinstance(coils4, MixedCoilSet)
         assert all(isinstance(coil, SplineXYZCoil) for coil in coils2)
+        assert all(isinstance(coil, FourierXYZCoil) for coil in coils3)
+        assert all(isinstance(coil, FourierPlanarCoil) for coil in coils4)
         x1 = coils1.compute("x", grid=grid, basis="xyz")
         x2 = coils2.compute("x", grid=grid, basis="xyz")
+        x3 = coils3.compute("x", grid=grid, basis="xyz")
+        zeta = np.arctan2(  # zeta = polar angle for planar coil for same points
+            x1[0]["x"][:, 1] - coils4[0].center[1],
+            x1[0]["x"][:, 0] - coils4[0].center[0],
+        )  # use Grid instead of LinearGrid to prevent node sorting
+        grid_planar = Grid(np.array([np.zeros_like(zeta), np.zeros_like(zeta), zeta]).T)
+        x4 = coils4.compute("x", grid=grid_planar, basis="xyz")
         np.testing.assert_allclose(
             [xi["x"] for xi in x1], [xi["x"] for xi in x2], atol=1e-12
         )
-        B1 = coils1.compute_magnetic_field(np.array([[10, 2, 1]]), source_grid=grid)
-        B2 = coils2.compute_magnetic_field(np.array([[10, 2, 1]]), source_grid=grid)
-        np.testing.assert_allclose(B1, B2, rtol=1e-2)
-
-        coils3 = CoilSet.linspaced_angular(coil2, n=12)
-        coils4 = coils3.to_FourierXYZ(grid=grid)
-        assert isinstance(coils4, CoilSet)
-        assert all(isinstance(coil, FourierXYZCoil) for coil in coils4)
-        x3 = coils3.compute("x", grid=grid, basis="xyz")
-        x4 = coils4.compute("x", grid=grid, basis="xyz")
         np.testing.assert_allclose(
-            [xi["x"] for xi in x3], [xi["x"] for xi in x4], atol=1e-12
+            [xi["x"] for xi in x1], [xi["x"] for xi in x3], atol=1e-12
         )
-        B3 = coils3.compute_magnetic_field(np.array([[10, 2, 1]]), source_grid=grid)
-        B4 = coils4.compute_magnetic_field(np.array([[10, 2, 1]]), source_grid=grid)
-        np.testing.assert_allclose(B3, B4, rtol=1e-2)
+        np.testing.assert_allclose(
+            [xi["x"] for xi in x1], [xi["x"] for xi in x4], atol=1e-12
+        )
+        B1 = coils1.compute_magnetic_field(np.array([[5, 2, 1]]), source_grid=grid)
+        B2 = coils2.compute_magnetic_field(np.array([[5, 2, 1]]), source_grid=grid)
+        B3 = coils3.compute_magnetic_field(np.array([[5, 2, 1]]), source_grid=grid)
+        B4 = coils4.compute_magnetic_field(np.array([[5, 2, 1]]), source_grid=grid)
+        np.testing.assert_allclose(B1, B2, rtol=1e-2)
+        np.testing.assert_allclose(B1, B3, rtol=1e-2)
+        np.testing.assert_allclose(B1, B4, rtol=1e-2)
+
+        # CoilSet
+        coil = coils3[0]  # FourierXYZCoil
+        coils5 = CoilSet.linspaced_linear(coil, displacement=[0, 0, 3.5], n=6)
+        coils6 = coils5.to_SplineXYZ(grid=grid)
+        coils7 = coils5.to_FourierRZ(grid=grid)
+        coils8 = coils5.to_FourierPlanar(grid=grid)
+        assert isinstance(coils6, CoilSet)
+        assert isinstance(coils7, CoilSet)
+        assert isinstance(coils8, CoilSet)
+        assert all(isinstance(coil, SplineXYZCoil) for coil in coils6)
+        assert all(isinstance(coil, FourierRZCoil) for coil in coils7)
+        assert all(isinstance(coil, FourierPlanarCoil) for coil in coils8)
+        x5 = coils5.compute("x", grid=grid, basis="xyz")
+        x6 = coils6.compute("x", grid=grid, basis="xyz")
+        x7 = coils7.compute("x", grid=grid, basis="xyz")
+        zeta = np.arctan2(  # zeta = polar angle for planar coil for same points
+            x5[0]["x"][:, 1] - coils8[0].center[1],
+            x5[0]["x"][:, 0] - coils8[0].center[0],
+        )  # use Grid instead of LinearGrid to prevent node sorting
+        grid_planar = Grid(np.array([np.zeros_like(zeta), np.zeros_like(zeta), zeta]).T)
+        x8 = coils8.compute("x", grid=grid_planar, basis="xyz")
+        np.testing.assert_allclose(
+            [xi["x"] for xi in x5], [xi["x"] for xi in x6], atol=1e-12
+        )
+        np.testing.assert_allclose(
+            [xi["x"] for xi in x5], [xi["x"] for xi in x7], atol=1e-12
+        )
+        np.testing.assert_allclose(
+            [xi["x"] for xi in x5], [xi["x"] for xi in x8], atol=1e-12
+        )
+        B5 = coils5.compute_magnetic_field(np.array([[5, 2, 1]]), source_grid=grid)
+        B6 = coils6.compute_magnetic_field(np.array([[5, 2, 1]]), source_grid=grid)
+        B7 = coils6.compute_magnetic_field(np.array([[5, 2, 1]]), source_grid=grid)
+        B8 = coils6.compute_magnetic_field(np.array([[5, 2, 1]]), source_grid=grid)
+        np.testing.assert_allclose(B5, B6, rtol=1e-2)
+        np.testing.assert_allclose(B5, B7, rtol=1e-2)
+        np.testing.assert_allclose(B5, B8, rtol=1e-2)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
These are methods that we forgot to add to #1116. 

It might also be worth adding an option to `CoilSet.from_makegrid_coilfile` so that the coil set can be loaded as any type, instead of always using `SplineXYZCoil`. But at least now we can load the spline coils and then convert to any other coil type. 