### PR TITLE
dont have pytest fail on finufft install warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,8 @@ filterwarnings=
     ignore:numpy.ndarray size changed:RuntimeWarning
     # ignore DeprecationWarnings from dependency packages
     ignore::DeprecationWarning:(?!desc)
+    # dont have pytest fail on finufft warning
+    ignore:jax-finufft is not installed:UserWarning
 
 [flake8]
 # Primarily ignoring whitespace, indentation, and commenting etiquette that black does not catch


### PR DESCRIPTION
Resolve #1986

This is benign for any test with nufft_eps=0, so mainly for if trying pytest on systems where finufft gpu is difficult to install (NERSC)