### PR TITLE
Fix readme badges and expected number of tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,12 +111,12 @@ Contribute
     :target: https://desc-docs.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation
 
-.. |UnitTests| image:: https://github.com/PlasmaControl/DESC/actions/workflows/unittest.yml/badge.svg
-    :target: https://github.com/PlasmaControl/DESC/actions/workflows/unittest.yml
+.. |UnitTests| image:: https://github.com/PlasmaControl/DESC/actions/workflows/unit_tests.yml/badge.svg
+    :target: https://github.com/PlasmaControl/DESC/actions/workflows/unit_tests.yml
     :alt: UnitTests
 
-.. |RegressionTests| image:: https://github.com/PlasmaControl/DESC/actions/workflows/regression_test.yml/badge.svg
-    :target: https://github.com/PlasmaControl/DESC/actions/workflows/regression_test.yml
+.. |RegressionTests| image:: https://github.com/PlasmaControl/DESC/actions/workflows/regression_tests.yml/badge.svg
+    :target: https://github.com/PlasmaControl/DESC/actions/workflows/regression_tests.yml
     :alt: RegressionTests
 
 .. |Codecov| image:: https://codecov.io/gh/PlasmaControl/DESC/branch/master/graph/badge.svg?token=5LDR4B1O7Z

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ comment:                  # this is a top-level key
   require_changes: false  # if true: only post the comment if coverage changes
   require_base: true        # [true :: must have a base report to post]
   require_head: true       # [true :: must have a head report to post]
-  after_n_builds: 10
+  after_n_builds: 14
 coverage:
   status:
     patch:


### PR DESCRIPTION
Some stuff that was missing from #1213 

- Updates readme badges to point to the renamed gh actions
- Tells codecov to expect 14 batches of coverage data, not 10 (we used to have 6 regression + 4 unit, now 6 regression + 8 unit)