### PR TITLE
Fix the sign error in wide QR factorization

### DIFF
--- a/desc/optimize/tr_subproblems.py
+++ b/desc/optimize/tr_subproblems.py
@@ -421,7 +421,7 @@ def trust_region_step_exact_qr(
         p_newton = solve_triangular_regularized(R, -Q.T @ f)
     else:
         Q, R = qr(J.T, mode="economic")
-        p_newton = Q @ solve_triangular_regularized(R.T, f, lower=True)
+        p_newton = Q @ solve_triangular_regularized(R.T, -f, lower=True)
 
     def truefun(*_):
         return p_newton, False, 0.0


### PR DESCRIPTION
When Jacobian is wide, instead of decomposing $\mathbf{J=QR}$, we do $\mathbf{J^T=QR}$. This later requires solving 
$$\mathbf{J}x= -f $$
$$\mathbf{R}^T \mathbf{Q}^Tx = - f $$
$$\mathbf{R}^Tv = - f,  \hspace{1cm}    \text{where } v = \mathbf{Q}^Tx$$
$$x = \mathbf{Q}v$$
where we call `p_newton` to `x`.