### PR TITLE
Change normalization of force balance to use correct units

### DIFF
--- a/desc/objectives/_equilibrium.py
+++ b/desc/objectives/_equilibrium.py
@@ -130,7 +130,7 @@ class ForceBalance(_Objective):
 
         if self._normalize:
             scales = compute_scaling_factors(eq)
-            self._normalization = scales["f"]
+            self._normalization = scales["F"]
 
         super().build(use_jit=use_jit, verbose=verbose)
 
@@ -279,7 +279,7 @@ class ForceBalanceAnisotropic(_Objective):
 
         if self._normalize:
             scales = compute_scaling_factors(eq)
-            self._normalization = scales["f"]
+            self._normalization = scales["F"]
 
         super().build(use_jit=use_jit, verbose=verbose)
 
@@ -416,7 +416,7 @@ class RadialForceBalance(_Objective):
 
         if self._normalize:
             scales = compute_scaling_factors(eq)
-            self._normalization = scales["f"]
+            self._normalization = scales["F"]
 
         super().build(use_jit=use_jit, verbose=verbose)
 
@@ -553,7 +553,7 @@ class HelicalForceBalance(_Objective):
 
         if self._normalize:
             scales = compute_scaling_factors(eq)
-            self._normalization = scales["f"]
+            self._normalization = scales["F"]
 
         super().build(use_jit=use_jit, verbose=verbose)
 


### PR DESCRIPTION
Currently we use `scales["f"]` for normalizing the force balance objectives, but they have units of Newton, not Newton per meter cubed, so this normalization technically is wrong.

- [ ] change weights for qh opt test
- [ ] rerun notebooks