### PR TITLE
Update jdotb formula when saving to wout, and don't negate current profile in `ensure_nested_jacobian`

### DIFF
--- a/desc/compat.py
+++ b/desc/compat.py
@@ -40,11 +40,10 @@ def ensure_positive_jacobian(eq):
             + " To avoid this warning in the future, switch the sign of all"
             + " modes with m<0 and iota/current profile."
         )
-
         if eq.iota is not None:
+            # reverse sign of iota to maintain physical  B direction, since
+            # we have reversed the poloidal angle direction.
             eq.i_l *= -1
-        else:
-            eq.c_l *= -1
 
         rone = np.ones_like(eq.R_lmn)
         rone[eq.R_basis.modes[:, 1] < 0] *= -1

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -362,6 +362,12 @@ class VMECIO:
                 "sqrt(g)",
                 "<|B|^2>",
                 "<J*B>",
+                "G_r",
+                "G",
+                "I_r",
+                "I",
+                "psi_r",
+                "sqrt(g)_Boozer",
             ],
             grid=grid_full,
         )
@@ -605,6 +611,7 @@ class VMECIO:
         buco = file.createVariable("buco", np.float64, ("radius",))
         buco.long_name = "Boozer toroidal current I, on half mesh"
         buco.units = "T*m"
+
         buco[1:] = -grid_half.compress(data_half["I"])  # - for negative Jacobian
         buco[0] = 0
 


### PR DESCRIPTION
- No longer negates the current profile in `ensure_nested_jacobian` when flipping from a left-handed to a right-handed coordinate system
- changes the formula for the `jdotb` variable to better match VMEC outputted `jdotb`