### PR TITLE
JAX environment variable name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Bug Fixes
 - Fix issue with interpolator for singular integrals [#1522](https://github.com/PlasmaControl/DESC/issues/1522) and additional checks [1519](https://github.com/PlasmaControl/DESC/issues/1519).
 - Fixes the coil currents in ``desc.coils.initialize_modular_coils`` to now give the correct expected linking current.
 - ``desc.objectives.PlasmaVesselDistance`` now correctly accounts for multiple field periods on both the equilibrium and the vessel surface. Previously it only considered distances within a single field period.
+- Sets ``os.environ["JAX_PLATFORMS"] = "cpu"`` instead of ``os.environ["JAX_PLATFORM_NAME"] = "cpu"`` when doing ``set_device("cpu")``.
 
 
 v0.13.0

--- a/desc/__init__.py
+++ b/desc/__init__.py
@@ -78,7 +78,7 @@ def set_device(kind="cpu", gpuid=None):
     """
     config["kind"] = kind
     if kind == "cpu":
-        os.environ["JAX_PLATFORM_NAME"] = "cpu"
+        os.environ["JAX_PLATFORMS"] = "cpu"
         os.environ["CUDA_VISIBLE_DEVICES"] = ""
         import psutil
 


### PR DESCRIPTION
Changes the environment variable name from `JAX_PLATFORM_NAME` to `JAX_PLATFORMS` when doing `set_device("cpu")`. 

It looks like this is the correct environment variable name from the [JAX documentation](https://docs.jax.dev/en/latest/faq.html#controlling-data-and-computation-placement-on-devices), I'm not sure where we got the old name from. 

This resolves the following issue that I started noticing recently (and mentioned at the dev meeting yesterday):

1. DESC is installed with GPU support, but you are on a machine with only a CPU (e.g., the head node of a cluster)
2. When you import anything from desc, it runs the backend logic and defaults to CPU
3. The following error is thrown when backend tries to use JAX:

> Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/global/u2/d/ddudt/DESC/desc/equilibrium/__init__.py", line 3, in <module>
    from .equilibrium import EquilibriaFamily, Equilibrium
  File "/global/u2/d/ddudt/DESC/desc/equilibrium/equilibrium.py", line 12, in <module>
    from desc.backend import execute_on_cpu, jnp
  File "/global/u2/d/ddudt/DESC/desc/backend.py", line 41, in <module>
    x = jnp.linspace(0, 5)
        ^^^^^^^^^^^^^^^^^^
  File "/global/homes/d/ddudt/.conda/envs/desc-env/lib/python3.11/site-packages/jax/_src/numpy/lax_numpy.py", line 6927, in linspace
    return _linspace(start, stop, num, endpoint, retstep, dtype, axis, device=device)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Unable to initialize backend 'cuda': FAILED_PRECONDITION: No visible GPU devices. (you may need to uninstall the failing plugin package, or set JAX_PLATFORMS=cpu to skip this backend.)

I'm not sure why this bug only appeared for me recently. But this fixes the issue and I think it is the proper environment variable name we should be using anyways, unless there was a reason we were using `JAX_PLATFORM_NAME`? 