### PR TITLE
Coil arclength variance for FourierXY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ New Features
 - `desc.magnetic_fields.field_line_integrate` now integrates the field line always in the given `phis` direction, and `phis` will always correspond to the physical toroidal angle (instead of time like coordinate previously). Previous implementation might have caused confusion about the output positions, especially when the magnetic field has negative toroidal component.
 - Adds ``grid.meshgrid_flatten`` for flattening 3d data to a 1d array in the correct order.
 - Ability to obtain the top eigenvalues and the corresponding eigenfunctions from the ``ideal ballooning lambda`` compute function by specifying the variable ``Neigvals``.
+- Adds ``FourierXYCoil`` to compatible coils for ``CoilSetArclengthVariance`` objective.
 
 Bug Fixes
 

--- a/desc/objectives/_coils.py
+++ b/desc/objectives/_coils.py
@@ -1335,14 +1335,23 @@ class CoilArclengthVariance(_CoilObjective):
 
         coilset = self.things[0]
         # local import to avoid circular import
-        from desc.coils import CoilSet, FourierXYZCoil, SplineXYZCoil, _Coil
+        from desc.coils import (
+            CoilSet,
+            FourierXYCoil,
+            FourierXYZCoil,
+            SplineXYZCoil,
+            _Coil,
+        )
 
         def _is_single_coil(c):
             return isinstance(c, _Coil) and not isinstance(c, CoilSet)
 
         coils = tree_leaves(coilset, is_leaf=_is_single_coil)
         self._constants["mask"] = np.array(
-            [int(isinstance(coil, (FourierXYZCoil, SplineXYZCoil))) for coil in coils]
+            [
+                int(isinstance(coil, (FourierXYZCoil, SplineXYZCoil, FourierXYCoil)))
+                for coil in coils
+            ]
         )
 
         if self._normalize:


### PR DESCRIPTION
`FourierXY` can also have varying arclengths. This PR includes `FourierXYCoil` in the list of permitted coil types for the `CoilArclengthVariance` objective.