### PR TITLE
Fix bug in PlasmaVesselDistance signed distance error checks 

### DIFF
--- a/desc/objectives/_geometry.py
+++ b/desc/objectives/_geometry.py
@@ -616,6 +616,18 @@ class PlasmaVesselDistance(_Objective):
         )
 
         # TODO: How to use with generalized toroidal angle?
+        # first check that the number of zeta nodes are the same, which
+        # is a prerequisite to the zeta nodes themselves being the same
+        errorif(
+            self._use_signed_distance
+            and not np.allclose(
+                plasma_grid.num_zeta,
+                surface_grid.num_zeta,
+            ),
+            ValueError,
+            "Plasma grid and surface grid must contain points only at the "
+            "same zeta values in order to use signed distance",
+        )
         errorif(
             self._use_signed_distance
             and not np.allclose(

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -1300,6 +1300,28 @@ class TestObjectiveFunction:
         assert abs(d.max() - (-a_s)) < 1e-14
         assert abs(d.min() - (-a_s)) < grid.spacing[0, 1] * a_s
 
+        # test errors
+        # differing grid zetas, same num_zeta
+        with pytest.raises(ValueError):
+            obj = PlasmaVesselDistance(
+                eq=eq,
+                surface_grid=grid,
+                plasma_grid=LinearGrid(M=grid.M, N=grid.N, NFP=2),
+                surface=surface,
+                use_signed_distance=True,
+            )
+            obj.build()
+        # test with differing grid.num_zeta
+        with pytest.raises(ValueError):
+            obj = PlasmaVesselDistance(
+                eq=eq,
+                surface_grid=grid,
+                plasma_grid=LinearGrid(M=grid.M, N=grid.N - 2),
+                surface=surface,
+                use_signed_distance=True,
+            )
+            obj.build()
+
 
 @pytest.mark.regression
 def test_derivative_modes():


### PR DESCRIPTION
when the grids have differing number of zeta points,  np.allclose errors out instead of the correct error passing. This fixes the bug