### PR TITLE
fix `P_fusion` computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Bug Fixes
 - Fixes bug that occurs when an NAE solution used with NAE constraints is asymmetric, but has a symmetric axis.
 - Fixes bug in ``FourierCurrentPotentialField.change_Phi_resolution`` where ``N_Phi`` would be changed to ``M_Phi`` if ``N`` is not explicitly passed into the method.
 - Fixes bug when setting current for a ``MixedCoilSet`` with an arbitrary tree structure.
+- Fixes bug in the formula for computing ``"P_fusion"``.
 
 Performance Improvements
 

--- a/desc/compute/_equil.py
+++ b/desc/compute/_equil.py
@@ -865,7 +865,7 @@ def _P_fusion(params, transforms, profiles, data, **kwargs):
     fuel = kwargs.get("fuel", "DT")
     energy = energies.get(fuel)
 
-    reaction_rate = jnp.sum(
+    reaction_rate = 0.25 * jnp.sum(
         data["ni"] ** 2
         * data["<sigma*nu>"]
         * data["sqrt(g)"]


### PR DESCRIPTION
The formula is: 

$P_{fusion} = \int_V n_D n_T \langle\sigma\nu\rangle dV$

Our ion density $n_i$ is the total density of all ion species and we are assuming a 50/50 mix of deuterium & tritium, so this is equivalent to:

$P_{fusion} = \int_V \frac{1}{4} n_i^2 \langle\sigma\nu\rangle dV$