### PR TITLE
Pin action-suggester version to 1.22 until a bug is fixed on reviewdog

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -51,7 +51,7 @@ jobs:
           black desc/ tests/
 
       - name: Annotate diff changes using reviewdog
-        uses: reviewdog/action-suggester@v1
+        uses: reviewdog/action-suggester@v1.22
         with:
           tool_name: blackfmt
 


### PR DESCRIPTION
Black formatting action fails as reported [here](https://github.com/reviewdog/action-suggester/issues/95). Temporarily fix to previous version until it is fixed.