### PR TITLE
Add degenerate row check to factorize linear constraints

### DIFF
--- a/desc/objectives/utils.py
+++ b/desc/objectives/utils.py
@@ -97,7 +97,7 @@ def factorize_linear_constraints(objective, constraint, x_scale="auto"):  # noqa
     # which are duplicate rows of A that also have duplicate entries of b,
     # if the entries of b aren't the same then the constraints are actually
     # incompatible and so we will leave those to be caught later.
-    A_augmented = np.hstack(A, b)
+    A_augmented = np.hstack([A, np.reshape(b, (A.shape[0], 1))])
     row_idx_to_delete = np.array([], dtype=int)
     for row_idx in range(A_augmented.shape[0]):
         # find all rows equal to this row

--- a/desc/objectives/utils.py
+++ b/desc/objectives/utils.py
@@ -120,7 +120,7 @@ def factorize_linear_constraints(objective, constraint, x_scale="auto"):  # noqa
     # delete the affected rows, and also the corresponding rows of b
     A_augmented = np.delete(A_augmented, row_idx_to_delete, axis=0)
     A = A_augmented[:, :-1]
-    b = A_augmented[:, -1].squeeze()
+    b = np.atleast_1d(A_augmented[:, -1].squeeze())
 
     # will store the global index of the unfixed rows, idx
     indices_row = np.arange(A.shape[0])

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -179,7 +179,7 @@ def test_1d_optimization():
         ForceBalance(eq=eq),
         FixBoundaryR(eq=eq),
         FixBoundaryR(eq=eq, modes=[0, 0, 0]),  # add a degenerate constraint to confirm
-        # lsq-exact not affected by GH #1297
+        # proximal-lsq-exact not affected by GH #1297
         FixBoundaryZ(eq=eq, modes=eq.surface.Z_basis.modes[0:-1, :]),
         FixPressure(eq=eq),
         FixIota(eq=eq),
@@ -219,8 +219,6 @@ def run_qh_step(n, eq):
     constraints = (
         ForceBalance(eq=eq),
         FixBoundaryR(eq=eq, modes=R_modes),
-        FixBoundaryR(eq=eq, modes=[0, 0, 0]),  # add a degenerate constraint to confirm
-        # proximal-lsq-exact not affected by GH #1297
         FixBoundaryZ(eq=eq, modes=Z_modes),
         FixPressure(eq=eq),
         FixCurrent(eq=eq),
@@ -650,7 +648,7 @@ def test_multiobject_optimization_al():
         FixBoundaryR(eq, modes=[[0, 0, 0]]),
         FixBoundaryR(
             eq=eq, modes=[0, 0, 0]
-        ),  # add a degenerate constraint to test fix of GH #1297
+        ),  # add a degenerate constraint to test fix of GH #1297 for lsq-auglag
         PlasmaVesselDistance(surface=surf, eq=eq, target=1),
     )
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -178,6 +178,8 @@ def test_1d_optimization():
     constraints = (
         ForceBalance(eq=eq),
         FixBoundaryR(eq=eq),
+        FixBoundaryR(eq=eq, modes=[0, 0, 0]),  # add a degenerate constraint to confirm
+        # lsq-exact not affected by GH #1297
         FixBoundaryZ(eq=eq, modes=eq.surface.Z_basis.modes[0:-1, :]),
         FixPressure(eq=eq),
         FixIota(eq=eq),
@@ -217,6 +219,8 @@ def run_qh_step(n, eq):
     constraints = (
         ForceBalance(eq=eq),
         FixBoundaryR(eq=eq, modes=R_modes),
+        FixBoundaryR(eq=eq, modes=[0, 0, 0]),  # add a degenerate constraint to confirm
+        # proximal-lsq-exact not affected by GH #1297
         FixBoundaryZ(eq=eq, modes=Z_modes),
         FixPressure(eq=eq),
         FixCurrent(eq=eq),
@@ -644,6 +648,9 @@ def test_multiobject_optimization_al():
         FixParameters(surf, {"R_lmn": np.array([0]), "Z_lmn": np.array([3])}),
         FixParameters(eq, {"Psi": True, "i_l": True}),
         FixBoundaryR(eq, modes=[[0, 0, 0]]),
+        FixBoundaryR(
+            eq=eq, modes=[0, 0, 0]
+        ),  # add a degenerate constraint to test fix of GH #1297
         PlasmaVesselDistance(surface=surf, eq=eq, target=1),
     )
 

--- a/tests/test_linear_objectives.py
+++ b/tests/test_linear_objectives.py
@@ -205,6 +205,9 @@ def test_fixed_mode_solve():
         FixIota(eq=eq),
         FixPsi(eq=eq),
         FixBoundaryR(eq=eq),
+        FixBoundaryR(
+            eq=eq, modes=[0, 0, 0]
+        ),  # add a degenerate constraint to test fix of GH #1297 for lsq-exact
         FixBoundaryZ(eq=eq),
         fixR,
         fixZ,


### PR DESCRIPTION
Resolves #1297 

Though what I found is that having degenerate constraints (like fixing [0,0,0] of Rb_mn with FixBoundaryR while also fixing that mode + others with another FixBoundaryR constraint) is only an issue when doing `lsq-auglag` and `lsq-exact` (when ForceBalance is not a constraint), not for `proximal-lsq-exact`... basically for when we aren't removing the eq DOFs from the system to solve. I did not dig into the real root but just found that removing the degenerate rows of the constraint matrix `A` worked to fix it, probably something to do with how the particular solution is assigned when there are degenerate rows

 @YigitElma there is likely a better fix than the one I chose which was simply to remove degenerate rows before we get into the while loop which finds the simple constraints and adjusts A,b accordingly, if you want feel free to make changes here