### PR TITLE
NFP bug fix in `MagneticField.save_mgrid()` and `SplineMagneticField.from_field()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ alternative to fourier continuation methods.
 
 Bug Fixes
 
-- No longer uses the full Hessian to compute the scale when ``x_scale="auto"`` and using a scipy optimizer that approximates the hessian (e.g. if using ``"scipy-bfgs"``, no longer attempts the Hessian computation to get the x_scale)
+- No longer uses the full Hessian to compute the scale when ``x_scale="auto"`` and using a scipy optimizer that approximates the hessian (e.g. if using ``"scipy-bfgs"``, no longer attempts the Hessian computation to get the x_scale).
+- ``SplineMagneticField.from_field()`` correctly uses the ``NFP`` input when given. Also adds this as a similar input option to ``MagneticField.save_mgrid()``.
 
 Performance Improvements
 

--- a/desc/magnetic_fields/_core.py
+++ b/desc/magnetic_fields/_core.py
@@ -617,6 +617,8 @@ class _MagneticField(IOAble, ABC):
         path = os.path.expanduser(path)
         # cylindrical coordinates grid
         NFP = getattr(self, "_NFP", 1) if NFP is None else NFP
+        if hasattr(self, "_NFP"):
+            warnif(NFP != self.NFP, UserWarning, "NFP input is not equal to field.NFP.")
         R = np.linspace(Rmin, Rmax, nR)
         Z = np.linspace(Zmin, Zmax, nZ)
         phi = np.linspace(0, 2 * np.pi / NFP, nphi, endpoint=False)
@@ -2226,6 +2228,10 @@ class SplineMagneticField(_MagneticField, Optimizable):
             coords, params, basis="rpz", chunk_size=chunk_size, source_grid=source_grid
         ).T
         NFP = getattr(field, "_NFP", 1) if NFP is None else NFP
+        if hasattr(field, "_NFP"):
+            warnif(
+                NFP != field.NFP, UserWarning, "NFP input is not equal to field.NFP."
+            )
         try:
             AR, AP, AZ = field.compute_magnetic_vector_potential(
                 coords,

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -1074,9 +1074,12 @@ class TestMagneticFields:
         field2 = SplineMagneticField.from_field(
             field1, R, p, Z, source_grid=LinearGrid(N=1)
         )
-        # this is just to test the logic when
-        # compute_vector_potential returns a ValueError
+        # test the logic when compute_vector_potential returns a ValueError
         _ = SplineMagneticField.from_field(field2, R, p, Z, source_grid=LinearGrid(N=1))
+        # test NFP warning
+        with pytest.warns(UserWarning):
+            # user warning because NFP != field.NFP
+            _ = SplineMagneticField.from_field(field1, R, p, Z, NFP=3)
 
         np.testing.assert_allclose(
             field1([1.0, 1.0, 1.0]), field2([1.0, 1.0, 1.0]), rtol=1e-2, atol=1e-2


### PR DESCRIPTION
This fixes two small bugs related to NFP in the magnetic field classes:

1. `SplineMagneticField.from_field()` took an input argument `NFP` but never actually used it. It would always use `field.NFP` or default to 1 instead. This PR allows the input argument to override the field's attribute. 
2. `MagneticField.save_mgrid()` would always use `self.NFP` or default to 1 if the attribute didn't exist. This PR adds `NFP` as an input argument to override this logic (same as above). 

Here is an example where overriding the default `field.NFP` attribute is useful: 
```
coil0 = FourierPlanarCoil(center=[2, 0, 0], normal=[0, 1, 0], r_n=[1])
coil1 = FourierPlanarCoil(center=[2, 0, 0], normal=[0, 1, 0], r_n=[2])
coilset0 = CoilSet(coil0, NFP=4)
coilset1 = CoilSet(coil1, NFP=4)
mixed_coilset = MixedCoilSet((coilset0, coilset1))
```
A `MixedCoilSet` always has `NFP = 1` by construction, even though all of its coils in this example have NFP=4 symmetry. With the changes in this PR, you can then take advantage of this field period symmetry by manually passing in the NFP argument: 
```
spline_field = SplineMagneticField.from_field(mixed_coilset, NFP=4)
mixed_coilset.save_mgrid("mgrid.nc", NFP=4)
```
