### PR TITLE
Add dependabot config to manage dependency versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,6 +82,7 @@ jobs:
           source .venv-${{ matrix.python-version }}/bin/activate
           pwd
           lscpu
+          pip list
           cd tests/benchmarks
           python -m pytest benchmark_cpu_small.py -vv \
             --benchmark-save='Latest_Commit' \
@@ -108,6 +109,7 @@ jobs:
           source .venv-${{ matrix.python-version }}/bin/activate
           pwd
           lscpu
+          pip list
           cd tests/benchmarks
           python -m pytest benchmark_cpu_small.py -vv \
             --benchmark-save='master' \

--- a/.github/workflows/jax_tests.yml
+++ b/.github/workflows/jax_tests.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           pwd
           lscpu
+          pip list
           python -m pytest -m unit \
             --durations=0 \
             --mpl \

--- a/.github/workflows/mpl_tests.yml
+++ b/.github/workflows/mpl_tests.yml
@@ -72,4 +72,5 @@ jobs:
         run: |
           pwd
           lscpu
+          pip list
           python -m pytest tests/test_plotting.py --durations=0 --mpl --maxfail=1

--- a/.github/workflows/notebook_tests.yml
+++ b/.github/workflows/notebook_tests.yml
@@ -75,6 +75,7 @@ jobs:
           source .venv-${{ matrix.python-version }}/bin/activate
           pwd
           lscpu
+          pip list
           export PYTHONPATH=$(pwd)
           pytest -v --nbmake "./docs/notebooks" \
             --nbmake-timeout=2000 \

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -80,6 +80,7 @@ jobs:
           source .venv-${{ matrix.python-version }}/bin/activate
           pwd
           lscpu
+          pip list
           python -m pytest -v -m regression\
             --durations=0 \
             --cov-report xml:cov.xml \

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -86,6 +86,7 @@ jobs:
           source .venv-${{ matrix.combos.python_version }}/bin/activate
           pwd
           lscpu
+          pip list
           python -m pytest -v -m unit \
             --durations=0 \
             --cov-report xml:cov.xml \

--- a/.github/workflows/weekly_tests.yml
+++ b/.github/workflows/weekly_tests.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           pwd
           lscpu
+          pip list
           python -m pytest -v -m unit \
             --durations=0 \
             --splits 4 \

--- a/devtools/dev-requirements_conda.yml
+++ b/devtools/dev-requirements_conda.yml
@@ -2,28 +2,10 @@ name: desc-env
 channels:
   - conda-forge
 dependencies:
-  - colorama
-  - h5py >= 3.0.0, < 4.0
-  - matplotlib >= 3.5.0, < 4.0.0
-  - mpmath >= 1.0.0, < 2.0
-  - netcdf4 >= 1.5.4, < 2.0
-  - numpy >= 1.20.0
-  - psutil
-  - scipy >= 1.7.0
-  - termcolor
   - pip
   - pip:
     # Conda only parses a single list of pip requirements.
     # If two pip lists are given, all but the last list is skipped.
