### PR TITLE
Add PlasmaCoilSetMaxDistance objective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Optionally can also contract the profiles of the original ``Equilibrium`` so tha
 - Updates Redl bootstrap current consistency tutorial to include a ``SplineProfile`` optimization
 - Adds automatically generated header file showing date the input file was created with `desc.vmec.VMECIO.write_vmec_input`
 - Adds ``source_grid`` argument to ``desc.magnetic_fields._MagneticField.save_mgrid function`` to allow user to control the discretization of the magnetic field object being used to construct the ``mgrid`` output.
+- Adds ``PlasmaCoilSetMaxDistance`` objective to allow a constraint on maximum distance between the plasma and coils.
 
 Bug Fixes
 

--- a/desc/objectives/__init__.py
+++ b/desc/objectives/__init__.py
@@ -11,6 +11,7 @@ from ._coils import (
     CoilSetMinDistance,
     CoilTorsion,
     LinkingCurrentConsistency,
+    PlasmaCoilSetMaxDistance,
     PlasmaCoilSetMinDistance,
     QuadraticFlux,
     SurfaceCurrentRegularization,

--- a/desc/objectives/utils.py
+++ b/desc/objectives/utils.py
@@ -241,7 +241,7 @@ class _Recover(IOAble):
         return jnp.atleast_1d(jnp.squeeze(x_full))
 
 
-def softmax(arr, alpha):
+def softmax(arr, alpha, axis=None):
     """JAX softmax implementation.
 
     Parameters
@@ -252,6 +252,9 @@ def softmax(arr, alpha):
         The parameter smoothly transitioning the function to a hardmax.
         as alpha increases, the value returned will come closer and closer to
         max(arr).
+    axis : int, optional
+        Axis along which the softmax is computed. The default is None, which
+        computes the softmax over the entire array.
 
     Returns
     -------
@@ -259,12 +262,16 @@ def softmax(arr, alpha):
         The soft-maximum of the array.
 
     """
-    arr = arr.flatten()
-    arr_times_alpha = alpha * arr
-    return softargmax(arr_times_alpha).dot(arr)
+    if axis is None:
+        arr = arr.flatten()
+        arr_times_alpha = alpha * arr
+        return softargmax(arr_times_alpha).dot(arr)
+    else:
+        arr_times_alpha = alpha * arr
+        return jnp.sum(arr * softargmax(arr_times_alpha, axis=axis), axis=axis)
 
 
-def softmin(arr, alpha):
+def softmin(arr, alpha, axis=None):
     """JAX softmin implementation, by taking negative of softmax(-arr).
 
     Parameters
@@ -275,6 +282,9 @@ def softmin(arr, alpha):
         The parameter smoothly transitioning the function to a hardmin.
         as alpha increases, the value returned will come closer and closer to
         min(arr).
+    axis : int, optional
+        Axis along which the softmax is computed. The default is None, which
+        computes the softmax over the entire array.
 
     Returns
     -------
@@ -282,7 +292,7 @@ def softmin(arr, alpha):
         The soft-minimum of the array.
 
     """
-    return -softmax(-arr, alpha)
+    return -softmax(-arr, alpha, axis)
 
 
 def combine_args(*objectives):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -232,6 +232,7 @@ Objective Functions
     desc.objectives.ObjectiveFromUser
     desc.objectives.ObjectiveFunction
     desc.objectives.Omnigenity
+    desc.objectives.PlasmaCoilSetMaxDistance
     desc.objectives.PlasmaCoilSetMinDistance
     desc.objectives.PlasmaVesselDistance
     desc.objectives.Pressure

--- a/docs/api_objectives.rst
+++ b/docs/api_objectives.rst
@@ -124,6 +124,7 @@ Coil Optimization
     desc.objectives.CoilTorsion
     desc.objectives.CoilSetLinkingNumber
     desc.objectives.CoilSetMinDistance
+    desc.objectives.PlasmaCoilSetMaxDistance
     desc.objectives.PlasmaCoilSetMinDistance
     desc.objectives.CoilIntegratedCurvature
     desc.objectives.CoilCurrentLength


### PR DESCRIPTION
Sometimes, the coils get too far away from the plasma, and I often need an objective function which constrains the distance between plasma and coil from above. This adds that objective by generalizing the PlasmaCoilSetDistance objective to find the maximum (over the coil) minimum (over the plasma) distance between coil and plasma. To do this, I also added functionality to the `softmax` function to allow it to perform maximization over a given axis rather than flattening the array. 