### PR TITLE
Add hidden files to upload artifacts step

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -136,17 +136,6 @@ jobs:
           pattern: benchmark_artifact_*
           path: tests/benchmarks
 
-      - name: Unzip artifacts if downloaded
-        if: always() && env.has_changes == 'true'
-        run: |
-          cd tests/benchmarks
-          ls
-          if [ -f tests/benchmarks/benchmark_artifact_*.zip ]; then
-            unzip tests/benchmarks/benchmark_artifact_*.zip -d tests/benchmarks
-          else
-            echo "No benchmark artifact file found."
-          fi
-
       - name: Compare latest commit results to the master branch results
         if: env.has_changes == 'true'
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -171,3 +171,4 @@ jobs:
         with:
           name: benchmark_artifact_${{ matrix.group }}
           path: tests/benchmarks/.benchmarks
+          include-hidden-files: true


### PR DESCRIPTION
`upload-artifact` action made a change 2 weeks ago that excludes hidden files (the ones start with . like /.benchmarks) for upload step. This broke our way of uploading the artifact for benchmarks workflow. As a result, benchmark stats shown as comment to PR had only half of the results.

Maybe another fix with this PR could be waiting for artifact-1 to be uploaded before running `download artifacts` step of group 2. For now it shouldn't cause an issue because group 1 of benchmarks is ~10 minutes shorter than group 2. But rarely, both may not find an artifact to download and the final comment can only have the half of the results
