### PR TITLE
Improve warning for grids with missing quadrature weights

### DIFF
--- a/desc/grid.py
+++ b/desc/grid.py
@@ -442,7 +442,13 @@ class _Grid(IOAble, ABC):
         errorif(
             self._spacing is None,
             AttributeError,
-            "Custom grids must have spacing specified by user.",
+            "Custom grids must have spacing specified by user.\n"
+            "Recall that the accurate computation of surface integral quantities "
+            "requires a specific set of quadrature nodes.\n"
+            "In particular, flux surface integrals are best performed on grids with "
+            "uniform spacing in (θ,ζ).\n"
+            "It is recommended to compute such quantities on the proper grid and use "
+            "the ``copy_data_from_other`` method to transfer values to custom grids.",
         )
         return self._spacing
 
@@ -452,7 +458,11 @@ class _Grid(IOAble, ABC):
         errorif(
             self._weights is None,
             AttributeError,
-            "Custom grids must have weights specified by user.",
+            "Custom grids must have weights specified by user.\n"
+            "Recall that the accurate computation of volume integral quantities "
+            "requires a specific set of quadrature nodes.\n"
+            "It is recommended to compute such quantities on a QuadratureGrid and use "
+            "the ``copy_data_from_other`` method to transfer values to custom grids.",
         )
         return self._weights
 


### PR DESCRIPTION
The current warning leads users to construct quadrature spacing and weights on their custom grids, i.e. following field lines or in other coordinate systems. Such grids are almost always ill-suited for quadrature. This PR updates the warning to resolve #1193.