### PR TITLE
Added function to set FourierRZToroidalSurface modes with high m or n to zero.

### DIFF
--- a/desc/geometry/surface.py
+++ b/desc/geometry/surface.py
@@ -302,6 +302,19 @@ class FourierRZToroidalSurface(Surface):
 
     def zero_coeffs_above_mn(self, m_retain, n_retain=None):
         """Zero-out Fourier coefficients with m,n above the specified m_retain and n_retain.
+
+        Specifically, zeros out (m,n)-modes that satisfy |m|>m_retain or |n| > n_retain.
+        The above inequalities are strict, so m_retain is the highest m value retained (i.e., kept non-zero).
+        This is useful for redoing a multigrid optimization step without retaining values in the higher Fourier modes.
+
+        Parameters
+        ----------
+        m_retain : int
+            Coefficient that satisfy |m| > m_retain are set to zero.
+        n_retain : int 
+            Coefficient that satisfy |n| > n_retain are set to zero. If not specified, n_retain=m_retain is assumed.
+        """
+        """Zero-out Fourier coefficients with m,n above the specified m_retain and n_retain.
         Specifically, zeros out (m,n)-modes that satisfy |m|>m_retain or |n| > n_retain.
         The above inequalities are strict, so m_retain is the highest m value retained (i.e., kept non-zero).
         This is useful for redoing a multigrid optimization step without retaining values in the higher Fourier modes.

--- a/desc/geometry/surface.py
+++ b/desc/geometry/surface.py
@@ -300,7 +300,7 @@ class FourierRZToroidalSurface(Surface):
                 self.Z_lmn = put(self.Z_lmn, idxZ, ZZ)
 
 
-    def zero_coeffs_above_nm(self, m_retain, n_retain=None):
+    def zero_coeffs_above_mn(self, m_retain, n_retain=None):
         """Zero-out Fourier coefficients with m,n above the specified m_retain and n_retain.
         Specifically, zeros out (m,n)-modes that satisfy |m|>m_retain or |n| > n_retain.
         The above inequalities are strict, so m_retain is the highest m value retained (i.e., kept non-zero).
@@ -336,13 +336,19 @@ class FourierRZToroidalSurface(Surface):
         nm = self.Z_basis.modes[:,1:]
         absnm = np.abs(nm)
         inds = np.any(np.greater(absnm,limits),axis=1)
-        self.Z_lmn = self.Z_lmn.at[inds].set(np.zeros_like(self.Z_lmn[inds]))
-
+        if isinstance(self.Z_lmn, jnp.ndarray):
+            self.Z_lmn = self.Z_lmn.at[inds].set(np.zeros_like(self.Z_lmn[inds]))
+        elif isinstance(self.Z_lmn, np.ndarray):
+            self.Z_lmn[inds] = np.zeros_like(self.Z_lmn[inds])
+        
         nm = self.R_basis.modes[:,1:]
         absnm = np.abs(nm)
         inds = np.any(np.greater(absnm,limits),axis=1)
-        self.R_lmn = self.R_lmn.at[inds].set(np.zeros_like(self.R_lmn[inds]))
-
+        if isinstance(self.R_lmn, jnp.ndarray):
+            self.R_lmn = self.R_lmn.at[inds].set(np.zeros_like(self.R_lmn[inds]))
+        elif isinstance(self.R_lmn, np.ndarray):
+            self.R_lmn[inds] = np.zeros_like(self.R_lmn[inds])
+        
                 
     @classmethod
     def from_input_file(cls, path, **kwargs):

