### PR TITLE
Fix bug that occurs when setting coilset current with a 0-D array

### DIFF
--- a/desc/coils.py
+++ b/desc/coils.py
@@ -1285,9 +1285,10 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
 
     @current.setter
     def current(self, new):
-        if jnp.isscalar(new):
-            new = [new] * len(self)
-        for coil, cur in zip(self.coils, jnp.atleast_1d(new)):
+        new = jnp.atleast_1d(new)
+        if new.size == 1:
+            new = jnp.broadcast_to(new, (len(self),))
+        for coil, cur in zip(self.coils, jnp.atleast_1d(new), strict=True):
             coil.current = cur
 
     def _all_currents(self, currents=None):

--- a/desc/coils.py
+++ b/desc/coils.py
@@ -1287,7 +1287,7 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
     def current(self, new):
         if jnp.isscalar(new):
             new = [new] * len(self)
-        for coil, cur in zip(self.coils, new):
+        for coil, cur in zip(self.coils, jnp.atleast_1d(new)):
             coil.current = cur
 
     def _all_currents(self, currents=None):

--- a/tests/test_coils.py
+++ b/tests/test_coils.py
@@ -472,6 +472,9 @@ class TestCoilSet:
             coil, displacement=[0, 0, 10], n=n, endpoint=True
         )
         coils.current = I
+        with pytest.raises(ValueError):
+            # we pass in a list less than len(coils), so throws a ValueError
+            coils.current = [I, I]
         np.testing.assert_allclose(coils.current, I)
         B_approx = coils.compute_magnetic_field(
             [0, 0, z[-1]], basis="xyz", source_grid=32


### PR DESCRIPTION
Bug was popping up in `test_things_per_objective_idx(self)` locally for me, specifically

```python
linking_current = 2 * np.pi * eq.compute("G", grid=grid)["G"][0] / mu_0
coils.current = linking_current / coils.num_coils
```

the second line here, the error was that zip cannot deal with 0-D arrays. Upon debugging, it seemed that for some reason `jnp.isscalar(new)` was False for the new current being assigned here, which was weird. Putting the at least 1D fixes this now, and the broadcast_to should still raise an error if a weird length array is passed in.