### PR TITLE
Set preferred coordinate direction for conversion from points to FourierPlanarCurve

### DIFF
--- a/desc/geometry/curve.py
+++ b/desc/geometry/curve.py
@@ -806,10 +806,10 @@ class FourierPlanarCurve(Curve):
 
         # center
         center = np.mean(coords, axis=0)
-        coords = coords - center  # shift to origin
+        coords_centered = coords - center  # shift to origin
 
         # normal
-        U, _, _ = np.linalg.svd(coords.T)
+        U, _, _ = np.linalg.svd(coords_centered.T)
         normal = U[:, -1].T  # left singular vector of the least singular value
 
         # axis and angle of rotation
@@ -817,17 +817,30 @@ class FourierPlanarCurve(Curve):
         axis = np.cross(Z_axis, normal)
         angle = np.arccos(np.dot(Z_axis, normal))
         rotmat = rotation_matrix(axis, angle)
-        coords = coords @ rotmat  # rotate to X-Y plane
+        coords_rotated = coords_centered @ rotmat  # rotate to X-Y plane
 
         warnif(
-            np.max(np.abs(coords[:, 2])) > 1e-14,  # check that Z=0 for all points
+            np.max(np.abs(coords_rotated[:, 2])) > 1e-14,  # check that Z=0 for all points
             UserWarning,
             "Curve values are not planar! Using the projection onto a plane.",
         )
 
+        # polar angle
+        s = np.arctan2(coords_rotated[:, 1], coords_rotated[:, 0])
+        unwrapped_s = np.unwrap(s)
+        curve_sign = np.sign(unwrapped_s[-1] - unwrapped_s[0])
+
+        if curve_sign == -1: #original curve was parameterized "backwards" (clockwise) compared to FourierPlanarCurve assumption
+            normal = -normal # flip normal vector direction
+            axis = np.cross(Z_axis, normal)
+            angle = np.arccos(np.dot(Z_axis, normal))
+
+            rotmat = rotation_matrix(axis, angle)
+            coords_rotated = coords_centered @ rotmat  # rotate to X-Y plane
+
         # polar radius and angle
-        r = np.sqrt(coords[:, 0] ** 2 + coords[:, 1] ** 2)
-        s = np.arctan2(coords[:, 1], coords[:, 0])
+        r = np.sqrt(coords_rotated[:, 0] ** 2 + coords_rotated[:, 1] ** 2)
+        s = np.arctan2(coords_rotated[:, 1], coords_rotated[:, 0])
         s = np.mod(s + 2 * np.pi, 2 * np.pi)  # mod angle to range [0, 2*pi)
         idx = np.argsort(s)  # sort angle to be monotonically increasing
         r = r[idx]

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -657,6 +657,56 @@ class TestFourierPlanarCurve:
         with pytest.raises(AssertionError):
             _ = FourierPlanarCurve(r_n=[1], modes=[1, 2])
 
+    @pytest.mark.unit
+    def test_to_FourierPlanarCurve(self):
+        """Test converting SplineXYZCurve to FourierPlanarCurve object."""
+        npts = 1000
+        N = 5
+
+        # Create a SplineXYZCurve of a planar circle
+        s = np.linspace(0, 2 * np.pi, npts)
+        X = 2 * np.cos(s)
+        Y = np.ones(npts)
+        Z = 2 * np.sin(s)
+        c = SplineXYZCurve(X=X, Y=Y, Z=Z)
+
+        # Create a backwards SplineXYZCurve by flipping the coordinates
+        c_backwards = SplineXYZCurve(
+            X=np.flip(X),
+            Y=np.flip(Y),
+            Z=np.flip(Z),
+        )
+
+        # Convert to FourierPlanarCurve
+        c_planar = c.to_FourierPlanar(N=N, grid=npts, basis="xyz")
+        c_backwards_planar = c_backwards.to_FourierPlanar(N=N, grid=npts, basis="xyz")
+
+        grid = LinearGrid(N=20, endpoint=True)
+
+        coords_spline = c.compute("x", grid=grid)["x"]
+        coords_planar = c_planar.compute("x", grid=grid)["x"]
+        coords_backwards_spline = c_backwards.compute("x", grid=grid)["x"]
+        coords_backwards_planar = c_backwards_planar.compute("x", grid=grid)["x"]
+
+        # Assertions for point positions
+        np.testing.assert_allclose(coords_spline, coords_planar, atol=1e-10)
+        np.testing.assert_allclose(
+            coords_backwards_spline,
+            coords_backwards_planar,
+            atol=1e-10,
+        )
+        # backwards coordinate order is import for Biot-Savart implicit current direction
+        np.testing.assert_allclose(
+            coords_planar, np.flip(coords_backwards_planar, axis=0), atol=1e-10
+        )
+
+        # Verify that the normal vectors are in opposite directions
+        np.testing.assert_allclose(
+            (c_planar.normal / c_backwards_planar.normal)[1],
+            np.array([-1]),
+            atol=1e-10,
+        )
+
 
 class TestSplineXYZCurve:
     """Tests for SplineXYZCurve class."""


### PR DESCRIPTION
Previously, the `from_values()` method in `FourierPlanarCurve` would convert the coords provided to an r(s) representation with s sorted to be monotonically increasing (counterclockwise). However, this means that if the original coordinates were parameterized "backwards" (clockwise), the new `FourierPlanarCurve` would return coordinates in a reversed order, which is problematic if you are trying to run something like a Biot Savart integral where the coordinate order is the implicit current direction in the loop. This PR fixes the issue by flipping the normal vector of the `FourierPlanarCurve` when the provided coordinates are in the clockwise direction. 