### PR TITLE
CI related fixes

### DIFF
--- a/.github/workflows/memory_benchmark.yml
+++ b/.github/workflows/memory_benchmark.yml
@@ -14,12 +14,29 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Filter changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            has_changes:
+              - 'desc/**'
+              - 'tests/**'
+              - 'requirements.txt'
+              - 'devtools/dev-requirements.txt'
+              - 'setup.cfg'
+              - '.github/workflows/memory_benchmarks.yml'
+
+      - name: Check for relevant changes
+        id: check_changes
+        run: echo "has_changes=${{ !contains(github.event.pull_request.labels.*.name, 'only-docs-comments') && steps.changes.outputs.has_changes}}" >> $GITHUB_ENV
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -34,6 +51,7 @@ jobs:
           echo "version=$python_version" >> $GITHUB_ENV
 
       - name: Restore Python environment cache
+        if: env.has_changes == 'true'
         id: restore-env
         uses: actions/cache/restore@v4
         with:
@@ -41,7 +59,7 @@ jobs:
           key: ${{ runner.os }}-venv-${{ env.version }}-${{ hashFiles('devtools/dev-requirements.txt', 'requirements.txt') }}
 
       - name: Set up virtual environment if not restored from cache
-        if: steps.restore-env.outputs.cache-hit != 'true'
+        if: steps.restore-env.outputs.cache-hit != 'true' && env.has_changes == 'true'
         run: |
           gh cache list
           python -m venv .venv-${{ env.version }}
@@ -52,11 +70,13 @@ jobs:
 
       # Add more memory just in case
       - name: Set Swap Space
+        if: env.has_changes == 'true'
         uses: pierotofy/set-swap-space@master
         with:
           swap-size-gb: 4
 
       - name: Action Details
+        if: env.has_changes == 'true'
         run: |
           source .venv-${{ env.version }}/bin/activate
           which python
@@ -66,27 +86,32 @@ jobs:
           pip list
 
       - name: Benchmark with pytest-benchmark (PR)
+        if: env.has_changes == 'true'
         run: |
           source .venv-${{ env.version }}/bin/activate
           cd tests/benchmarks
           python memory_benchmark_cpu.py pr
 
       - name: Checkout current master
+        if: env.has_changes == 'true'
         uses: actions/checkout@v5
         with:
           ref: master
           clean: false
 
       - name: Checkout benchmarks from PR head
+        if: env.has_changes == 'true'
         run: git checkout ${{ github.event.pull_request.head.sha }} -- tests/benchmarks
 
       - name: Benchmark with pytest-benchmark (MASTER)
+        if: env.has_changes == 'true'
         run: |
           source .venv-${{ env.version }}/bin/activate
           cd tests/benchmarks
           python memory_benchmark_cpu.py master
 
       - name: Compare latest commit results to the master branch results
+        if: env.has_changes == 'true'
         run: |
           source .venv-${{ env.version }}/bin/activate
           cd tests/benchmarks
@@ -95,12 +120,14 @@ jobs:
           cat commit_msg.txt
 
       - name: Upload memory comparison plot
+        if: env.has_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: compare-plot
           path: tests/benchmarks/compare.png
 
       - name: Comment PR with the results
+        if: env.has_changes == 'true'
         uses: thollander/actions-comment-pull-request@v3
         env:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,20 +16,22 @@ concurrency:
 
 jobs:
   unit_tests:
-
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
     strategy:
       matrix:
-        combos: [{group: 1, python_version: '3.10'},
-                 {group: 2, python_version: '3.10'},
-                 {group: 3, python_version: '3.11'},
-                 {group: 4, python_version: '3.11'},
-                 {group: 5, python_version: '3.12'},
-                 {group: 6, python_version: '3.12'},
-                 {group: 7, python_version: '3.13'},
-                 {group: 8, python_version: '3.13'}]
+        combos:
+          [
+            { group: 1, python_version: "3.10" },
+            { group: 2, python_version: "3.10" },
+            { group: 3, python_version: "3.11" },
+            { group: 4, python_version: "3.11" },
+            { group: 5, python_version: "3.12" },
+            { group: 6, python_version: "3.12" },
+            { group: 7, python_version: "3.13" },
+            { group: 8, python_version: "3.13" },
+          ]
 
     steps:
       - uses: actions/checkout@v5
