### PR TITLE
Fix bug in `FourierPlanarCurve.from_values` where orientation of curve could flip unintentionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Bug Fixes
 
 - Fixes bug where ``ObjectiveFunction`` was incorrectly using ``deriv_mode="batched"`` and the heuristic-set ``jac_chunk_size`` when ``jac_chunk_size`` is given to a sub-objective, where it should have instead defaulted to ``deriv_mode="blocked"``. See #1687
 - Allows ``x_scale`` to be passed to ``factorize_linear_constraints`` in ``Optimizer.optimize`` through the new ``"linear_constraint_options"``.
+- Fixes issue in ``desc.geometry.curve.FourierPlanarCurve.from_values`` where the orientation of the fitted curve can be the reverse of the original curve, which can be problematic for coils (the current is not negated, so the resulting fitted coil would have field opposite of the initial)
 
 
 v0.14.1

--- a/desc/geometry/curve.py
+++ b/desc/geometry/curve.py
@@ -850,6 +850,13 @@ class FourierPlanarCurve(Curve):
         s = np.arctan2(coords[:, 1], coords[:, 0])
         s = np.mod(s + 2 * np.pi, 2 * np.pi)  # mod angle to range [0, 2*pi)
         idx = np.argsort(s)  # sort angle to be monotonically increasing
+        # have to track if we end up re-sorting it, bc if we did, then
+        # we have effectively reversed the direction that the curve is being
+        # traversed (i.e. we reversed the sign of x_s)
+        was_sorted = np.allclose(s, s[idx])
+        # if it was sorted, negate the normal so that
+        # the fitted curve is traversed in same direction as original
+        normal = -normal if was_sorted else normal
         r = r[idx]
         s = s[idx]
 

--- a/tests/test_coils.py
+++ b/tests/test_coils.py
@@ -1502,3 +1502,21 @@ def test_initialize_helical():
     # first take a min over plasma pts to get distance from each coil pt to plasma
     # then we expect the avg of that to be ~a since r/a=2 so offset is 1*a
     np.testing.assert_allclose(dist.min(axis=1).mean(axis=-1), a, rtol=3e-2)
+
+
+@pytest.mark.unit
+def test_FourierPlanarCoil_from_values_orientation():
+    """Test that fitting with FourierPlanarCoil preserves orientation."""
+    # easiest to check this is working using a coil, as can use
+    # biot savart to see if B is same or not
+    # tests fix for GH #1715
+    coil_XYZ = FourierXYZCoil(
+        current=1e6, X_n=[0, 10, 2], Y_n=[-2, 0, 0], Z_n=[0, 0, 0.1]
+    )
+    coil_planar = coil_XYZ.to_FourierPlanar(N=1)
+
+    coords = [[1, 1, 1]]
+    grid = LinearGrid(N=40)
+    B_XYZ = coil_XYZ.compute_magnetic_field(coords, source_grid=grid)
+    B_planar = coil_planar.compute_magnetic_field(coords, source_grid=grid)
+    np.testing.assert_allclose(B_XYZ, B_planar, rtol=1e-3)


### PR DESCRIPTION
Resolves #1715

Duplicate of the better fix in https://github.com/PlasmaControl/DESC/pull/1463 , so close this one in favor of that one once that is merged in
