### PR TITLE
`flip_theta` compatibility function

### DIFF
--- a/desc/compat.py
+++ b/desc/compat.py
@@ -111,6 +111,46 @@ def flip_helicity(eq):
     return eq
 
 
+def flip_theta(eq):
+    """Change the gauge freedom of the poloidal angle of an Equilibrium.
+
+    Equivalent to redefining theta_new = theta_old + π
+
+    Parameters
+    ----------
+    eq : Equilibrium or iterable of Equilibrium
+        Equilibria to flip the helicity of.
+
+    Returns
+    -------
+    eq : Equilibrium or iterable of Equilibrium
+        Same as input, but with the poloidal angle redefined.
+
+    """
+    # maybe it's iterable:
+    if hasattr(eq, "__len__"):
+        for e in eq:
+            flip_theta(e)
+        return eq
+
+    rone = np.ones_like(eq.R_lmn)
+    rone[eq.R_basis.modes[:, 1] % 2 == 1] *= -1
+    eq.R_lmn *= rone
+
+    zone = np.ones_like(eq.Z_lmn)
+    zone[eq.Z_basis.modes[:, 1] % 2 == 1] *= -1
+    eq.Z_lmn *= zone
+
+    lone = np.ones_like(eq.L_lmn)
+    lone[eq.L_basis.modes[:, 1] % 2 == 1] *= -1
+    eq.L_lmn *= lone
+
+    eq.axis = eq.get_axis()
+    eq.surface = eq.get_surface_at(rho=1)
+
+    return eq
+
+
 def rescale(
     eq, L=("R0", None), B=("B0", None), scale_pressure=True, copy=False, verbose=0
 ):

--- a/desc/compat.py
+++ b/desc/compat.py
@@ -119,7 +119,7 @@ def flip_theta(eq):
     Parameters
     ----------
     eq : Equilibrium or iterable of Equilibrium
-        Equilibria to flip the helicity of.
+        Equilibria to redefine the poloidal angle of.
 
     Returns
     -------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -41,6 +41,7 @@ Compatibility
 
     desc.compat.ensure_positive_jacobian
     desc.compat.flip_helicity
+    desc.compat.flip_theta
     desc.compat.rescale
 
 Continuation

--- a/docs/api_equilibrium.rst
+++ b/docs/api_equilibrium.rst
@@ -66,4 +66,5 @@ equilibria to a given size and/or field strength.
 
     desc.compat.ensure_positive_jacobian
     desc.compat.flip_helicity
+    desc.compat.flip_theta
     desc.compat.rescale

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -188,13 +188,12 @@ def test_flip_theta_nonaxisym():
 
     data_old = eq.compute(data_keys, grid=grid, helicity=(1, eq.NFP))
     eq = flip_theta(eq)
-    data_new = eq.compute(data_keys, grid=grid, helicity=(1, eq.NFP))
-    data_flip = eq.compute(data_keys, grid=grid_flip, helicity=(1, eq.NFP))
+    data_new = eq.compute(data_keys, grid=grid_flip, helicity=(1, eq.NFP))
 
     # check that basis vectors did not change
-    np.testing.assert_allclose(data_old["e_rho"], data_flip["e_rho"], atol=1e-15)
-    np.testing.assert_allclose(data_old["e_theta"], data_flip["e_theta"], atol=1e-15)
-    np.testing.assert_allclose(data_old["e^zeta"], data_flip["e^zeta"], atol=1e-15)
+    np.testing.assert_allclose(data_old["e_rho"], data_new["e_rho"], atol=1e-15)
+    np.testing.assert_allclose(data_old["e_theta"], data_new["e_theta"], atol=1e-15)
+    np.testing.assert_allclose(data_old["e^zeta"], data_new["e^zeta"], atol=1e-15)
 
     # check that Jacobian is still positive
     np.testing.assert_array_less(0, grid.compress(data_new["sqrt(g)"]))
@@ -208,11 +207,11 @@ def test_flip_theta_nonaxisym():
 
     # check that the total force balance error on each surface did not change
     # (equivalent collocation points now corresond to theta + pi)
-    np.testing.assert_allclose(data_old["|F|"], data_flip["|F|"], rtol=1e-3)
+    np.testing.assert_allclose(data_old["|F|"], data_new["|F|"], rtol=1e-3)
 
     # check that the QH helicity did not change
     # (equivalent collocation points now corresond to theta + pi)
-    np.testing.assert_allclose(data_old["f_C"], data_flip["f_C"], atol=1e-8)
+    np.testing.assert_allclose(data_old["f_C"], data_new["f_C"], atol=1e-8)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Redefines $\theta_{new} = \theta_{old} + \pi$ by flipping the sign of all $R$, $Z$, $\lambda$ coefficients with odd $m$. 

This is useful for stuff like omnigenity and TERPSICHORE that assume $\theta=0$ is on the inboard/outboard side. 