### PR TITLE
Update matplotlib cache and tests

### DIFF
--- a/.github/workflows/mpl_tests.yml
+++ b/.github/workflows/mpl_tests.yml
@@ -45,6 +45,17 @@ jobs:
           - mpl-version: 3.7.0
           - mpl-version: 3.7.1
           - mpl-version: 3.7.2
+          - mpl-version: 3.7.3
+          - mpl-version: 3.7.4
+          - mpl-version: 3.7.5
+          - mpl-version: 3.8.0
+          - mpl-version: 3.8.1
+          - mpl-version: 3.8.2
+          - mpl-version: 3.8.3
+          - mpl-version: 3.8.4
+          - mpl-version: 3.9.0
+          - mpl-version: 3.9.2
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.10

--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -67,6 +67,7 @@ jobs:
           source .venv-${{ matrix.python-version }}/bin/activate
           python -m pip install --upgrade pip
           pip install -r devtools/dev-requirements.txt
+          pip install matplotlib==3.7.2
 
       - name: Test notebooks with pytest and nbmake
         if: env.has_changes == 'true'

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -66,6 +66,7 @@ jobs:
           source .venv-${{ matrix.python-version }}/bin/activate
           python -m pip install --upgrade pip
           pip install -r devtools/dev-requirements.txt
+          pip install matplotlib==3.7.2
 
       - name: Set Swap Space
         if: env.has_changes == 'true'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -72,6 +72,7 @@ jobs:
           source .venv-${{ matrix.combos.python_version }}/bin/activate
           python -m pip install --upgrade pip
           pip install -r devtools/dev-requirements.txt
+          pip install matplotlib==3.7.2
 
       - name: Set Swap Space
         if: env.has_changes == 'true'

--- a/desc/plotting.py
+++ b/desc/plotting.py
@@ -110,7 +110,7 @@ _AXIS_LABELS_XYZ = [r"$X ~(\mathrm{m})$", r"$Y ~(\mathrm{m})$", r"$Z ~(\mathrm{m
 
 def _set_tight_layout(fig):
     # compat layer to deal with API changes in mpl 3.6.0
-    if int(matplotlib._version.version.split(".")[1]) < 6:
+    if int(matplotlib.__version__[0]) == 3 and int(matplotlib.__version__[2]) < 6:
         fig.set_tight_layout(True)
     else:
         fig.set_layout_engine("tight")
@@ -118,7 +118,7 @@ def _set_tight_layout(fig):
 
 def _get_cmap(name, n=None):
     # compat layer to deal with API changes in mpl 3.6.0
-    if int(matplotlib._version.version.split(".")[1]) < 6:
+    if int(matplotlib.__version__[0]) == 3 and int(matplotlib.__version__[2]) < 6:
         return matplotlib.cm.get_cmap(name, n)
     else:
         c = matplotlib.colormaps[name]


### PR DESCRIPTION
- Adds more recent versions of matplotlib to `test_mpl`
- In case there is no cached dependency, `Set up virtual environment if not restored from cache` step was installing latest matplotlib version. This PR fixes that
- Older versions were throwing error on `int(matplotlib._version.version.split(".")[1])`, this fixes the syntax