### PR TITLE
Add `wb` and `wp` to `VMECIO.save`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ New Feature
 - Adds an option ``scaled_termination`` (defaults to True) to all of the desc optimizers to measure the norms for ``xtol`` and ``gtol`` in the scaled norm provided by ``x_scale`` (which defaults to using an adaptive scaling based on the Jacobian or Hessian). This should make things more robust when optimizing parameters with widely different magnitudes. The old behavior can be recovered by passing ``options={"scaled_termination": False}``.
 - ``desc.objectives.Omnigenity`` is now vectorized and able to optimize multiple surfaces at the same time. Previously it was required to use a different objective for each surface.
 - Adds a new objective ``desc.objectives.MirrorRatio`` for targeting a particular mirror ratio on each flux surface, for either an ``Equilibrium`` or ``OmnigenousField``.
+- Adds the output quantities ``wb`` and ``wp`` to ``VMECIO.save``.
 
 Bug Fixes
 

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -289,7 +289,16 @@ class VMECIO:
         grid_full = LinearGrid(M=M_nyq, N=N_nyq, NFP=NFP, rho=r_full)
 
         data_quad = eq.compute(
-            ["R0/a", "V", "<|B|>_rms", "<beta>_vol", "<beta_pol>_vol", "<beta_tor>_vol"]
+            [
+                "R0/a",
+                "V",
+                "W_B",
+                "W_p",
+                "<|B|>_rms",
+                "<beta>_vol",
+                "<beta_pol>_vol",
+                "<beta_tor>_vol",
+            ]
         )
         data_axis = eq.compute(["G", "p", "R", "<|B|^2>", "<|B|>"], grid=grid_axis)
         data_lcfs = eq.compute(["G", "I", "R", "Z"], grid=grid_lcfs)
@@ -501,6 +510,16 @@ class VMECIO:
         betator.long_name = "normalized toroidal plasma pressure"
         betator.units = "None"
         betator[:] = data_quad["<beta_tor>_vol"]
+
+        wb = file.createVariable("wb", np.float64)
+        wb.long_name = "plasma magnetic energy * mu_0/(4*pi^2)"
+        wb.units = "J^2/A^2"
+        wb[:] = data_quad["W_B"] * mu_0 / (4 * np.pi**2)
+
+        wp = file.createVariable("wp", np.float64)
+        wp.long_name = "plasma thermodynamic energy * mu_0/(4*pi^2)"
+        wp.units = "J^2/A^2"
+        wp[:] = np.abs(data_quad["W_p"]) * mu_0 / (4 * np.pi**2)
 
         # scalars computed at the magnetic axis
 
@@ -1338,16 +1357,8 @@ class VMECIO:
         specw = file.createVariable("specw", np.float64, ("radius",))
         specw[:] = np.zeros((file.dimensions["radius"].size,))
 
-        # this is not the same as DESC's "W_B"
-        wb = file.createVariable("wb", np.float64)
-        wb[:] = 0.0
-
         wdot = file.createVariable("wdot", np.float64, ("time",))
         wdot[:] = np.zeros((file.dimensions["time"].size,))
-
-        # this is not the same as DESC's "W_p"
-        wp = file.createVariable("wp", np.float64)
-        wp[:] = 0.0
         """
 
         file.close()

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -513,12 +513,12 @@ class VMECIO:
 
         wb = file.createVariable("wb", np.float64)
         wb.long_name = "plasma magnetic energy * mu_0/(4*pi^2)"
-        wb.units = "J^2/A^2"
+        wb.units = "T^2*m^3"
         wb[:] = data_quad["W_B"] * mu_0 / (4 * np.pi**2)
 
         wp = file.createVariable("wp", np.float64)
         wp.long_name = "plasma thermodynamic energy * mu_0/(4*pi^2)"
-        wp.units = "J^2/A^2"
+        wp.units = "T^2*m^3"
         wp[:] = np.abs(data_quad["W_p"]) * mu_0 / (4 * np.pi**2)
 
         # scalars computed at the magnetic axis

--- a/tests/test_vmec.py
+++ b/tests/test_vmec.py
@@ -496,6 +496,10 @@ def test_vmec_save_1(VMEC_save):
     np.testing.assert_allclose(
         vmec.variables["betator"][:], desc.variables["betator"][:], rtol=1e-5
     )
+    np.testing.assert_allclose(vmec.variables["wb"][:], desc.variables["wb"][:])
+    np.testing.assert_allclose(
+        vmec.variables["wp"][:], desc.variables["wp"][:], rtol=1e-6
+    )
     np.testing.assert_allclose(
         vmec.variables["ctor"][:], desc.variables["ctor"][:], rtol=1e-5
     )


### PR DESCRIPTION
Adds two additional quantities to the VMEC "wout" output. They are normalized versions of our `"W_B"` and `"W_p"` compute quantities. 