### PR TITLE
Make scipy requirement uniform across requirements files

### DIFF
--- a/devtools/dev-requirements_conda.yml
+++ b/devtools/dev-requirements_conda.yml
@@ -9,7 +9,7 @@ dependencies:
   - netcdf4 >= 1.5.4, < 2.0
   - numpy >= 1.20.0
   - psutil
-  - scipy >= 1.7.0, < 2.0
+  - scipy >= 1.7.0
   - termcolor
   - pip
   - pip:

--- a/requirements_conda.yml
+++ b/requirements_conda.yml
@@ -9,7 +9,7 @@ dependencies:
   - netcdf4 >= 1.5.4, < 2.0
   - numpy >= 1.20.0
   - psutil
-  - scipy >= 1.7.0, < 2.0
+  - scipy >= 1.7.0
   - termcolor
   - pip
   - pip:


### PR DESCRIPTION
This was overlooked in #1319 , I think, which changed the scipy requirement to remove the `<2.0` in `requirements.txt` but not anywhere else