### PR TITLE
Fix `np` bug in `LinearConstraintProjection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Bug Fixes
 
 - No longer uses the full Hessian to compute the scale when ``x_scale="auto"`` and using a scipy optimizer that approximates the hessian (e.g. if using ``"scipy-bfgs"``, no longer attempts the Hessian computation to get the x_scale).
 - ``SplineMagneticField.from_field()`` correctly uses the ``NFP`` input when given. Also adds this as a similar input option to ``MagneticField.save_mgrid()``.
+- Fixes bug that was overriding some components of the user supplied ``linear_constraint_options["x_scale"]``. Now, the given value is used without any alterations.
 
 Performance Improvements
 

--- a/desc/objectives/utils.py
+++ b/desc/objectives/utils.py
@@ -123,15 +123,17 @@ def factorize_linear_constraints(objective, constraint, x_scale="auto"):  # noqa
     # compute x_scale if not provided
     # Note: this x_scale is not the same as the x_scale as in solve_options["x_scale"]
     # but the one given as solve_options["linear_constraint_options"]["x_scale"]
-    if x_scale == "auto":
+    if isinstance(x_scale, str) and x_scale == "auto":
         x_scale = objective.x(*objective.things)
+        D = np.where(np.abs(x_scale) < 1e2, 1, np.abs(x_scale))
+    else:
+        D = x_scale
     errorif(
         x_scale.shape != xp.shape,
         ValueError,
         "x_scale must be the same size as the full state vector. "
         + f"Got size {x_scale.size} for state vector of size {xp.size}.",
     )
-    D = np.where(np.abs(x_scale) < 1e2, 1, np.abs(x_scale))
 
     # null space & particular solution
     A = A * D[None, unfixed_idx]

--- a/tests/test_linear_objectives.py
+++ b/tests/test_linear_objectives.py
@@ -1241,6 +1241,7 @@ def test_linearconstraintprojection_xscale():
     eq = desc.examples.get("DSHAPE")
     with pytest.warns(UserWarning, match="Reducing radial"):
         eq.change_resolution(L=2, M=2, L_grid=4, M_grid=4)
+    # use standard fixed boundary constraints as test
     cons = get_fixed_boundary_constraints(eq)
     cons = maybe_add_self_consistency(eq, cons)
     con = ObjectiveFunction(cons)


### PR DESCRIPTION
- Fixes the bug in `factorize_linear_constraints` for numpy array `x_scale`
- Removes any change applied to the user-supplied `x_scale`. For example, if I want to give a scale to lambda (to make it have a similar magnitude as R and Z) based on the major radius etc. currently I cannot because the check x<100 will override that scale.