### PR TITLE
Add support for benchmark test from forks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - master
+  pull_request_target:
+    types: [opened, synchronize]
   workflow_dispatch:
     inputs:
       debug_enabled:


### PR DESCRIPTION
Benchmark action requires write access for commenting which forks don't have. This change makes the benchmark workflow coming from a fork run on our CI and thus have proper access. 

This shouldn't change the general permissions for fork repos, so someone in the DESC team must still approve to test to run for such PRs.

https://github.com/thollander/actions-comment-pull-request?tab=readme-ov-file#permissions

- [ ] Make sure this is secure! Check from a fork repo!