### PR TITLE
Fix error in AD with default grid for splineXYZCoil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 Bug Fixes
 - Fixes bug in ``desc.vmec.VMECIO.write_vmec_input`` for current-constrained equilibria, where DESC was incorrectly writing the ``s**0`` mode, where VMEC actually assumes it is zero and starts at the  ``s**1`` (which is different than the usual convention VMEC uses for its current profile when it uses the current derivative, where it starts with the ``s**0`` mode).
+- Fixes error that occurs when using the default grid for ``SplineXYZCoil`` in an optimization.
 
 v0.14.0
 -------

--- a/desc/coils.py
+++ b/desc/coils.py
@@ -1106,8 +1106,8 @@ class SplineXYZCoil(_Coil, SplineXYZCurve):
 
         if source_grid is None:
             # NFP=1 to ensure points span the entire length of the coil
-            # multiply resolution by NFP to ensure Biot-Savart integration is accurate
-            source_grid = LinearGrid(zeta=self.knots)
+            # using more points than knots.size (self.N) to better sample coil
+            source_grid = LinearGrid(N=self.N * 2 + 5)
         else:
             # coil grids should have NFP=1. The only possible exception is FourierRZCoil
             # which in theory can be different as long as it matches the coils NFP.

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -3458,7 +3458,7 @@ class TestObjectiveNaNGrad:
     @pytest.mark.unit
     def test_objective_no_nangrad_quadratic_flux_minimizing(self):
         """SurfaceQuadraticFlux."""
-        ext_field = ToroidalMagneticField(1.0, 1.0)
+        ext_field = FourierXYZCoil().to_SplineXYZ(grid=3)
 
         surf = FourierRZToroidalSurface(
             R_lmn=[4.0, 1.0],

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -3467,8 +3467,9 @@ class TestObjectiveNaNGrad:
             modes_Z=[[-1, 0]],
             NFP=1,
         )
-
-        obj = ObjectiveFunction(SurfaceQuadraticFlux(surf, ext_field), use_jit=False)
+        # have use_jit=True here to check that runs correctly with spline
+        # coils, see PR #1656
+        obj = ObjectiveFunction(SurfaceQuadraticFlux(surf, ext_field), use_jit=True)
         obj.build()
         g = obj.grad(obj.x(surf, ext_field))
         assert not np.any(np.isnan(g)), "quadratic flux"


### PR DESCRIPTION
When providing `zeta` to a `LinearGrid` that is built on-the-fly, the resulting manipulations trigger some array conversions which don't play well with AD. This was happening in the default grid for `SplineXYZCoil` so I've changed that here.

I checked through the code for other instances where this may occur but I did not find any.