### PR TITLE
Dp/from field hotfix

### DIFF
--- a/desc/magnetic_fields/_core.py
+++ b/desc/magnetic_fields/_core.py
@@ -2215,7 +2215,7 @@ class SplineMagneticField(_MagneticField, Optimizable):
             AR = AR.reshape(shp)
             AP = AP.reshape(shp)
             AZ = AZ.reshape(shp)
-        except NotImplementedError:
+        except (ValueError, NotImplementedError):
             AR = AP = AZ = None
         return cls(
             R,

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -1066,6 +1066,9 @@ class TestMagneticFields:
         field2 = SplineMagneticField.from_field(
             field1, R, p, Z, source_grid=LinearGrid(N=1)
         )
+        # this is just to test the logic when
+        # compute_vector_potential returns a ValueError
+        _ = SplineMagneticField.from_field(field2, R, p, Z, source_grid=LinearGrid(N=1))
 
         np.testing.assert_allclose(
             field1([1.0, 1.0, 1.0]), field2([1.0, 1.0, 1.0]), rtol=1e-2, atol=1e-2


### PR DESCRIPTION
`SplineMagneticField.from_field` fails when used with `SplineMagneticField` due to an unexpected error type in computing the vector potential.