### PR TITLE
Add check_intersection flag to the coilset conversion methods

### DIFF
--- a/desc/coils.py
+++ b/desc/coils.py
@@ -1596,7 +1596,9 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
         with open(coilsFilename, "w") as f:
             f.writelines(lines)
 
-    def to_FourierPlanar(self, N=10, grid=None, basis="xyz", name=""):
+    def to_FourierPlanar(
+        self, N=10, grid=None, basis="xyz", name="", check_intersection=True
+    ):
         """Convert all coils to FourierPlanarCoil.
 
         Note that some types of coils may not be representable in this basis.
@@ -1614,6 +1616,8 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
             Coordinate system for center and normal vectors. Default = 'xyz'.
         name : str
             Name for this coilset.
+        check_intersection: bool
+            Whether or not to check the coils in the new coilset for intersections.
 
         Returns
         -------
@@ -1623,9 +1627,17 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
 
         """
         coils = [coil.to_FourierPlanar(N=N, grid=grid, basis=basis) for coil in self]
-        return self.__class__(*coils, NFP=self.NFP, sym=self.sym, name=name)
+        return self.__class__(
+            *coils,
+            NFP=self.NFP,
+            sym=self.sym,
+            name=name,
+            check_intersection=check_intersection,
+        )
 
-    def to_FourierRZ(self, N=10, grid=None, NFP=None, sym=False, name=""):
+    def to_FourierRZ(
+        self, N=10, grid=None, NFP=None, sym=False, name="", check_intersection=True
+    ):
         """Convert all coils to FourierRZCoil representaion.
 
         Note that some types of coils may not be representable in this basis.
@@ -1644,6 +1656,8 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
             Whether the curve is stellarator-symmetric or not. Default is False.
         name : str
             Name for this coilset.
+        check_intersection: bool
+            Whether or not to check the coils in the new coiilset for intersections.
 
         Returns
         -------
@@ -1652,9 +1666,15 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
 
         """
         coils = [coil.to_FourierRZ(N=N, grid=grid, NFP=NFP, sym=sym) for coil in self]
-        return self.__class__(*coils, NFP=self.NFP, sym=self.sym, name=name)
+        return self.__class__(
+            *coils,
+            NFP=self.NFP,
+            sym=self.sym,
+            name=name,
+            check_intersection=check_intersection,
+        )
 
-    def to_FourierXYZ(self, N=10, grid=None, s=None, name=""):
+    def to_FourierXYZ(self, N=10, grid=None, s=None, name="", check_intersection=True):
         """Convert all coils to FourierXYZCoil representation.
 
         Parameters
@@ -1669,6 +1689,8 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
             normalized arclength.
         name : str
             Name for the new CoilSet.
+        check_intersection: bool
+            Whether or not to check the coils in the new coiilset for intersections.
 
         Returns
         -------
@@ -1678,9 +1700,17 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
 
         """
         coils = [coil.to_FourierXYZ(N, grid, s) for coil in self]
-        return self.__class__(*coils, NFP=self.NFP, sym=self.sym, name=name)
+        return self.__class__(
+            *coils,
+            NFP=self.NFP,
+            sym=self.sym,
+            name=name,
+            check_intersection=check_intersection,
+        )
 
-    def to_SplineXYZ(self, knots=None, grid=None, method="cubic", name=""):
+    def to_SplineXYZ(
+        self, knots=None, grid=None, method="cubic", name="", check_intersection=True
+    ):
         """Convert all coils to SplineXYZCoil representation.
 
         Parameters
@@ -1704,6 +1734,8 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
             - `'catmull-rom'`: C1 cubic centripetal "tension" splines
         name : str
             Name for the new CoilSet.
+        check_intersection: bool
+            Whether or not to check the coils in the new coiilset for intersections.
 
         Returns
         -------
@@ -1712,7 +1744,13 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
 
         """
         coils = [coil.to_SplineXYZ(knots, grid, method) for coil in self]
-        return self.__class__(*coils, NFP=self.NFP, sym=self.sym, name=name)
+        return self.__class__(
+            *coils,
+            NFP=self.NFP,
+            sym=self.sym,
+            name=name,
+            check_intersection=check_intersection,
+        )
 
     def is_self_intersecting(self, grid=None, tol=None):
         """Check if any coils in the CoilSet intersect.
@@ -2001,7 +2039,9 @@ class MixedCoilSet(CoilSet):
 
         return B
 
-    def to_FourierPlanar(self, N=10, grid=None, basis="xyz", name=""):
+    def to_FourierPlanar(
+        self, N=10, grid=None, basis="xyz", name="", check_intersection=False
+    ):
         """Convert all coils to FourierPlanarCoil representation.
 
         Note that some types of coils may not be representable in this basis.
@@ -2019,6 +2059,8 @@ class MixedCoilSet(CoilSet):
             Coordinate system for center and normal vectors. Default = 'xyz'.
         name : str
             Name for the new MixedCoilSet.
+        check_intersection: bool
+            Whether or not to check the coils in the new coiilset for intersections.
 
         Returns
         -------
