### PR TITLE
Remove zip strict statement, always attempt broadcast when setting coilset current

### DIFF
--- a/desc/coils.py
+++ b/desc/coils.py
@@ -1286,9 +1286,8 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
     @current.setter
     def current(self, new):
         new = jnp.atleast_1d(new)
-        if new.size == 1:
-            new = jnp.broadcast_to(new, (len(self),))
-        for coil, cur in zip(self.coils, jnp.atleast_1d(new), strict=True):
+        new = jnp.broadcast_to(new, (len(self),))
+        for coil, cur in zip(self.coils, new):
             coil.current = cur
 
     def _all_currents(self, currents=None):


### PR DESCRIPTION
Python 3.9 does not support `strict=True` for zip, so this change has the same check but makes `strict=True` unneecessary, as now it will always call broadcast_to 