--- a/desc/geometry/surface.py
+++ b/desc/geometry/surface.py
@@ -314,53 +314,45 @@ class FourierRZToroidalSurface(Surface):
         n_retain : int 
             Coefficient that satisfy |n| > n_retain are set to zero. If not specified, n_retain=m_retain is assumed.
         """
-        """Zero-out Fourier coefficients with m,n above the specified m_retain and n_retain.
-        Specifically, zeros out (m,n)-modes that satisfy |m|>m_retain or |n| > n_retain.
-        The above inequalities are strict, so m_retain is the highest m value retained (i.e., kept non-zero).
-        This is useful for redoing a multigrid optimization step without retaining values in the higher Fourier modes.
-
-        Parameters
-        ----------
-        m_retain : Coefficient that satisfy |m| > m_retain are set to zero.
-        n_retain : Coefficient that satisfy |m| > m_retain are set to zero. If not specified, n_retain=m_retain is assumed.
-
-        WARNING: Like other set_coeffs function, this does not recompute the actual surface. 
-        This needs to be done manually. TODO: SUGGEST HOW?
-
-        """
-
+  
         if n_retain is None:
             n_retain = m_retain
 
         errorif(
             m_retain <= 0,
             ValueError,
-            f"zero_coeffs_above_nm(m_retains, n_retains) expects a positive m_retain, but got {m_retain=}",
+            f"zero_coeffs_above_nm(m_retains, n_retains) expects a positive integer m_retain, but got {m_retain=}",
         )
             
         errorif(
             n_retain <= 0,
             ValueError,
-            f"zero_coeffs_above_nm(m_retains, n_retains) expects a positive n_retain, but got {n_retain=}",
+            f"zero_coeffs_above_nm(m_retains, n_retains) expects a positive integer n_retain, but got {n_retain=}",
+        )
+
+        errorif(
+            m_retain != int(m_retain),
+            ValueError,
+            f"m_retain must be a positive integer, got {m_retain}",
+        )
+
+        errorif(
+            n_retain != int(n_retain),
+            ValueError,
+            f"n_retain must be a positive integer, got {n_retain}",
         )
         
-        limits = np.array([n_retain,m_retain])
+        limits = np.array([m_retain,n_retain])
         
         nm = self.Z_basis.modes[:,1:]
         absnm = np.abs(nm)
         inds = np.any(np.greater(absnm,limits),axis=1)
-        if isinstance(self.Z_lmn, jnp.ndarray):
-            self.Z_lmn = self.Z_lmn.at[inds].set(np.zeros_like(self.Z_lmn[inds]))
-        elif isinstance(self.Z_lmn, np.ndarray):
-            self.Z_lmn[inds] = np.zeros_like(self.Z_lmn[inds])
-        
+        self.Z_lmn = put(self.Z_lmn, inds, np.zeros_like(self.Z_lmn[inds]))
+
         nm = self.R_basis.modes[:,1:]
         absnm = np.abs(nm)
         inds = np.any(np.greater(absnm,limits),axis=1)
-        if isinstance(self.R_lmn, jnp.ndarray):
-            self.R_lmn = self.R_lmn.at[inds].set(np.zeros_like(self.R_lmn[inds]))
-        elif isinstance(self.R_lmn, np.ndarray):
-            self.R_lmn[inds] = np.zeros_like(self.R_lmn[inds])
+        self.R_lmn = put(self.R_lmn, inds, np.zeros_like(self.R_lmn[inds]))
         
                 
     @classmethod


### PR DESCRIPTION
This adds a function to FourierRZToroidalSurface objects to set modes with values of |m| or |n| above user-specified values to zero.

This is frequently useful when doing multi-step optimizations for several objectives, where the user adds an additional objective to an existing optimization and start from a previously obtained optimum. To avoid being too constrained by the initial guess, it is often useful to zero-out higher (m,n)-modes from the previous optimum and redo part of a multi-grid optimization.
For example, to find a QS equilibrium with Mercier stability, we could start from the 'Precise-QA' equilibrium, zero out the higher Fourier modes, and use this as our initial condition for the QS+Mercier optimization. This can then be repeated to add more objectives. For each such iteration, it is potentially useful to experiment with zeroing out modes to achieve varying degrees of 'hot-start'.

Feel free to suggest moving this method away from the FourierRZToroidalSurface itself. It is basically a low-pass filter for surfaces. The current implementation only works for FourierRZToroidalSurface, so it may currently be too narrow as a general utility function.

Usage example:

```python
import matplotlib.pyplot as plt
from desc.plotting import plot_boundary
from desc.examples import get

fig, axes = plt.subplots(2)
axes = axes.flatten()

eq = get("precise_QA")
plot_boundary(eq.surface, ax = axes[0])
eq.surface.zero_coeffs_above_mn(1,1)
plot_boundary(eq.surface, ax = axes[1])
plt.show()
```

Output:
![before_after](https://github.com/user-attachments/assets/1e23a733-273e-4363-9d26-2d566854ce44)
