### PR TITLE
Use svd for first iteration of the optimisation

### DIFF
--- a/desc/optimize/aug_lagrangian_ls.py
+++ b/desc/optimize/aug_lagrangian_ls.py
@@ -374,7 +374,7 @@ def lsq_auglag(  # noqa: C901
         J_a = jnp.vstack([J_h, jnp.diag(diag_h**0.5)]) if bounded else J_h
         L_a = jnp.concatenate([L, jnp.zeros(diag_h.size)]) if bounded else L
 
-        if tr_method == "svd":
+        if tr_method == "svd" or iteration == 0:
             U, s, Vt = jnp.linalg.svd(J_a, full_matrices=False)
         elif tr_method == "cho":
             B_h = jnp.dot(J_a.T, J_a)
@@ -403,7 +403,7 @@ def lsq_auglag(  # noqa: C901
             # This gives us the proposed step relative to the current position
             # and it tells us whether the proposed step
             # has reached the trust region boundary or not.
-            if tr_method == "svd":
+            if tr_method == "svd" or iteration == 0:
                 step_h, hits_boundary, alpha = trust_region_step_exact_svd(
                     L_a, U, s, Vt.T, trust_radius, alpha
                 )

--- a/desc/optimize/least_squares.py
+++ b/desc/optimize/least_squares.py
@@ -277,7 +277,7 @@ def lsqtr(  # noqa: C901
         J_a = jnp.vstack([J_h, jnp.diag(diag_h**0.5)]) if bounded else J_h
         f_a = jnp.concatenate([f, jnp.zeros(diag_h.size)]) if bounded else f
 
-        if tr_method == "svd":
+        if tr_method == "svd" or iteration == 0:
             U, s, Vt = jnp.linalg.svd(J_a, full_matrices=False)
         elif tr_method == "cho":
             B_h = jnp.dot(J_a.T, J_a)
@@ -305,7 +305,7 @@ def lsqtr(  # noqa: C901
             # This gives us the proposed step relative to the current position
             # and it tells us whether the proposed step
             # has reached the trust region boundary or not.
-            if tr_method == "svd":
+            if tr_method == "svd" or iteration == 0:
                 step_h, hits_boundary, alpha = trust_region_step_exact_svd(
                     f_a, U, s, Vt.T, trust_radius, alpha
                 )

--- a/desc/optimize/tr_subproblems.py
+++ b/desc/optimize/tr_subproblems.py
@@ -152,7 +152,7 @@ def solve_trust_region_2d_subspace(g, H, trust_radius, initial_alpha=None, **kwa
 
 @jit
 def trust_region_step_exact_svd(
-    f, u, s, v, trust_radius, initial_alpha=None, rtol=0.01, max_iter=10, threshold=None
+    f, u, s, v, trust_radius, initial_alpha=None, rtol=0.01, max_iter=40, threshold=None
 ):
     """Solve a trust-region problem using a semi-exact method.
 


### PR DESCRIPTION
Use SVD for the first iteration of the optimisation since it requires 1 decomposition and the root finding is faster, QR is better for later steps where root finding converges in a couple of steps.

See the [docs](https://desc-docs.readthedocs.io/en/latest/dev_guide/notebooks/getting-started-eq-solve.html#Solving-Trust-Region-Problem-with-QR) for the math, but in a nutshell, trust region subproblem when solved by SVD requires only 1 matrix decomposition. Then the root finding in alpha uses USV. However, with QR method, initial Q and R matrices cannot be used multiple times. Even though QR is significantly faster than SVD, this difference causes the first iteration to be slower in practice (due to multiple big linear system solves) since the initial values of alpha and trust radius are far from optimal.

This change attempts to combine the best of both worlds (hopefully). I created the PR mainly for the benchmarks.