### PR TITLE
Bump action version and update cached Matplotlib

### DIFF
--- a/.github/workflows/cache_dependencies.yml
+++ b/.github/workflows/cache_dependencies.yml
@@ -34,12 +34,14 @@ jobs:
             gh cache delete "$cache_key"
           done
 
+      # Update the matplotlib version if needed later
       - name: Set up virtual environment
         run: |
           python -m venv .venv-${{ matrix.python-version }}
           source .venv-${{ matrix.python-version }}/bin/activate
           python -m pip install --upgrade pip
           pip install -r devtools/dev-requirements.txt
+          pip install matplotlib==3.7.2
 
       - name: Cache Python environment
         id: cache-env

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -66,7 +66,6 @@ jobs:
           source .venv-${{ matrix.python-version }}/bin/activate
           python -m pip install --upgrade pip
           pip install -r devtools/dev-requirements.txt
-          pip install matplotlib==3.7.2
 
       - name: Set Swap Space
         if: env.has_changes == 'true'
@@ -78,7 +77,6 @@ jobs:
         if: env.has_changes == 'true'
         run: |
           source .venv-${{ matrix.python-version }}/bin/activate
-          pip install matplotlib==3.7.2
           pwd
           lscpu
           python -m pytest -v -m regression\

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -107,7 +107,7 @@ jobs:
         id : codecov
         uses: Wandalen/wretry.action@v3.5.0
         with:
-          action: codecov/codecov-action@v3
+          action: codecov/codecov-action@v4
           with: |
             token: ${{ secrets.CODECOV_TOKEN }}
             name: codecov-umbrella

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Upload coverage
         if: env.has_changes == 'true'
         id : codecov
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: Wandalen/wretry.action@v3.5.0
         with:
           action: codecov/codecov-action@v3
           with: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -72,7 +72,6 @@ jobs:
           source .venv-${{ matrix.combos.python_version }}/bin/activate
           python -m pip install --upgrade pip
           pip install -r devtools/dev-requirements.txt
-          pip install matplotlib==3.7.2
 
       - name: Set Swap Space
         if: env.has_changes == 'true'
@@ -84,7 +83,6 @@ jobs:
         if: env.has_changes == 'true'
         run: |
           source .venv-${{ matrix.combos.python_version }}/bin/activate
-          pip install matplotlib==3.7.2
           pwd
           lscpu
           python -m pytest -v -m unit \
@@ -113,7 +111,7 @@ jobs:
       - name: Upload coverage
         if: env.has_changes == 'true'
         id : codecov
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: Wandalen/wretry.action@v3.5.0
         with:
           action: codecov/codecov-action@v3
           with: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -113,7 +113,7 @@ jobs:
         id : codecov
         uses: Wandalen/wretry.action@v3.5.0
         with:
-          action: codecov/codecov-action@v3
+          action: codecov/codecov-action@v4
           with: |
             token: ${{ secrets.CODECOV_TOKEN }}
             name: codecov-umbrella


### PR DESCRIPTION
1. Bumps the `Wandalen/wretry.action` version to the latest to solve the Node.js version warning as mentioned in #843 
2. For `regression/unit` tests, we use specific `matplotlib` version, but we don't cache that version. If we instead cache that we can save time.
3. Bumps`codecov` version to `v4`