### PR TITLE
Fix error message formatting in _omnigenity.py

### DIFF
--- a/desc/objectives/_omnigenity.py
+++ b/desc/objectives/_omnigenity.py
@@ -678,7 +678,7 @@ class Omnigenity(_Objective):
         )
         errorif(
             jnp.any(field.B_lm[: field.M_B] < 0),
-            "|B| on axis must be positive! Check B_lm input.",
+            msg="|B| on axis must be positive! Check B_lm input.",
         )
 
         timer = Timer()


### PR DESCRIPTION
The second argument of 'errorif' is 'err', so the error message must use the keyword 'msg' explicitly.