### PR TITLE
Ku/einsum

### DIFF
--- a/desc/integrals/_bounce_utils.py
+++ b/desc/integrals/_bounce_utils.py
@@ -831,7 +831,7 @@ def mmt_for_bounce(v, c):
         Fourier coefficients.
 
     """
-    return (v * c[..., None, None, None, :, :]).real.sum((-2, -1))
+    return jnp.einsum("...pwqzt, ...zt -> ...pwq", v, c).real
 
 
 def broadcast_for_bounce(pitch_inv):

--- a/desc/integrals/basis.py
+++ b/desc/integrals/basis.py
@@ -636,9 +636,10 @@ class PiecewiseChebyshevSeries(IOAble):
         #      ∂f/∂y =      ∑ₙ₌₀ᴺ⁻¹ aₙ(x) n Uₙ₋₁(y)
         # sign ∂f/∂y = sign ∑ₙ₌₀ᴺ⁻¹ aₙ(x) n sin(n arcos y)
         df_dy = jnp.sign(
-            jnp.linalg.vecdot(
+            jnp.einsum(
+                "...yn, ...n",
                 n * jnp.sin(n * jnp.arccos(y)[..., None]),
-                self.cheb[..., None, :],
+                self.cheb,
             )
         )
         y = bijection_from_disc(y, self.domain[0], self.domain[-1])

--- a/desc/objectives/_fast_ion.py
+++ b/desc/objectives/_fast_ion.py
@@ -55,7 +55,6 @@ class GammaC(_Objective):
     Notes
     -----
     Performance will improve significantly by resolving these GitHub issues.
-      * https://github.com/jax-ml/jax/issues/30627
       * ``1303`` Patch for differentiable code with dynamic shapes
       * ``1206`` Upsample data above midplane to full grid assuming stellarator symmetry
       * ``1034`` Optimizers/objectives with auxiliary output

--- a/desc/objectives/_neoclassical.py
+++ b/desc/objectives/_neoclassical.py
@@ -51,7 +51,6 @@ class EffectiveRipple(_Objective):
     Notes
     -----
     Performance will improve significantly by resolving these GitHub issues.
-      * https://github.com/jax-ml/jax/issues/30627
       * ``1303`` Patch for differentiable code with dynamic shapes
       * ``1206`` Upsample data above midplane to full grid assuming stellarator symmetry
       * ``1034`` Optimizers/objectives with auxiliary output

--- a/tests/test_neoclassical.py
+++ b/tests/test_neoclassical.py
@@ -15,14 +15,7 @@ from desc.integrals import Bounce2D
 @pytest.mark.mpl_image_compare(remove_text=True, tolerance=tol_1d)
 @pytest.mark.parametrize("nufft_eps", [0, 1e-6])
 def test_effective_ripple_2D(nufft_eps):
-    """Test effective ripple with W7-X against NEO.
-
-    If this test has a peak memory consumption of more than 2.7 GB on JAX version 0.5.0
-    or more than 5.7 GB on JAX versions 0.5.3+, then there is another memory regression.
-    These values are for the test where nufft_eps is zero.
-    https://github.com/jax-ml/jax/issues/30627.
-    For nufft_eps nonzero with surf_batch_size = 2, memory is 1 GB.
-    """
+    """Test effective ripple with W7-X against NEO."""
     eq = get("W7-X")
     rho = np.linspace(0, 1, 10)
     grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=False)


### PR DESCRIPTION
use einsum and the like to save memory since at this point it's clear jax won't fix the memory regression in 0.5.3