### PR TITLE
Add action for checking changelog updates

### DIFF
--- a/.github/workflows/changelog_update.yml
+++ b/.github/workflows/changelog_update.yml
@@ -1,0 +1,19 @@
+name: Check changelog updated
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  check_changelog_updated:
+    if: ${{contains(github.event.pull_request.labels.*.name, 'skip_changelog') == false}}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: danieljimeneznz/ensure-files-changed@v4.1.0
+        with:
+          require-changes-to: |
+            CHANGELOG.md
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog_update.yml
+++ b/.github/workflows/changelog_update.yml
@@ -7,9 +7,26 @@ on:
   workflow_dispatch:
 
 jobs:
-  check_changelog_updated:
-    if: contains(github.event.pull_request.labels.*.name, 'skip_changelog') == false
+  get_labels:
     runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.step1.outputs.labels }}
+    steps:
+      - id: step1
+        run: |
+          labels="$(gh api repos/$OWNER/$REPO_NAME/pulls/$PULL_REQUEST_NUMBER --jq '.labels.[].name')"
+          echo "$labels"
+          echo "$labels" >> "$GITHUB_OUTPUT"
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+  check_changelog_updated:
+    runs-on: ubuntu-latest
+    needs: get_labels
+    if: contains(${{needs.get_labels.outputs.labels}}, 'skip_changelog') == false
     steps:
       - uses: actions/checkout@v4
       - uses: danieljimeneznz/ensure-files-changed@v4.1.0

--- a/.github/workflows/changelog_update.yml
+++ b/.github/workflows/changelog_update.yml
@@ -4,29 +4,12 @@ on:
   pull_request:
     branches:
       - master
-  workflow_dispatch:
+    types: [opened, synchronize, labeled, unlabeled]
 
 jobs:
-  get_labels:
-    runs-on: ubuntu-latest
-    outputs:
-      labels: ${{ steps.step1.outputs.labels }}
-    steps:
-      - id: step1
-        run: |
-          labels="$(gh api repos/$OWNER/$REPO_NAME/pulls/$PULL_REQUEST_NUMBER --jq '.labels.[].name')"
-          echo "$labels"
-          echo "$labels" >> "$GITHUB_OUTPUT"
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          REPO_NAME: ${{ github.event.repository.name }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
   check_changelog_updated:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip_changelog') }}
     runs-on: ubuntu-latest
-    needs: get_labels
-    if: contains(${{needs.get_labels.outputs.labels}}, 'skip_changelog') == false
     steps:
       - uses: actions/checkout@v4
       - uses: danieljimeneznz/ensure-files-changed@v4.1.0

--- a/.github/workflows/changelog_update.yml
+++ b/.github/workflows/changelog_update.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check_changelog_updated:
-    if: ${{contains(github.event.pull_request.labels.*.name, 'skip_changelog') == false}}
+    if: contains(github.event.pull_request.labels.*.name, 'skip_changelog') == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/changelog_update.yml
+++ b/.github/workflows/changelog_update.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   check_changelog_updated:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip_changelog') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: danieljimeneznz/ensure-files-changed@v4.1.0
+      - if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip_changelog') }}
+        uses: danieljimeneznz/ensure-files-changed@v4.1.0
         with:
           require-changes-to: |
             CHANGELOG.md

--- a/.github/workflows/changelog_update.yml
+++ b/.github/workflows/changelog_update.yml
@@ -10,8 +10,24 @@ jobs:
   check_changelog_updated:
     runs-on: ubuntu-latest
     steps:
+      - name: Filter changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            has_changes:
+              - 'desc/**'
+              - 'requirements.txt'
+              - 'requirements_conda.yml'
+              - '.github/workflows/changelog_update.yml'
+
+      - name: Check for relevant changes
+        id: check_changes
+        run: echo "has_changes=${{ steps.changes.outputs.has_changes }}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
-      - if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip_changelog') }}
+
+      - if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip_changelog') && env.has_changes == 'true'}}
         uses: danieljimeneznz/ensure-files-changed@v4.1.0
         with:
           require-changes-to: |


### PR DESCRIPTION
Adds a GH action that ensures `CHANGELOG.md` is updated with each PR, unless the PR is labelled `skip_changelog`

Resolves #1340 