### PR TITLE
Fix `_print_value_fmt` for some objectives and fix some latex labels

### DIFF
--- a/desc/compute/_equil.py
+++ b/desc/compute/_equil.py
@@ -625,7 +625,7 @@ def _e_sup_helical_times_sqrt_g_mag(params, transforms, profiles, data, **kwargs
 
 @register_compute_fun(
     name="F_anisotropic",
-    label="F_{anisotropic}",
+    label="F_{\\mathrm{anisotropic}}",
     units="N \\cdot m^{-3}",
     units_long="Newtons / cubic meter",
     description="Anisotropic force balance error",

--- a/desc/compute/_field.py
+++ b/desc/compute/_field.py
@@ -1644,7 +1644,7 @@ def _B_sub_zeta(params, transforms, profiles, data, **kwargs):
 
 @register_compute_fun(
     name="B_phi|r,t",
-    label="B_{\\phi} = B \\dot \\mathbf{e}_{\\phi} |_{\\rho, \\theta}",
+    label="B_{\\phi} = B \\cdot \\mathbf{e}_{\\phi} |_{\\rho, \\theta}",
     units="T \\cdot m",
     units_long="Tesla * meters",
     description="Covariant toroidal component of magnetic field in (ρ,θ,ϕ) "
@@ -2269,7 +2269,7 @@ def _B_sub_zeta_rz(params, transforms, profiles, data, **kwargs):
 
 @register_compute_fun(
     name="<|B|>_axis",
-    label="\\lange |\\mathbf{B}| \\rangle_{axis}",
+    label="\\langle |\\mathbf{B}| \\rangle_{axis}",
     units="T",
     units_long="Tesla",
     description="Average magnitude of magnetic field on the magnetic axis",

--- a/desc/objectives/_equilibrium.py
+++ b/desc/objectives/_equilibrium.py
@@ -557,7 +557,7 @@ class HelicalForceBalance(_Objective):
     _equilibrium = True
     _coordinates = "rtz"
     _units = "(N)"
-    _print_value_fmt = "Helical force error: {:10.3e}, "
+    _print_value_fmt = "Helical force error: "
 
     def __init__(
         self,

--- a/desc/objectives/_power_balance.py
+++ b/desc/objectives/_power_balance.py
@@ -61,7 +61,7 @@ class FusionPower(_Objective):
 
     _scalar = True
     _units = "(W)"
-    _print_value_fmt = "Fusion power: {:10.3e} "
+    _print_value_fmt = "Fusion power: "
 
     def __init__(
         self,
@@ -246,7 +246,7 @@ class HeatingPowerISS04(_Objective):
 
     _scalar = True
     _units = "(W)"
-    _print_value_fmt = "Heating power: {:10.3e} "
+    _print_value_fmt = "Heating power: "
 
     def __init__(
         self,


### PR DESCRIPTION
#1189 changed the format of `_print_value_fmt` some recent merged PR's added new objectives that shouldn't work with the new format and throw `IndexError: Replacement index 2 out of range for positional args tuple`.

Also, I think I missed one of the objectives during that PR. This fixes the formats.

And some small label fixes.