@@ -2028,9 +2070,11 @@ class MixedCoilSet(CoilSet):
 
         """
         coils = [coil.to_FourierPlanar(N=N, grid=grid, basis=basis) for coil in self]
-        return self.__class__(*coils, name=name)
+        return self.__class__(*coils, name=name, check_intersection=check_intersection)
 
-    def to_FourierRZ(self, N=10, grid=None, NFP=None, sym=False, name=""):
+    def to_FourierRZ(
+        self, N=10, grid=None, NFP=None, sym=False, name="", check_intersection=True
+    ):
         """Convert all coils to FourierRZCoil representation.
 
         Note that some types of coils may not be representable in this basis.
@@ -2049,6 +2093,8 @@ class MixedCoilSet(CoilSet):
             Whether the curve is stellarator-symmetric or not. Default is False.
         name : str
             Name for the new MixedCoilSet.
+        check_intersection: bool
+            Whether or not to check the coils in the new coiilset for intersections.
 
         Returns
         -------
@@ -2057,9 +2103,9 @@ class MixedCoilSet(CoilSet):
 
         """
         coils = [coil.to_FourierRZ(N=N, grid=grid, NFP=NFP, sym=sym) for coil in self]
-        return self.__class__(*coils, name=name)
+        return self.__class__(*coils, name=name, check_intersection=check_intersection)
 
-    def to_FourierXYZ(self, N=10, grid=None, s=None, name=""):
+    def to_FourierXYZ(self, N=10, grid=None, s=None, name="", check_intersection=True):
         """Convert all coils to FourierXYZCoil representation.
 
         Parameters
@@ -2074,6 +2120,8 @@ class MixedCoilSet(CoilSet):
             normalized arclength.
         name : str
             Name for the new MixedCoilSet.
+        check_intersection: bool
+            Whether or not to check the coils in the new coiilset for intersections.
 
         Returns
         -------
@@ -2083,9 +2131,11 @@ class MixedCoilSet(CoilSet):
 
         """
         coils = [coil.to_FourierXYZ(N, grid, s) for coil in self]
-        return self.__class__(*coils, name=name)
+        return self.__class__(*coils, name=name, check_intersection=check_intersection)
 
-    def to_SplineXYZ(self, knots=None, grid=None, method="cubic", name=""):
+    def to_SplineXYZ(
+        self, knots=None, grid=None, method="cubic", name="", check_intersection=True
+    ):
         """Convert all coils to SplineXYZCoil representation.
 
         Parameters
@@ -2109,6 +2159,8 @@ class MixedCoilSet(CoilSet):
             - `'catmull-rom'`: C1 cubic centripetal "tension" splines
         name : str
             Name for the new MixedCoilSet.
+        check_intersection: bool
+            Whether or not to check the coils in the new coiilset for intersections.
 
         Returns
         -------
@@ -2117,7 +2169,7 @@ class MixedCoilSet(CoilSet):
 
         """
         coils = [coil.to_SplineXYZ(knots, grid, method) for coil in self]
-        return self.__class__(*coils, name=name)
+        return self.__class__(*coils, name=name, check_intersection=check_intersection)
 
     def __add__(self, other):
         if isinstance(other, (CoilSet, MixedCoilSet)):

--- a/tests/test_coils.py
+++ b/tests/test_coils.py
@@ -542,9 +542,9 @@ class TestCoilSet:
 
         # MixedCoilSet
         coils1 = MixedCoilSet.linspaced_linear(coil, displacement=[0, 0, 2.5], n=4)
-        coils2 = coils1.to_SplineXYZ(grid=grid)
-        coils3 = coils1.to_FourierXYZ(grid=grid)
-        coils4 = coils1.to_FourierPlanar(grid=grid)
+        coils2 = coils1.to_SplineXYZ(grid=grid, check_intersection=False)
+        coils3 = coils1.to_FourierXYZ(grid=grid, check_intersection=False)
+        coils4 = coils1.to_FourierPlanar(grid=grid, check_intersection=False)
         assert isinstance(coils2, MixedCoilSet)
         assert isinstance(coils3, MixedCoilSet)
         assert isinstance(coils4, MixedCoilSet)
@@ -580,9 +580,9 @@ class TestCoilSet:
         # CoilSet
         coil = coils3[0]  # FourierXYZCoil
         coils5 = CoilSet.linspaced_linear(coil, displacement=[0, 0, 3.5], n=6)
-        coils6 = coils5.to_SplineXYZ(grid=grid)
-        coils7 = coils5.to_FourierRZ(grid=grid)
-        coils8 = coils5.to_FourierPlanar(grid=grid)
+        coils6 = coils5.to_SplineXYZ(grid=grid, check_intersection=False)
+        coils7 = coils5.to_FourierRZ(grid=grid, check_intersection=False)
+        coils8 = coils5.to_FourierPlanar(grid=grid, check_intersection=False)
         assert isinstance(coils6, CoilSet)
         assert isinstance(coils7, CoilSet)
         assert isinstance(coils8, CoilSet)


### PR DESCRIPTION
Add `check_intersection` flag to the `To_XXX` coilset methods, to avoid costly intersection checks when we are confident the fit won't mess up the original coilset and so the check is unnecessary.