### PR TITLE
Some improvements to distance calculation objectives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ New Features
 - Changes hessian computation to use chunked ``jacfwd`` and ``jacrev``, allowing ``jac_chunk_size`` to now reduce hessian memory usage as well.
 - Adds an option to ``VMECIO.save`` to specify the grid resolution in real space.
 - Adds a new objective ``desc.objectives.CoilIntegratedCurvature`` for targeting convex coils.
+- ``desc.objectives.CoilSetMinDistance`` and ``desc.objectives.PlasmaCoilSetMinDistance`` now include the option to use a softmin which can give smoother gradients. They also both now have a ``dist_chunk_size`` option to break up the distance calculation into smaller pieces to save memory
+
 
 Bug Fixes
 
@@ -25,6 +27,8 @@ Bug Fixes
 - Fixed I/O bug when saving/loading ``_Profile`` classes that do not have a ``_params`` attribute.
 - Minor bugs described in [#1323](https://github.com/PlasmaControl/DESC/pull/1323).
 - Corrects basis vectors computations made on surface objects [#1175](https://github.com/PlasmaControl/DESC/pull/1175).
+- ``desc.objectives.PlasmaVesselDistance`` now correctly accounts for multiple field periods on both the equilibrium and the vessel surface. Previously it only considered distances within a single field period.
+
 
 v0.13.0
 -------

--- a/desc/compute/geom_utils.py
+++ b/desc/compute/geom_utils.py
@@ -161,3 +161,12 @@ def rpz2xyz_vec(vec, x=None, y=None, phi=None):
         return cart
 
     return inner(vec, phi)
+
+
+def copy_rpz_periods(rpz, NFP):
+    """Copy a rpz position vector into multiple field periods."""
+    r, p, z = rpz.T
+    r = jnp.tile(r, NFP)
+    z = jnp.tile(z, NFP)
+    p = p[None, :] + jnp.linspace(0, 2 * jnp.pi, NFP, endpoint=False)[:, None]
+    return jnp.array([r, p.flatten(), z]).T

--- a/desc/objectives/_geometry.py
+++ b/desc/objectives/_geometry.py
@@ -462,13 +462,6 @@ class PlasmaVesselDistance(_Objective):
     points on surface corresponding to the grid that the plasma-vessel distance
     is evaluated at, which can cause cusps or regions of very large curvature.
 
-    NOTE: When use_softmin=True, ensures that softmin_alpha*values passed in is
-    at least >1, otherwise the softmin will return inaccurate approximations
-    of the minimum. Will automatically multiply array values by 2 / min_val if the min
-    of softmin_alpha*array is <1. This is to avoid inaccuracies when values <1
-    are present in the softmin, which can cause inaccurate mins or even incorrect
-    signs of the softmin versus the actual min.
-
     Parameters
     ----------
     eq : Equilibrium

--- a/desc/objectives/_geometry.py
+++ b/desc/objectives/_geometry.py
@@ -3,7 +3,8 @@
 import numpy as np
 
 from desc.backend import jnp, vmap
-from desc.compute import get_profiles, get_transforms, rpz2xyz, xyz2rpz
+from desc.compute import get_profiles, get_transforms, rpz2xyz
+from desc.compute.geom_utils import copy_rpz_periods
 from desc.compute.utils import _compute as compute_fun
 from desc.grid import LinearGrid, QuadratureGrid
 from desc.utils import Timer, errorif, parse_argname_change, safenorm, warnif
@@ -688,7 +689,6 @@ class PlasmaVesselDistance(_Objective):
                 transforms=surface_transforms,
                 profiles={},
             )["x"]
-            surface_coords = rpz2xyz(surface_coords)
             self._constants["surface_coords"] = surface_coords
         elif self._eq_fixed:
             data_eq = compute_fun(
@@ -750,26 +750,30 @@ class PlasmaVesselDistance(_Objective):
         else:
             data = constants["data_equil"]
         plasma_coords_rpz = jnp.array([data["R"], data["phi"], data["Z"]]).T
-        plasma_coords = rpz2xyz(plasma_coords_rpz)
+        # we only copy the plasma data to the full torus, so that we still only
+        # consider a single period of the surface.
+        plasma_coords_nfp = copy_rpz_periods(
+            plasma_coords_rpz, constants["equil_transforms"]["grid"].NFP
+        )
+        plasma_coords = rpz2xyz(plasma_coords_nfp)
         if self._surface_fixed:
-            surface_coords = constants["surface_coords"]
+            surface_coords_rpz = constants["surface_coords"]
         else:
-            surface_coords = compute_fun(
+            surface_coords_rpz = compute_fun(
                 self._surface,
                 self._surface_data_keys,
                 params=surface_params,
                 transforms=constants["surface_transforms"],
                 profiles={},
             )["x"]
-            surface_coords = rpz2xyz(surface_coords)
+        surface_coords = rpz2xyz(surface_coords_rpz)
 
         diff_vec = plasma_coords[:, None, :] - surface_coords[None, :, :]
         d = safenorm(diff_vec, axis=-1)
 
         point_signs = jnp.ones(surface_coords.shape[0])
         if self._use_signed_distance:
-            surface_coords_rpz = xyz2rpz(surface_coords)
-
+            # for sign, we ignore other periods since the sign will be the same in each
             plasma_coords_rpz = plasma_coords_rpz.reshape(
                 constants["equil_transforms"]["grid"].num_zeta,
                 constants["equil_transforms"]["grid"].num_theta,

--- a/desc/objectives/utils.py
+++ b/desc/objectives/utils.py
@@ -285,6 +285,7 @@ def softmax(arr, alpha):
         The soft-maximum of the array.
 
     """
+    arr = arr.flatten()
     arr_times_alpha = alpha * arr
     return softargmax(arr_times_alpha).dot(arr)
 

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -1094,6 +1094,25 @@ class TestObjectiveFunction:
                 f = obj.compute(params_1=eq.params_dict, params_2=coils.params_dict)
             assert f.size == coils.num_coils
             np.testing.assert_allclose(f, mindist)
+            obj2 = PlasmaCoilSetMinDistance(
+                eq=eq,
+                coil=coils,
+                plasma_grid=plasma_grid,
+                coil_grid=coil_grid,
+                eq_fixed=eq_fixed,
+                coils_fixed=coils_fixed,
+                use_softmin=True,
+                softmin_alpha=40,
+            )
+            obj2.build()
+            if eq_fixed:
+                f = obj2.compute(params_1=coils.params_dict)
+            elif coils_fixed:
+                f = obj2.compute(params_1=eq.params_dict)
+            else:
+                f = obj2.compute(params_1=eq.params_dict, params_2=coils.params_dict)
+            assert f.size == coils.num_coils
+            np.testing.assert_allclose(f, mindist, rtol=5e-2, atol=1e-3)
 
         plasma_grid = LinearGrid(M=4, zeta=16)
         coil_grid = LinearGrid(N=8)

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -998,6 +998,13 @@ class TestObjectiveFunction:
             assert f.size == coils.num_coils
             np.testing.assert_allclose(f, mindist)
             assert coils.is_self_intersecting(grid=grid, tol=tol) == expect_intersect
+            obj2 = CoilSetMinDistance(
+                coils, grid=grid, use_softmin=True, softmin_alpha=10
+            )
+            obj2.build()
+            f = obj2.compute(params=coils.params_dict)
+            assert f.size == coils.num_coils
+            np.testing.assert_allclose(f, mindist, rtol=5e-2, atol=1e-3)
 
         # linearly spaced planar coils, all coils are min distance from their neighbors
         n = 3


### PR DESCRIPTION
- Uses full torus when measuring distance in `PlasmaVesselDistance`, rather than just a single field period
- Adds option to use softmin to `CoilSetMinDistance` and `PlasmaCoilSetMinDistance`
- Adds `dist_chunk_size` to `CoilSetMinDistance` and `PlasmaCoilSetMinDistance` for breaking the distance calculations into smaller pieces (or really larger pieces since previously it used a loop so chunk_size=1). Default is no chunking which will generally be fastest, and the memory requirements shouldn't be too bad since the coils are just 1d.

Resolves #652 
Resolves #1063 
Resolves #1064 