@@ -126,7 +128,7 @@ jobs:
 
       - name: Upload coverage
         if: env.has_changes == 'true'
-        id : codecov
+        id: codecov
         uses: codecov/codecov-action@v5
         with:
           name: codecov-umbrella

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,22 +16,20 @@ concurrency:
 
 jobs:
   unit_tests:
+
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
     strategy:
       matrix:
-        combos:
-          [
-            { group: 1, python_version: "3.10" },
-            { group: 2, python_version: "3.10" },
-            { group: 3, python_version: "3.11" },
-            { group: 4, python_version: "3.11" },
-            { group: 5, python_version: "3.12" },
-            { group: 6, python_version: "3.12" },
-            { group: 7, python_version: "3.13" },
-            { group: 8, python_version: "3.13" },
-          ]
+        combos: [{group: 1, python_version: '3.10'},
+                 {group: 2, python_version: '3.10'},
+                 {group: 3, python_version: '3.11'},
+                 {group: 4, python_version: '3.11'},
+                 {group: 5, python_version: '3.12'},
+                 {group: 6, python_version: '3.12'},
+                 {group: 7, python_version: '3.13'},
+                 {group: 8, python_version: '3.13'}]
 
     steps:
       - uses: actions/checkout@v5
@@ -128,7 +126,7 @@ jobs:
 
       - name: Upload coverage
         if: env.has_changes == 'true'
-        id: codecov
+        id : codecov
         uses: codecov/codecov-action@v5
         with:
           name: codecov-umbrella

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,16 +3,18 @@ comment:                  # this is a top-level key
   behavior: default
   require_changes: false  # if true: only post the comment if coverage changes
   require_base: true        # [true :: must have a base report to post]
-  require_head: true       # [true :: must have a head report to post]
-  after_n_builds: 14
+  require_head: true        # [true :: must have a head report to post]
+  after_n_builds: 14   # wait for 8 unit and 6 regression tests to complete
 coverage:
   status:
     patch:
       default:
         informational: false
+        if_not_found: success # for 'only-docs-comments' labeled PRs
     project:
       default:
         informational: false
         threshold: 2.0
+        if_not_found: success # for 'only-docs-comments' labeled PRs
 github_checks:
   annotations: true

--- a/tests/benchmarks/compare_bench_results.py
+++ b/tests/benchmarks/compare_bench_results.py
@@ -119,6 +119,10 @@ for i, (dt, dpct, sdt, sdpct) in enumerate(
     commit_msg_lines.append(line)
 
 commit_msg_lines.append("```")
+commit_msg_lines += (
+    "\n\nGithub CI performance can be noisy. When evaluating the "
+    "benchmarks, developers should take this into account.\n"
+)
 commit_msg_lines = [line + "\n" for line in commit_msg_lines]
 print("".join(commit_msg_lines))
 # write out commit msg

--- a/tests/benchmarks/memory_benchmark_cpu.py
+++ b/tests/benchmarks/memory_benchmark_cpu.py
@@ -107,6 +107,18 @@ if __name__ == "__main__":
         # wait until the child exits, then join the sampler
         child.wait()
         sampler.join()
+
+        # check if one of the processes failed
+        if child.returncode != 0:
+            print(
+                f"ERROR: Subprocess for function {funs[i]} failed with "
+                f"exit code {child.returncode}"
+            )
+            # Raising an exception will cause the main script to fail,
+            # making the overall GitHub Actions job fail.
+            raise subprocess.CalledProcessError(
+                returncode=child.returncode, cmd=funs[i], output=None
+            )
         # save the data
         # make sure memory usage is 0 somewhere and t starts at 0
         data[funs[i]] = {}


### PR DESCRIPTION
- Skip memory benchmarks for `only-docs-comments` labeled PRs
- Fail memory benchmark if the underlying test fails
- Skip codecov if no report is uploaded for any of the workflows
- Add comment on the possible noise on benchmarks

Resolves #1913 
Resolves #1929 
Resolves #1852 