### PR TITLE
don't close over field in field_line_integrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Bug Fixes
 
 Backend
 - Significant changes to how DESC handles static attributes during JIT compilation. Going forward if any class/object has attributes that should be treated as static by `jax.jit`, these should be declared at the class level like `_static_attrs = ["foo", "bar"]`. Generally, non-arraylike attributes such as functions, strings etc should be marked static, as well as any attributes used for control flow. Previously this was done automatically, but in a way that caused a lot of performance bugs and unnecessary recompilation. These changes have been implemented for all classes in the `desc` repository, but if you have custom objectives or other local objects that subclass from `desc` you may need to add this yourself. JAX error messages usually do a good job of alerting you to things that need to be static, and feel free to open an issue with `desc` if you have any questions.
+- No longer closes over the field in ``desc.magnetic_fields._core.field_line_integrate``, which can dramatically reduce compile times when the field being traced has large size attributes (for example, when using a ``desc.magnetic_fields._core.SplineMagneticField`` object).
 
 v0.14.2
 -------

--- a/desc/magnetic_fields/_core.py
+++ b/desc/magnetic_fields/_core.py
@@ -2646,6 +2646,7 @@ def field_line_integrate(
     @jit
     def odefun(s, rpz, args):
         rpz = rpz.reshape((3, -1)).T
+        field = args[0]
         r = rpz[:, 0]
         br, bp, bz = (
             scale
@@ -2684,6 +2685,7 @@ def field_line_integrate(
         saveat=saveat,
         max_steps=maxstep * len(phis),
         dt0=min_step_size,
+        args=(field,),
         **kwargs,
     ).ys
 


### PR DESCRIPTION
Don't close over `field` to avoid long compile times due to constant folding when the field has large array attributes.

This helps dramatically reduce compile times when constant folding would be slow, and seems to have no effect on runtimes in cases where there would not be appreciably slow constant folding occuring, so it seems to be a harmless change.

- [x] check effect on GPU (before, running on gpu took a surprisingly large amount of memory, even if it could run easily on the cpu with less memory) - this PR also improves speed for GPU, have not profiled memory.

Resolves #1829