-    - jax >= 0.4.24, <= 0.4.35
-    - diffrax >= 0.4.1
-    - interpax >= 0.3.3
-    - nvgpu
-    - orthax
-    - plotly >= 5.16, < 6.0
-    - pylatexenc >= 2.0, < 3.0
-    - quadax >= 0.2.2
-    - scikit-image
     # building the docs
     - sphinx-github-style >= 1.0, < 2.0
     # testing and benchmarking

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,7 +55,7 @@ Option 2: Using conda to install packages (this will only install DESC + JAX wit
 .. code-block:: sh
 
     conda env create --file requirements_conda.yml
-    # option B: with developer requirements (if you want to run tests)
+    # optionally: install developer requirements (if you want to run tests)
     conda install --file devtools/dev-requirements_conda.yml
 
     # to add DESC to your Python path

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -54,11 +54,9 @@ Option 2: Using conda to install packages (this will only install DESC + JAX wit
 
 .. code-block:: sh
 
-    # only need to do one of these conda env create commands, not both
-    # option A: without developer requirements
     conda env create --file requirements_conda.yml
     # option B: with developer requirements (if you want to run tests)
-    conda env create --file devtools/dev-requirements_conda.yml
+    conda install --file devtools/dev-requirements_conda.yml
 
     # to add DESC to your Python path
     conda activate desc-env

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,18 @@
 jax >= 0.4.24, <= 0.4.35
-colorama
-diffrax >= 0.4.1
-h5py >= 3.0.0, < 4.0
-interpax >= 0.3.3
-matplotlib >= 3.5.0, < 4.0.0
-mpmath >= 1.0.0, < 2.0
-netcdf4 >= 1.5.4, < 2.0
-numpy >= 1.20.0
-nvgpu
-orthax
-plotly >= 5.16, < 6.0
-psutil
-pylatexenc >= 2.0, < 3.0
-quadax >= 0.2.2
-scikit-image
-scipy >= 1.7.0
-termcolor
+colorama <= 0.4.6
+diffrax >= 0.4.1, <= 0.6.0
+h5py >= 3.0.0, <= 3.12.1
+interpax >= 0.3.3, <= 0.3.4
+matplotlib >= 3.5.0, <= 3.9.3
+mpmath >= 1.0.0, <= 1.3.0
+netcdf4 >= 1.5.4, <= 1.7.2
+numpy >= 1.20.0, <= 2.1.3
+nvgpu <= 0.10.0
+orthax <= 0.2.1
+plotly >= 5.16, <= 5.24.1
+psutil <= 6.1.0
+pylatexenc >= 2.0, <= 2.10
+quadax >= 0.2.2, <= 0.2.4
+scikit-image <= 0.24.0
+scipy >= 1.7.0, <= 1.14.1
+termcolor <= 2.5.0

--- a/requirements_conda.yml
+++ b/requirements_conda.yml
@@ -1,25 +1,25 @@
 name: desc-env
 dependencies:
   # standard install
-  - colorama
-  - diffrax >= 0.4.1
-  - h5py >= 3.0.0, < 4.0
-  - matplotlib >= 3.5.0, < 4.0.0
-  - mpmath >= 1.0.0, < 2.0
-  - netcdf4 >= 1.5.4, < 2.0
-  - numpy >= 1.20.0
-  - psutil
-  - scipy >= 1.7.0
-  - termcolor
+  - colorama <= 0.4.6
+  - diffrax >= 0.4.1, <= 0.6.0
+  - h5py >= 3.0.0, <= 3.12.1
+  - matplotlib >= 3.5.0, <= 3.9.3
+  - mpmath >= 1.0.0, <= 1.3.0
+  - netcdf4 >= 1.5.4, <= 1.7.2
+  - numpy >= 1.20.0, <= 2.1.3
+  - psutil <= 6.1.0
+  - scipy >= 1.7.0, <= 1.14.1
+  - termcolor <= 2.5.0
   - pip
   - pip:
     # Conda only parses a single list of pip requirements.
     # If two pip lists are given, all but the last list is skipped.
     - jax >= 0.4.24, <= 0.4.35
-    - interpax >= 0.3.3
-    - nvgpu
-    - orthax
-    - plotly >= 5.16, < 6.0
-    - pylatexenc >= 2.0, < 3.0
-    - quadax >= 0.2.2
-    - scikit-image
+    - interpax >= 0.3.3, <= 0.3.4
+    - nvgpu <= 0.10.0
+    - orthax <= 0.2.1
+    - plotly >= 5.16, <= 5.24.1
+    - pylatexenc >= 2.0, <= 2.10
+    - quadax >= 0.2.2, <= 0.2.4
+    - scikit-image <= 0.24.0


### PR DESCRIPTION
Rather than us having to manually check compatible versions and update things accordingly, this PR pins the maximum versions of our dependencies to their current version, and enables githubs [dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) to regularly update the requirements file. 

Right now its set to check for new versions every monday and automatically opens a PR to update `requirements.txt` if new versions are available. This will then trigger our regular CI so we can see if the new version works correctly, and make any necessary fixes if not before merging.

Note this only pins the main requirements, not dev-requirements, which I figured we don't need to keep up to date as rigorously so we can manage that ourselves.