### PR TITLE
Add ITG turbulence proxy and neural network objectives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ alternative to fourier continuation methods.
 - Adds ``"scipy-l-bfgs-b"`` optimizer option as a wrapper to scipy's ``"l-bfgs-b"`` method.
 - Adds ``check_intersection`` flag to ``desc.magnetic_fields.FourierCurrentPotentialField.to_Coilset``, to allow the choice of checking the resulting coilset for intersections or not.
 - Changes the import paths for ``desc.external`` to require reference to the sub-modules.
+- Adds ``ITGProxy`` and ``NNITGProxy`` objective classes for ITG turbulence optimization based on Landreman et al. 2025, with GX geometric feature compute functions and flux tube geometry utilities.
 
 Bug Fixes
 

--- a/desc/compute/__init__.py
+++ b/desc/compute/__init__.py
@@ -43,6 +43,7 @@ from . import (
     _profiles,
     _stability,
     _surface,
+    _turbulence,
 )
 from .data_index import all_kwargs, allowed_kwargs, data_index
 from .utils import (

--- a/desc/compute/_turbulence.py
+++ b/desc/compute/_turbulence.py
@@ -1,0 +1,88 @@
+"""Compute functions for ITG turbulence proxies and related quantities.
+
+This module provides GX geometric coefficients and ITG turbulence proxies
+for gyrokinetic turbulence prediction. The implementation follows the
+conventions established in Landreman et al. 2025 (arXiv:2502.11657).
+
+Notes
+-----
+Reference quantities use the following normalizations:
+- B_reference = 2|ψ_b|/a² where ψ_b is the boundary toroidal flux
+- L_reference = a (minor radius)
+
+Some quantities may have singularities at the magnetic axis (ρ=0).
+Objectives using these quantities should use ρ > 0.
+"""
+
+from desc.backend import jnp
+
+from .data_index import register_compute_fun
+
+
+# =============================================================================
+# Reference Quantities
+# =============================================================================
+
+
+@register_compute_fun(
+    name="gx_B_reference",
+    label="B_{\\mathrm{ref}}",
+    units="T",
+    units_long="Tesla",
+    description="GX reference magnetic field: B_ref = 2|ψ_b|/a²",
+    dim=0,
+    params=["Psi"],
+    transforms={},
+    profiles=[],
+    coordinates="",
+    data=["a"],
+)
+def _gx_B_reference(params, transforms, profiles, data, **kwargs):
+    # ψ_b = Psi/(2π) is the boundary toroidal flux
+    psi_b = jnp.abs(params["Psi"]) / (2 * jnp.pi)
+    data["gx_B_reference"] = 2 * psi_b / data["a"] ** 2
+    return data
+
+
+@register_compute_fun(
+    name="gx_L_reference",
+    label="L_{\\mathrm{ref}}",
+    units="m",
+    units_long="meters",
+    description="GX reference length: L_ref = a (minor radius)",
+    dim=0,
+    params=[],
+    transforms={},
+    profiles=[],
+    coordinates="",
+    data=["a"],
+)
+def _gx_L_reference(params, transforms, profiles, data, **kwargs):
+    data["gx_L_reference"] = data["a"]
+    return data
+
+
+# =============================================================================
+# Normalized Magnetic Field
+# =============================================================================
+
+
+@register_compute_fun(
+    name="gx_bmag",
+    label="|\\mathbf{B}|/B_{\\mathrm{ref}}",
+    units="~",
+    units_long="dimensionless",
+    description="Normalized magnetic field magnitude |B|/B_ref for GX",
+    dim=1,
+    params=["Psi"],
+    transforms={},
+    profiles=[],
+    coordinates="rtz",
+    data=["|B|", "a"],
+)
+def _gx_bmag(params, transforms, profiles, data, **kwargs):
+    # B_ref = 2|ψ_b|/a² where ψ_b = Psi/(2π)
+    psi_b = jnp.abs(params["Psi"]) / (2 * jnp.pi)
+    B_ref = 2 * psi_b / data["a"] ** 2
+    data["gx_bmag"] = data["|B|"] / B_ref
+    return data

--- a/desc/compute/_turbulence.py
+++ b/desc/compute/_turbulence.py
@@ -11,7 +11,7 @@ from scipy.constants import mu_0
 
 from desc.backend import jnp
 
-from ..utils import cross, dot
+from ..utils import cross, dot, safediv
 from .data_index import register_compute_fun
 
 # Slope for smooth Heaviside (sigmoid) used in ITG proxy
@@ -152,8 +152,8 @@ def _gx_gds22_over_shat_squared(params, transforms, profiles, data, **kwargs):
     L_ref = data["gx_L_reference"]
     B_ref = data["gx_B_reference"]
     s = data["rho"] ** 2
-    data["gx_gds22_over_shat_squared"] = data["|grad(psi)|^2"] / (
-        L_ref**2 * B_ref**2 * s
+    data["gx_gds22_over_shat_squared"] = safediv(
+        data["|grad(psi)|^2"], L_ref**2 * B_ref**2 * s
     )
     return data
 

--- a/desc/compute/_turbulence.py
+++ b/desc/compute/_turbulence.py
@@ -509,37 +509,6 @@ def resample_to_uniform_arclength(arclength, data, npoints_out):
     return z_uniform, data_uniform
 
 
-def compute_flux_tube_length(gradpar, theta_pest):
-    """Compute total flux tube length from gradpar.
-
-    The flux tube length is the integral of dl along the field line,
-    where dl/d(theta_PEST) = 1/|gradpar|.
-
-    Parameters
-    ----------
-    gradpar : ndarray, shape (npoints,)
-        GX gradpar coefficient along the field line.
-    theta_pest : ndarray, shape (npoints,)
-        Straight-field-line poloidal angles (assumed uniformly spaced).
-
-    Returns
-    -------
-    length : float
-        Total flux tube length in units of L_ref (since gx_gradpar includes L_ref).
-
-    Notes
-    -----
-    This is equivalent to ``arclength[-1]`` from ``compute_arclength_via_gradpar``,
-    but provided as a separate function for clarity.
-
-    See Also
-    --------
-    compute_arclength_via_gradpar : Compute cumulative arclength.
-    """
-    arclength = compute_arclength_via_gradpar(gradpar, theta_pest)
-    return arclength[-1]
-
-
 def solve_poloidal_turns_for_length(length_fn, target_length, x0_guess=1.0):
     """Solve for poloidal turns to achieve a target flux tube length.
 
@@ -581,7 +550,7 @@ def solve_poloidal_turns_for_length(length_fn, target_length, x0_guess=1.0):
 
     See Also
     --------
-    compute_flux_tube_length : Compute length from gradpar.
+    compute_arclength_via_gradpar : Compute cumulative arclength from gradpar.
 
     Examples
     --------
@@ -589,7 +558,7 @@ def solve_poloidal_turns_for_length(length_fn, target_length, x0_guess=1.0):
     ...     # Compute gradpar for this many poloidal turns
     ...     theta_pest = np.linspace(-np.pi * poloidal_turns, np.pi * poloidal_turns, 1001)
     ...     gradpar = compute_gradpar_for_field_line(eq, rho, alpha, theta_pest)
-    ...     return compute_flux_tube_length(gradpar, theta_pest)
+    ...     return np.abs(np.trapezoid(1.0 / gradpar, theta_pest))
     >>> poloidal_turns = solve_poloidal_turns_for_length(length_fn, target_length=75.4)
     """
     from scipy.optimize import brentq

--- a/desc/compute/_turbulence.py
+++ b/desc/compute/_turbulence.py
@@ -259,3 +259,31 @@ def _gx_gbdrift0_over_shat(params, transforms, profiles, data, **kwargs):
         2 * psi_sign * B_cross_grad_B_dot_grad_psi / (data["|B|"] ** 3 * sqrt_s)
     )
     return data
+
+
+# =============================================================================
+# Parallel Gradient
+# =============================================================================
+
+
+@register_compute_fun(
+    name="gx_gradpar",
+    label="L_{\\mathrm{ref}} \\mathbf{b} \\cdot \\nabla",
+    units="~",
+    units_long="dimensionless",
+    description="GX gradpar: L_ref * (B^θ*(1+λ_θ) + B^ζ*λ_ζ) / |B|",
+    dim=1,
+    params=[],
+    transforms={},
+    profiles=[],
+    coordinates="rtz",
+    data=["a", "|B|", "B^theta", "B^zeta", "lambda_t", "lambda_z"],
+)
+def _gx_gradpar(params, transforms, profiles, data, **kwargs):
+    L_ref = data["a"]
+    data["gx_gradpar"] = (
+        L_ref
+        * (data["B^theta"] * (1 + data["lambda_t"]) + data["B^zeta"] * data["lambda_z"])
+        / data["|B|"]
+    )
+    return data

--- a/desc/compute/_turbulence.py
+++ b/desc/compute/_turbulence.py
@@ -16,6 +16,7 @@ Objectives using these quantities should use ρ > 0.
 
 from desc.backend import jnp
 
+from ..utils import dot
 from .data_index import register_compute_fun
 
 
@@ -38,7 +39,6 @@ from .data_index import register_compute_fun
     data=["a"],
 )
 def _gx_B_reference(params, transforms, profiles, data, **kwargs):
-    # ψ_b = Psi/(2π) is the boundary toroidal flux
     psi_b = jnp.abs(params["Psi"]) / (2 * jnp.pi)
     data["gx_B_reference"] = 2 * psi_b / data["a"] ** 2
     return data
@@ -81,8 +81,79 @@ def _gx_L_reference(params, transforms, profiles, data, **kwargs):
     data=["|B|", "a"],
 )
 def _gx_bmag(params, transforms, profiles, data, **kwargs):
-    # B_ref = 2|ψ_b|/a² where ψ_b = Psi/(2π)
     psi_b = jnp.abs(params["Psi"]) / (2 * jnp.pi)
     B_ref = 2 * psi_b / data["a"] ** 2
     data["gx_bmag"] = data["|B|"] / B_ref
+    return data
+
+
+# =============================================================================
+# Gradient Coefficients
+# =============================================================================
+
+
+@register_compute_fun(
+    name="gx_gds2",
+    label="|\\nabla \\alpha|^2 L_{\\mathrm{ref}}^2 s",
+    units="~",
+    units_long="dimensionless",
+    description="GX gds2: |grad(alpha)|^2 * L_ref^2 * s, where s = rho^2",
+    dim=1,
+    params=[],
+    transforms={},
+    profiles=[],
+    coordinates="rtz",
+    data=["a", "rho", "grad(alpha)"],
+)
+def _gx_gds2(params, transforms, profiles, data, **kwargs):
+    L_ref = data["a"]
+    s = data["rho"] ** 2
+    grad_alpha_sq = dot(data["grad(alpha)"], data["grad(alpha)"])
+    data["gx_gds2"] = grad_alpha_sq * L_ref**2 * s
+    return data
+
+
+@register_compute_fun(
+    name="gx_gds21_over_shat",
+    label="\\mathrm{gds21} / \\hat{s}",
+    units="~",
+    units_long="dimensionless",
+    description="GX gds21/shat: grad(alpha).grad(psi) * sigma_Bxy / B_ref",
+    dim=1,
+    params=["Psi"],
+    transforms={},
+    profiles=[],
+    coordinates="rtz",
+    data=["a", "grad(alpha)", "grad(psi)"],
+)
+def _gx_gds21_over_shat(params, transforms, profiles, data, **kwargs):
+    sigma_Bxy = -1  # GX sign convention
+    psi_b = params["Psi"] / (2 * jnp.pi)
+    B_ref = 2 * psi_b / data["a"] ** 2
+    grad_alpha_dot_grad_psi = dot(data["grad(alpha)"], data["grad(psi)"])
+    data["gx_gds21_over_shat"] = sigma_Bxy * grad_alpha_dot_grad_psi / B_ref
+    return data
+
+
+@register_compute_fun(
+    name="gx_gds22_over_shat_squared",
+    label="\\mathrm{gds22} / \\hat{s}^2",
+    units="~",
+    units_long="dimensionless",
+    description="GX gds22/shat^2: |grad(psi)|^2 / (L_ref^2 * B_ref^2 * s)",
+    dim=1,
+    params=["Psi"],
+    transforms={},
+    profiles=[],
+    coordinates="rtz",
+    data=["a", "rho", "|grad(psi)|^2"],
+)
+def _gx_gds22_over_shat_squared(params, transforms, profiles, data, **kwargs):
+    psi_b = params["Psi"] / (2 * jnp.pi)
+    B_ref = 2 * psi_b / data["a"] ** 2
+    L_ref = data["a"]
+    s = data["rho"] ** 2
+    data["gx_gds22_over_shat_squared"] = (
+        data["|grad(psi)|^2"] / (L_ref**2 * B_ref**2 * s)
+    )
     return data

--- a/desc/compute/_turbulence.py
+++ b/desc/compute/_turbulence.py
@@ -656,9 +656,15 @@ def _conv1d_circular(x, weight, bias, kernel_size):
     The circular padding ensures that conv1d output has the same length as
     input (equivalent to PyTorch's padding='same' with padding_mode='circular').
     This maintains the periodic structure of the flux tube geometry.
+
+    The padding is asymmetric for even kernel sizes to match PyTorch exactly:
+    - For kernel_size=3: pad_left=1, pad_right=1 (symmetric)
+    - For kernel_size=4: pad_left=1, pad_right=2 (asymmetric)
     """
-    pad = (kernel_size - 1) // 2
-    x_padded = _circular_pad_1d(x, pad, pad)
+    total_pad = kernel_size - 1
+    pad_left = total_pad // 2
+    pad_right = total_pad - pad_left
+    x_padded = _circular_pad_1d(x, pad_left, pad_right)
 
     out = jax.lax.conv_general_dilated(
         x_padded,

--- a/desc/objectives/__init__.py
+++ b/desc/objectives/__init__.py
@@ -56,7 +56,7 @@ from ._omnigenity import (
 from ._power_balance import FusionPower, HeatingPowerISS04
 from ._profiles import Pressure, RotationalTransform, Shear, ToroidalCurrent
 from ._stability import BallooningStability, MagneticWell, MercierStability
-from ._turbulence import ITGProxy
+from ._turbulence import ITGProxy, NNITGProxy
 from .getters import (
     get_equilibrium_objective,
     get_fixed_axis_constraints,

--- a/desc/objectives/__init__.py
+++ b/desc/objectives/__init__.py
@@ -56,6 +56,7 @@ from ._omnigenity import (
 from ._power_balance import FusionPower, HeatingPowerISS04
 from ._profiles import Pressure, RotationalTransform, Shear, ToroidalCurrent
 from ._stability import BallooningStability, MagneticWell, MercierStability
+from ._turbulence import ITGProxy
 from .getters import (
     get_equilibrium_objective,
     get_fixed_axis_constraints,

--- a/desc/objectives/_turbulence.py
+++ b/desc/objectives/_turbulence.py
@@ -1,0 +1,219 @@
+"""Objectives for ITG turbulence optimization."""
+
+import numpy as np
+
+from desc.backend import jnp
+from desc.compute import get_profiles, get_transforms
+from desc.compute.utils import _compute as compute_fun
+from desc.grid import LinearGrid
+from desc.utils import setdefault
+
+from .objective_funs import _Objective, collect_docs
+
+
+class ITGProxy(_Objective):
+    """ITG turbulence proxy from Landreman et al. 2025.
+
+    This objective computes the analytical proxy for Ion Temperature Gradient
+    (ITG) turbulence heat flux. The proxy is defined as:
+
+    f_Q = mean((sigmoid(cvdrift) + 0.2) * |grad_x|^3 / B)
+
+    Lower values indicate configurations with reduced ITG turbulence.
+
+    Parameters
+    ----------
+    eq : Equilibrium
+        Equilibrium to be optimized.
+    rho : float or array-like
+        Flux surface(s) to evaluate on.
+    alpha : float or array-like, optional
+        Field line labels to evaluate. Default is 8 field lines in [0, pi]
+        for non-axisymmetric cases, or alpha=0 for axisymmetric.
+    nturns : int, optional
+        Number of toroidal transits per field line. Default is 3.
+    nzetaperturn : int, optional
+        Number of points per toroidal transit. Default is 100.
+
+    """
+
+    __doc__ = __doc__.rstrip() + collect_docs(
+        target_default="``target=0``.",
+        bounds_default="``target=0``.",
+        normalize_detail=" Note: Has no effect for this objective.",
+        normalize_target_detail=" Note: Has no effect for this objective.",
+    )
+
+    _static_attrs = _Objective._static_attrs + [
+        "_iota_keys",
+        "_nturns",
+        "_nzetaperturn",
+        "_add_lcfs",
+    ]
+
+    _coordinates = "r"
+    _units = "~"
+    _print_value_fmt = "ITG Proxy f_Q: "
+
+    def __init__(
+        self,
+        eq,
+        rho,
+        target=None,
+        bounds=None,
+        weight=1,
+        normalize=True,
+        normalize_target=True,
+        loss_function=None,
+        deriv_mode="auto",
+        alpha=None,
+        nturns=3,
+        nzetaperturn=100,
+        name="ITG Proxy",
+        jac_chunk_size=None,
+    ):
+        if target is None and bounds is None:
+            target = 0
+
+        self._nturns = nturns
+        self._nzetaperturn = nzetaperturn
+        self._rho = np.atleast_1d(rho)
+        self._add_lcfs = np.all(self._rho < 0.97)
+        self._alpha = setdefault(
+            alpha,
+            (
+                jnp.linspace(0, (1 + eq.sym) * jnp.pi, (1 + eq.sym) * 8)
+                if eq.N
+                else jnp.array([0])
+            ),
+        )
+
+        super().__init__(
+            things=eq,
+            target=target,
+            bounds=bounds,
+            weight=weight,
+            normalize=normalize,
+            normalize_target=normalize_target,
+            loss_function=loss_function,
+            deriv_mode=deriv_mode,
+            name=name,
+            jac_chunk_size=jac_chunk_size,
+        )
+
+    def build(self, use_jit=True, verbose=1):
+        """Build constant arrays.
+
+        Parameters
+        ----------
+        use_jit : bool, optional
+            Whether to just-in-time compile the objective and derivatives.
+        verbose : int, optional
+            Level of output.
+
+        """
+        self._iota_keys = ["iota", "iota_r", "shear", "a"]
+
+        eq = self.things[0]
+        iota_grid = LinearGrid(
+            rho=np.append(self._rho, 1) if self._add_lcfs else self._rho,
+            M=eq.M_grid,
+            N=eq.N_grid,
+            NFP=eq.NFP,
+            sym=eq.sym,
+        )
+        assert not iota_grid.axis.size
+        self._dim_f = iota_grid.num_rho - self._add_lcfs
+        transforms = get_transforms(self._iota_keys, eq, iota_grid)
+        profiles = get_profiles(
+            self._iota_keys + ["ITG proxy integrand"], eq, iota_grid
+        )
+        self._constants = {
+            "rho": self._rho,
+            "alpha": self._alpha,
+            "zeta": jnp.linspace(
+                -self._nturns * jnp.pi,
+                +self._nturns * jnp.pi,
+                +self._nturns * self._nzetaperturn,
+            ),
+            "iota_transforms": transforms,
+            "profiles": profiles,
+            "quad_weights": 1.0,
+        }
+        super().build(use_jit=use_jit, verbose=verbose)
+
+    def compute(self, params, constants=None):
+        """Compute the ITG turbulence proxy.
+
+        Parameters
+        ----------
+        params : dict
+            Dictionary of equilibrium degrees of freedom.
+        constants : dict
+            Dictionary of constant data. Defaults to self.constants.
+
+        Returns
+        -------
+        f_Q : ndarray
+            ITG proxy values for each flux surface.
+
+        """
+        if constants is None:
+            constants = self.constants
+        eq = self.things[0]
+
+        # Compute iota on the iota grid
+        iota_data = compute_fun(
+            eq,
+            self._iota_keys,
+            params,
+            constants["iota_transforms"],
+            constants["profiles"],
+        )
+        iota_grid = constants["iota_transforms"]["grid"]
+
+        def get(key):
+            x = iota_grid.compress(iota_data[key])
+            return x[:-1] if self._add_lcfs else x
+
+        iota = get("iota")
+
+        # Create field-aligned grid
+        grid = eq._get_rtz_grid(
+            constants["rho"],
+            constants["alpha"],
+            constants["zeta"],
+            coordinates="raz",
+            iota=iota,
+            params=params,
+        )
+
+        # Prepare data for the compute function
+        data = {
+            key: grid.expand(get(key))
+            for key in self._iota_keys
+            if (key != "iota" and key != "a")
+        }
+        data["iota"] = grid.expand(iota)
+        data["a"] = iota_data["a"]
+
+        # Compute the ITG proxy integrand
+        data = compute_fun(
+            eq,
+            ["ITG proxy integrand"],
+            params,
+            transforms=get_transforms(["ITG proxy integrand"], eq, grid, jitable=True),
+            profiles=constants["profiles"],
+            data=data,
+        )
+
+        # Average over field line to get per-flux-surface values
+        integrand = data["ITG proxy integrand"]
+        num_rho = len(constants["rho"])
+        num_alpha = len(constants["alpha"])
+        num_zeta = len(constants["zeta"])
+
+        integrand_reshaped = integrand.reshape(num_zeta, num_rho, num_alpha)
+        f_Q = jnp.mean(integrand_reshaped, axis=(0, 2))
+
+        return f_Q

--- a/desc/objectives/_turbulence.py
+++ b/desc/objectives/_turbulence.py
@@ -943,6 +943,15 @@ class NNITGProxy(_Objective):
         for i_rho in range(num_rho):
             gradpar_2d = gradpar_3d[:, i_rho, :]
             signals_2d = jnp.stack([gx_features[k][:, i_rho, :] for k in gx_keys])
+
+            # Correct z-direction reversal for zeta parameterization.
+            # When iota < 0, uniform zeta traverses the field line opposite to
+            # the gx_geometry convention (uniform theta_pest), flipping the sign
+            # of anti-symmetric features along the field line.
+            iota_sign = jnp.sign(iota_arr[i_rho])
+            signals_2d = signals_2d.at[3].multiply(iota_sign)  # gbdrift0/shat
+            signals_2d = signals_2d.at[5].multiply(iota_sign)  # gds21/shat
+
             theta_pest_offset_rho = iota_arr[i_rho] * zeta_offset
 
             result = self._run_cnn_inference_for_rho(

--- a/desc/objectives/_turbulence.py
+++ b/desc/objectives/_turbulence.py
@@ -4,8 +4,17 @@ import numpy as np
 
 from desc.backend import jnp
 from desc.compute import get_profiles, get_transforms
+from desc.compute._turbulence import (
+    _cyclic_invariant_forward,
+    _ensemble_forward,
+    _load_ensemble_weights_cached,
+    _load_nn_weights,
+    compute_arclength_via_gradpar,
+    resample_to_uniform_arclength,
+    solve_poloidal_turns_for_length,
+)
 from desc.compute.utils import _compute as compute_fun
-from desc.grid import LinearGrid
+from desc.grid import Grid, LinearGrid
 from desc.utils import setdefault
 
 from .objective_funs import _Objective, collect_docs
@@ -192,7 +201,7 @@ class ITGProxy(_Objective):
         data = {
             key: grid.expand(get(key))
             for key in self._iota_keys
-            if (key != "iota" and key != "a")
+            if key not in ("iota", "a")
         }
         data["iota"] = grid.expand(iota)
         data["a"] = iota_data["a"]
@@ -217,3 +226,326 @@ class ITGProxy(_Objective):
         f_Q = jnp.mean(integrand_reshaped, axis=(0, 2))
 
         return f_Q
+
+
+class NNITGProxy(_Objective):
+    """Neural network ITG turbulence proxy from Landreman et al. 2025.
+
+    Uses a trained CNN to predict ITG-driven heat flux based on the 7 GX
+    geometric coefficients along a flux tube. The CNN was trained on over
+    200,000 GX gyrokinetic simulations.
+
+    The model takes as input:
+    - 7 geometric features along the field line (bmag, gbdrift, cvdrift, etc.)
+    - Temperature gradient scale length (a/LT)
+    - Density gradient scale length (a/Ln)
+
+    And predicts the gyro-Bohm normalized heat flux Q.
+
+    Two modes are supported:
+    - **Single model mode**: Using `model_path` for a single .pt/.pth file
+    - **Ensemble mode**: Using `ensemble_dir` and `ensemble_csv` for multiple models
+
+    Parameters
+    ----------
+    eq : Equilibrium
+        Equilibrium that will be optimized to satisfy the Objective.
+    rho : float or array-like
+        Flux surface(s) to evaluate on. Must be specified (no default).
+    alpha : float or array-like, optional
+        Field line labels to evaluate. Values should be in [0, 2pi).
+        Default is alpha=0.
+    npoints : int, optional
+        Number of points along the field line for CNN input. Grid is periodic
+        with endpoint excluded (i.e., uniform in [-π, π)). Default is 96.
+    nz_internal : int, optional
+        Number of internal grid points for accurate arclength computation.
+        Default is 1001.
+    target_flux_tube_length : float, optional
+        Target flux tube length. Default is 75.4 (= 4*pi*6).
+    a_over_LT : float, optional
+        Normalized inverse temperature gradient scale length. Default 3.0.
+    a_over_Ln : float, optional
+        Normalized inverse density gradient scale length. Default 1.0.
+    model_path : str, optional
+        Path to the trained model weights (single-model mode).
+    ensemble_dir : str, optional
+        Path to directory containing ensemble model files (.pth).
+    ensemble_csv : str, optional
+        Path to results.csv with DeepHyper scores for model selection.
+        Required if ensemble_dir is specified.
+    n_ensemble : int, optional
+        Number of top-performing models to use for ensemble. Default 10.
+
+    """
+
+    __doc__ = __doc__.rstrip() + collect_docs(
+        target_default="``target=0``.",
+        bounds_default="``target=0``.",
+        normalize_detail=" Note: Has no effect for this objective.",
+        normalize_target_detail=" Note: Has no effect for this objective.",
+    )
+
+    _static_attrs = _Objective._static_attrs + [
+        "_gx_keys",
+        "_iota_keys",
+        "_npoints",
+        "_nz_internal",
+        "_target_flux_tube_length",
+        "_a_over_LT",
+        "_a_over_Ln",
+        "_model_path",
+        "_ensemble_dir",
+        "_ensemble_csv",
+        "_n_ensemble",
+    ]
+
+    _coordinates = "r"
+    _units = "~"
+    _print_value_fmt = "NN ITG Q: "
+
+    def __init__(
+        self,
+        eq,
+        rho,
+        target=None,
+        bounds=None,
+        weight=1,
+        normalize=True,
+        normalize_target=True,
+        loss_function=None,
+        deriv_mode="auto",
+        alpha=None,
+        npoints=96,
+        nz_internal=1001,
+        target_flux_tube_length=75.4,
+        a_over_LT=3.0,
+        a_over_Ln=1.0,
+        model_path=None,
+        ensemble_dir=None,
+        ensemble_csv=None,
+        n_ensemble=10,
+        name="NN ITG Proxy",
+        jac_chunk_size=None,
+    ):
+        if target is None and bounds is None:
+            target = 0
+
+        # Validate ensemble parameters
+        if ensemble_dir is not None and ensemble_csv is None:
+            raise ValueError("ensemble_csv must be specified when using ensemble_dir")
+
+        self._npoints = npoints
+        self._nz_internal = nz_internal
+        self._target_flux_tube_length = target_flux_tube_length
+        self._a_over_LT = a_over_LT
+        self._a_over_Ln = a_over_Ln
+        self._model_path = model_path
+        self._ensemble_dir = ensemble_dir
+        self._ensemble_csv = ensemble_csv
+        self._n_ensemble = n_ensemble
+        self._rho = np.atleast_1d(rho)
+        self._alpha = np.atleast_1d(setdefault(alpha, jnp.array([0.0])))
+
+        super().__init__(
+            things=eq,
+            target=target,
+            bounds=bounds,
+            weight=weight,
+            normalize=normalize,
+            normalize_target=normalize_target,
+            loss_function=loss_function,
+            deriv_mode=deriv_mode,
+            name=name,
+            jac_chunk_size=jac_chunk_size,
+        )
+
+    def build(self, use_jit=True, verbose=1):
+        """Build constant arrays.
+
+        Parameters
+        ----------
+        use_jit : bool, optional
+            Whether to just-in-time compile the objective and derivatives.
+        verbose : int, optional
+            Level of output.
+
+        """
+        # GX coefficient keys for CNN input
+        self._gx_keys = [
+            "gx_bmag",
+            "gx_gbdrift",
+            "gx_cvdrift",
+            "gx_gbdrift0_over_shat",
+            "gx_gds2",
+            "gx_gds21_over_shat",
+            "gx_gds22_over_shat_squared",
+            "gx_gradpar",
+        ]
+        # Iota and related quantities needed for coordinate mapping
+        self._iota_keys = ["iota", "iota_r", "shear", "a", "p_r"]
+
+        eq = self.things[0]
+        iota_grid = LinearGrid(
+            rho=self._rho,
+            M=eq.M_grid,
+            N=eq.N_grid,
+            NFP=eq.NFP,
+            sym=eq.sym,
+        )
+        self._dim_f = len(self._rho)
+        transforms = get_transforms(self._iota_keys, eq, iota_grid)
+        profiles = get_profiles(self._iota_keys + self._gx_keys, eq, iota_grid)
+
+        # Compute target flux tube length
+        eq_data = eq.compute(["a"])
+        minor_radius = float(eq_data["a"])
+
+        target_length = self._target_flux_tube_length
+
+        # Compute iota at reference rho for poloidal_turns computation
+        iota_data = compute_fun(
+            eq, self._iota_keys, eq.params_dict, transforms, profiles
+        )
+        iota = iota_grid.compress(iota_data["iota"])
+
+        # Use first rho/alpha as reference for solving poloidal_turns
+        rho_ref = float(self._rho[0])
+        alpha_ref = float(self._alpha[0])
+        iota_ref = float(iota[0])
+        iota_r_ref = float(iota_grid.compress(iota_data["iota_r"])[0])
+
+        def length_fn(poloidal_turns):
+            """Compute flux tube length for given poloidal_turns."""
+            # Uniform θ_PEST grid
+            theta_pest_offset = jnp.linspace(
+                -jnp.pi * poloidal_turns, jnp.pi * poloidal_turns, self._nz_internal
+            )
+            theta_pest = alpha_ref + theta_pest_offset
+            zeta = theta_pest_offset / iota_ref
+
+            # Map PEST → DESC coordinates
+            rho_arr = jnp.full(self._nz_internal, rho_ref)
+            coords_pest = jnp.column_stack([rho_arr, theta_pest, zeta])
+            desc_coords = eq.map_coordinates(
+                coords_pest,
+                inbasis=("rho", "theta_PEST", "zeta"),
+                outbasis=("rho", "theta", "zeta"),
+                params=eq.params_dict,
+                tol=1e-10,
+                maxiter=50,
+            )
+            theta_desc = desc_coords[:, 1]
+
+            # Fix theta wrapping for continuity
+            theta_desc = theta_desc + 2 * jnp.pi * jnp.round(
+                (theta_pest - theta_desc) / (2 * jnp.pi)
+            )
+
+            # Create grid and compute gradpar
+            grid = Grid(
+                jnp.column_stack([rho_arr, theta_desc, zeta]), sort=False, jitable=True
+            )
+            data = compute_fun(
+                eq,
+                ["gx_gradpar"],
+                eq.params_dict,
+                get_transforms(["gx_gradpar"], eq, grid, jitable=True),
+                get_profiles(["gx_gradpar"], eq, grid),
+                data={
+                    "a": minor_radius,
+                    "iota": jnp.full(self._nz_internal, iota_ref),
+                    "iota_r": jnp.full(self._nz_internal, iota_r_ref),
+                    "rho": rho_arr,
+                },
+            )
+
+            # L = ∫ dθ_PEST / |gradpar|
+            return jnp.abs(jnp.trapezoid(1.0 / data["gx_gradpar"], theta_pest))
+
+        poloidal_turns = solve_poloidal_turns_for_length(
+            length_fn, target_length, x0_guess=2.0 * abs(iota_ref)
+        )
+
+        if verbose > 0:
+            print(
+                f"NNITGProxy: target L={target_length:.2f}, "
+                f"poloidal_turns={poloidal_turns:.4f}, "
+                f"achieved L={length_fn(poloidal_turns):.2f}"
+            )
+
+        # Load model weights (ensemble or single model)
+        nn_weights, ensemble_weights = self._load_model_weights(verbose)
+
+        self._constants = {
+            "rho": self._rho,
+            "alpha": self._alpha,
+            "poloidal_turns": poloidal_turns,
+            "target_length": target_length,
+            "a": minor_radius,
+            "iota_transforms": transforms,
+            "profiles": profiles,
+            "a_over_LT": self._a_over_LT,
+            "a_over_Ln": self._a_over_Ln,
+            "nn_weights": nn_weights,
+            "ensemble_weights": ensemble_weights,
+            "quad_weights": 1.0,
+        }
+        super().build(use_jit=use_jit, verbose=verbose)
+
+    def _load_model_weights(self, verbose):
+        """Load neural network weights (ensemble or single model).
+
+        Parameters
+        ----------
+        verbose : int
+            Verbosity level for printing.
+
+        Returns
+        -------
+        nn_weights : dict or None
+            Single model weights, or None if using ensemble.
+        ensemble_weights : list or None
+            List of ensemble model weights, or None if using single model.
+
+        Raises
+        ------
+        ValueError
+            If neither model_path nor ensemble_dir is specified.
+
+        """
+        if self._ensemble_dir is not None:
+            ensemble_weights = _load_ensemble_weights_cached(
+                self._ensemble_dir, self._ensemble_csv, self._n_ensemble
+            )
+            if verbose > 0:
+                print(f"NNITGProxy: Loaded {len(ensemble_weights)} ensemble models")
+            return None, ensemble_weights
+
+        if self._model_path is not None:
+            nn_weights = _load_nn_weights(self._model_path)
+            return nn_weights, None
+
+        raise ValueError("Either model_path or ensemble_dir must be specified")
+
+    def compute(self, params, constants=None):
+        """Compute the NN ITG heat flux prediction.
+
+        Parameters
+        ----------
+        params : dict
+            Dictionary of equilibrium degrees of freedom.
+        constants : dict
+            Dictionary of constant data. Defaults to self.constants.
+
+        Returns
+        -------
+        Q : ndarray
+            Predicted heat flux for each flux surface, averaged over field lines.
+
+        """
+        if constants is None:
+            constants = self.constants
+
+        num_rho = len(constants["rho"])
+        return jnp.ones(num_rho)

--- a/desc/objectives/_turbulence.py
+++ b/desc/objectives/_turbulence.py
@@ -65,7 +65,7 @@ class ITGProxy(_Objective):
     def __init__(
         self,
         eq,
-        rho,
+        rho=0.5,
         target=None,
         bounds=None,
         weight=1,
@@ -324,7 +324,7 @@ class NNITGProxy(_Objective):
     def __init__(
         self,
         eq,
-        rho,
+        rho=0.5,
         target=None,
         bounds=None,
         weight=1,

--- a/desc/objectives/_turbulence.py
+++ b/desc/objectives/_turbulence.py
@@ -314,6 +314,7 @@ class NNITGProxy(_Objective):
         "_ensemble_csv",
         "_n_ensemble",
         "_solve_length_at_compute",
+        "_models",
     ]
 
     _coordinates = "r"
@@ -528,8 +529,9 @@ class NNITGProxy(_Objective):
             print("Loading neural network weights")
         timer.start("Loading NN weights")
 
-        # Load JIT-compiled forward functions
-        models = self._load_model_weights(verbose)
+        # Load JIT-compiled forward functions (stored as static attr so JAX
+        # does not try to trace PjitFunction objects during pytree flattening)
+        self._models = self._load_model_weights(verbose)
 
         timer.stop("Loading NN weights")
         if verbose > 1:
@@ -545,7 +547,6 @@ class NNITGProxy(_Objective):
             "profiles": profiles,
             "a_over_LT": self._a_over_LT,
             "a_over_Ln": self._a_over_Ln,
-            "models": models,
             "quad_weights": 1.0,
         }
         super().build(use_jit=use_jit, verbose=verbose)
@@ -835,7 +836,7 @@ class NNITGProxy(_Objective):
         minor_radius = constants["a"]
         a_over_LT = constants["a_over_LT"]
         a_over_Ln = constants["a_over_Ln"]
-        models = constants["models"]
+        models = self._models
 
         num_rho = len(rho_arr)
         num_alpha = len(alpha_arr)

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -6,125 +6,86 @@ import pytest
 from desc.examples import get
 from desc.grid import LinearGrid
 
-@pytest.mark.unit
-def test_gx_B_reference():
-    """Test GX reference magnetic field B_ref = 2|ψ_b|/a²."""
-    eq = get("DSHAPE")
-    data = eq.compute(["gx_B_reference", "a"])
 
+@pytest.mark.unit
+def test_gx_reference_quantities():
+    """Test GX reference quantities B_ref and L_ref."""
+    eq = get("DSHAPE")
+    data = eq.compute(["gx_B_reference", "gx_L_reference", "a"])
+
+    # B_ref = 2|ψ_b|/a²
     psi_b = np.abs(eq.Psi) / (2 * np.pi)
-    expected = 2 * psi_b / data["a"] ** 2
+    expected_B_ref = 2 * psi_b / data["a"] ** 2
 
     assert np.isfinite(data["gx_B_reference"])
-    np.testing.assert_allclose(data["gx_B_reference"], expected, rtol=1e-10)
-
-@pytest.mark.unit
-def test_gx_L_reference():
-    """Test GX reference length L_ref = a."""
-    eq = get("DSHAPE")
-    data = eq.compute(["gx_L_reference", "a"])
-
     assert np.isfinite(data["gx_L_reference"])
+    np.testing.assert_allclose(data["gx_B_reference"], expected_B_ref, rtol=1e-10)
     np.testing.assert_allclose(data["gx_L_reference"], data["a"], rtol=1e-10)
 
+
 @pytest.mark.unit
-def test_gx_bmag():
-    """Test normalized magnetic field bmag = |B|/B_ref."""
+def test_gx_bmag_order_unity():
+    """Test that bmag is O(1) for well-normalized equilibria."""
+    for eq_name in ["DSHAPE", "HELIOTRON"]:
+        eq = get(eq_name)
+        rho = np.linspace(0.1, 1, 5)
+        grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
+        data = eq.compute(["gx_bmag"], grid=grid)
+
+        assert np.isfinite(data["gx_bmag"]).all(), f"Non-finite bmag for {eq_name}"
+        assert np.all(data["gx_bmag"] > 0.1), f"bmag too small for {eq_name}"
+        assert np.all(data["gx_bmag"] < 10), f"bmag too large for {eq_name}"
+
+
+@pytest.mark.unit
+def test_gx_coefficients_tokamak():
+    """Test all GX coefficients on tokamak equilibrium."""
     eq = get("DSHAPE")
-    rho = np.linspace(0.1, 1, 5)
+    rho = np.linspace(0.2, 0.8, 3)
     grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
-    data = eq.compute(["gx_bmag", "gx_B_reference", "|B|"], grid=grid)
 
-    expected = data["|B|"] / data["gx_B_reference"]
+    quantities = [
+        "gx_bmag",
+        "gx_gds2",
+        "gx_gds21_over_shat",
+        "gx_gds22_over_shat_squared",
+        "gx_gbdrift",
+        "gx_cvdrift",
+        "gx_gbdrift0_over_shat",
+    ]
+    data = eq.compute(quantities, grid=grid)
 
-    assert np.isfinite(data["gx_bmag"]).all()
-    np.testing.assert_allclose(data["gx_bmag"], expected, rtol=1e-10)
-    # bmag should be O(1) for well-normalized equilibrium
-    assert np.all(data["gx_bmag"] > 0.1)
-    assert np.all(data["gx_bmag"] < 10)
+    for name in quantities:
+        assert np.isfinite(data[name]).all(), f"Non-finite values for {name}"
 
-@pytest.mark.unit
-def test_gx_bmag_stellarator():
-    """Test bmag on 3D stellarator equilibrium."""
-    eq = get("HELIOTRON")
-    rho = np.linspace(0.1, 1, 5)
-    grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
-    data = eq.compute(["gx_bmag"], grid=grid)
-
-    assert np.isfinite(data["gx_bmag"]).all()
+    # Positivity checks for squared quantities
     assert np.all(data["gx_bmag"] > 0)
+    assert np.all(data["gx_gds2"] > 0)
+    assert np.all(data["gx_gds22_over_shat_squared"] > 0)
+
 
 @pytest.mark.unit
-def test_gx_gds2():
-    """Test gds2 = |∇α|² × L_ref² × s."""
-    eq = get("DSHAPE")
-    rho = np.linspace(0.2, 0.8, 3)
-    grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
-    data = eq.compute(["gx_gds2", "grad(alpha)", "a", "rho"], grid=grid)
-
-    # Manual calculation
-    from desc.utils import dot
-    grad_alpha_sq = dot(data["grad(alpha)"], data["grad(alpha)"])
-    L_ref = data["a"]
-    s = data["rho"] ** 2
-    expected = grad_alpha_sq * L_ref**2 * s
-
-    assert np.isfinite(data["gx_gds2"]).all()
-    np.testing.assert_allclose(data["gx_gds2"], expected, rtol=1e-10)
-    assert np.all(data["gx_gds2"] > 0)  # Should be positive (squared quantity)
-
-@pytest.mark.unit
-def test_gx_gds21_over_shat():
-    """Test gds21/shat = σ_Bxy × (∇α·∇ψ) / B_ref."""
-    eq = get("DSHAPE")
-    rho = np.linspace(0.2, 0.8, 3)
-    grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
-    data = eq.compute(
-        ["gx_gds21_over_shat", "grad(alpha)", "grad(psi)", "a"], grid=grid
-    )
-
-    # Manual calculation
-    from desc.utils import dot
-    sigma_Bxy = -1
-    psi_b = eq.Psi / (2 * np.pi)
-    B_ref = 2 * psi_b / data["a"] ** 2
-    grad_alpha_dot_grad_psi = dot(data["grad(alpha)"], data["grad(psi)"])
-    expected = sigma_Bxy * grad_alpha_dot_grad_psi / B_ref
-
-    assert np.isfinite(data["gx_gds21_over_shat"]).all()
-    np.testing.assert_allclose(data["gx_gds21_over_shat"], expected, rtol=1e-10)
-
-@pytest.mark.unit
-def test_gx_gds22_over_shat_squared():
-    """Test gds22/shat² = |∇ψ|² / (L_ref² × B_ref² × s)."""
-    eq = get("DSHAPE")
-    rho = np.linspace(0.2, 0.8, 3)
-    grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
-    data = eq.compute(["gx_gds22_over_shat_squared", "|grad(psi)|^2", "a", "rho"], grid=grid)
-
-    # Manual calculation
-    psi_b = eq.Psi / (2 * np.pi)
-    B_ref = 2 * psi_b / data["a"] ** 2
-    L_ref = data["a"]
-    s = data["rho"] ** 2
-    expected = data["|grad(psi)|^2"] / (L_ref**2 * B_ref**2 * s)
-
-    assert np.isfinite(data["gx_gds22_over_shat_squared"]).all()
-    np.testing.assert_allclose(data["gx_gds22_over_shat_squared"], expected, rtol=1e-10)
-    assert np.all(data["gx_gds22_over_shat_squared"] > 0)  # Should be positive
-
-@pytest.mark.unit
-def test_gx_gradient_coefficients_stellarator():
-    """Test gradient coefficients on 3D stellarator equilibrium."""
+def test_gx_coefficients_stellarator():
+    """Test all GX coefficients on stellarator equilibrium."""
     eq = get("HELIOTRON")
     rho = np.linspace(0.2, 0.8, 3)
     grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
-    data = eq.compute(
-        ["gx_gds2", "gx_gds21_over_shat", "gx_gds22_over_shat_squared"], grid=grid
-    )
 
-    assert np.isfinite(data["gx_gds2"]).all()
-    assert np.isfinite(data["gx_gds21_over_shat"]).all()
-    assert np.isfinite(data["gx_gds22_over_shat_squared"]).all()
+    quantities = [
+        "gx_bmag",
+        "gx_gds2",
+        "gx_gds21_over_shat",
+        "gx_gds22_over_shat_squared",
+        "gx_gbdrift",
+        "gx_cvdrift",
+        "gx_gbdrift0_over_shat",
+    ]
+    data = eq.compute(quantities, grid=grid)
+
+    for name in quantities:
+        assert np.isfinite(data[name]).all(), f"Non-finite values for {name}"
+
+    # Positivity checks for squared quantities
+    assert np.all(data["gx_bmag"] > 0)
     assert np.all(data["gx_gds2"] > 0)
     assert np.all(data["gx_gds22_over_shat_squared"] > 0)

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -1,0 +1,59 @@
+"""Tests for ITG turbulence compute functions."""
+
+import numpy as np
+import pytest
+
+from desc.examples import get
+from desc.grid import LinearGrid
+
+
+@pytest.mark.unit
+def test_gx_B_reference():
+    """Test GX reference magnetic field B_ref = 2|ψ_b|/a²."""
+    eq = get("DSHAPE")
+    data = eq.compute(["gx_B_reference", "a"])
+
+    psi_b = np.abs(eq.Psi) / (2 * np.pi)
+    expected = 2 * psi_b / data["a"] ** 2
+
+    assert np.isfinite(data["gx_B_reference"])
+    np.testing.assert_allclose(data["gx_B_reference"], expected, rtol=1e-10)
+
+
+@pytest.mark.unit
+def test_gx_L_reference():
+    """Test GX reference length L_ref = a."""
+    eq = get("DSHAPE")
+    data = eq.compute(["gx_L_reference", "a"])
+
+    assert np.isfinite(data["gx_L_reference"])
+    np.testing.assert_allclose(data["gx_L_reference"], data["a"], rtol=1e-10)
+
+
+@pytest.mark.unit
+def test_gx_bmag():
+    """Test normalized magnetic field bmag = |B|/B_ref."""
+    eq = get("DSHAPE")
+    rho = np.linspace(0.1, 1, 5)
+    grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
+    data = eq.compute(["gx_bmag", "gx_B_reference", "|B|"], grid=grid)
+
+    expected = data["|B|"] / data["gx_B_reference"]
+
+    assert np.isfinite(data["gx_bmag"]).all()
+    np.testing.assert_allclose(data["gx_bmag"], expected, rtol=1e-10)
+    # bmag should be O(1) for well-normalized equilibrium
+    assert np.all(data["gx_bmag"] > 0.1)
+    assert np.all(data["gx_bmag"] < 10)
+
+
+@pytest.mark.unit
+def test_gx_bmag_stellarator():
+    """Test bmag on 3D stellarator equilibrium."""
+    eq = get("HELIOTRON")
+    rho = np.linspace(0.1, 1, 5)
+    grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
+    data = eq.compute(["gx_bmag"], grid=grid)
+
+    assert np.isfinite(data["gx_bmag"]).all()
+    assert np.all(data["gx_bmag"] > 0)

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -79,8 +79,12 @@ def test_itg_proxy():
         data = eq.compute(["ITG proxy integrand", "ITG proxy"], grid=grid)
 
         # Integrand should be finite and positive (sigmoid + 0.2 >= 0.2)
-        assert np.isfinite(data["ITG proxy integrand"]).all(), f"Non-finite for {eq_name}"
-        assert np.all(data["ITG proxy integrand"] >= 0), f"Negative integrand for {eq_name}"
+        assert np.isfinite(
+            data["ITG proxy integrand"]
+        ).all(), f"Non-finite for {eq_name}"
+        assert np.all(
+            data["ITG proxy integrand"] >= 0
+        ), f"Negative integrand for {eq_name}"
 
         # Scalar proxy should be finite and positive
         assert np.isfinite(data["ITG proxy"]), f"Non-finite proxy for {eq_name}"
@@ -174,7 +178,9 @@ def test_resample_to_uniform_arclength():
     data[1] = theta_pest / np.pi  # Linear
     data[2] = np.ones(npoints_in)  # Constant
 
-    z_uniform, data_uniform = resample_to_uniform_arclength(arclength, data, npoints_out)
+    z_uniform, data_uniform = resample_to_uniform_arclength(
+        arclength, data, npoints_out
+    )
 
     # Output shape checks
     assert z_uniform.shape == (npoints_out,)
@@ -270,9 +276,8 @@ def test_batch_norm_1d():
 
     output = _batch_norm_1d(x, gamma, beta, running_mean, running_var)
 
-    # Expected: scale * (x - mean) / sqrt(var + eps) + shift
-    # = 0.5 * (2.0 - 1.0) / sqrt(0.25 + 1e-5) + 1.0
-    # ≈ 0.5 * 1.0 / 0.5 + 1.0 = 1.0 + 1.0 = 2.0
+    # Expected: scale * (x - mean) / sqrt(var + eps) + shift,
+    # which gives 0.5 * (2.0 - 1.0) / sqrt(0.25 + 1e-5) + 1.0 = 2.0
     expected = jnp.ones((batch, channels, length)) * 2.0
     np.testing.assert_allclose(np.array(output), np.array(expected), rtol=1e-5)
 
@@ -321,14 +326,25 @@ def test_cyclic_invariant_forward_with_batchnorm():
     weights_bn = {}
     for i in range(5):
         weights_bn[f"conv_layers.{i}.weight"] = jnp.array(
-            np.random.randn(conv_channels[i + 1], conv_channels[i], kernel_sizes[i]) * 0.1
+            np.random.randn(conv_channels[i + 1], conv_channels[i], kernel_sizes[i])
+            * 0.1
         ).astype(jnp.float32)
-        weights_bn[f"conv_layers.{i}.bias"] = jnp.zeros(conv_channels[i + 1], dtype=jnp.float32)
+        weights_bn[f"conv_layers.{i}.bias"] = jnp.zeros(
+            conv_channels[i + 1], dtype=jnp.float32
+        )
         # Add BatchNorm parameters
-        weights_bn[f"conv_batch_norms.{i}.weight"] = jnp.ones(conv_channels[i + 1], dtype=jnp.float32)
-        weights_bn[f"conv_batch_norms.{i}.bias"] = jnp.zeros(conv_channels[i + 1], dtype=jnp.float32)
-        weights_bn[f"conv_batch_norms.{i}.running_mean"] = jnp.zeros(conv_channels[i + 1], dtype=jnp.float32)
-        weights_bn[f"conv_batch_norms.{i}.running_var"] = jnp.ones(conv_channels[i + 1], dtype=jnp.float32)
+        weights_bn[f"conv_batch_norms.{i}.weight"] = jnp.ones(
+            conv_channels[i + 1], dtype=jnp.float32
+        )
+        weights_bn[f"conv_batch_norms.{i}.bias"] = jnp.zeros(
+            conv_channels[i + 1], dtype=jnp.float32
+        )
+        weights_bn[f"conv_batch_norms.{i}.running_mean"] = jnp.zeros(
+            conv_channels[i + 1], dtype=jnp.float32
+        )
+        weights_bn[f"conv_batch_norms.{i}.running_var"] = jnp.ones(
+            conv_channels[i + 1], dtype=jnp.float32
+        )
 
     weights_bn["fc_layers.0.weight"] = jnp.array(
         np.random.randn(fc_dims[1], fc_dims[0]) * 0.1
@@ -336,7 +352,9 @@ def test_cyclic_invariant_forward_with_batchnorm():
     weights_bn["fc_layers.0.bias"] = jnp.zeros(fc_dims[1], dtype=jnp.float32)
     weights_bn["fc_batch_norms.0.weight"] = jnp.ones(fc_dims[1], dtype=jnp.float32)
     weights_bn["fc_batch_norms.0.bias"] = jnp.zeros(fc_dims[1], dtype=jnp.float32)
-    weights_bn["fc_batch_norms.0.running_mean"] = jnp.zeros(fc_dims[1], dtype=jnp.float32)
+    weights_bn["fc_batch_norms.0.running_mean"] = jnp.zeros(
+        fc_dims[1], dtype=jnp.float32
+    )
     weights_bn["fc_batch_norms.0.running_var"] = jnp.ones(fc_dims[1], dtype=jnp.float32)
 
     weights_bn["fc_layers.1.weight"] = jnp.array(
@@ -345,7 +363,9 @@ def test_cyclic_invariant_forward_with_batchnorm():
     weights_bn["fc_layers.1.bias"] = jnp.zeros(fc_dims[2], dtype=jnp.float32)
     weights_bn["fc_batch_norms.1.weight"] = jnp.ones(fc_dims[2], dtype=jnp.float32)
     weights_bn["fc_batch_norms.1.bias"] = jnp.zeros(fc_dims[2], dtype=jnp.float32)
-    weights_bn["fc_batch_norms.1.running_mean"] = jnp.zeros(fc_dims[2], dtype=jnp.float32)
+    weights_bn["fc_batch_norms.1.running_mean"] = jnp.zeros(
+        fc_dims[2], dtype=jnp.float32
+    )
     weights_bn["fc_batch_norms.1.running_var"] = jnp.ones(fc_dims[2], dtype=jnp.float32)
 
     weights_bn["output_layer.weight"] = jnp.array(
@@ -388,67 +408,6 @@ def test_cyclic_invariant_forward_shape():
     assert np.isfinite(np.array(output)).all()
 
 
-@pytest.mark.slow
-def test_jax_vs_pytorch_forward_pass():
-    """Test that JAX forward pass matches PyTorch CyclicInvariantNet output.
-
-    Runs in subprocess due to JAX/PyTorch conflicts on some systems.
-    """
-    import subprocess
-    import sys
-    import textwrap
-
-    pytest.importorskip("torch")
-
-    script = textwrap.dedent("""
-        import numpy as np
-        import torch
-        import torch.nn as nn
-        from desc.backend import jnp
-        from desc.compute._turbulence import _cyclic_invariant_forward
-
-        class CyclicNet(nn.Module):
-            def __init__(self):
-                super().__init__()
-                ch = [7, 16, 32, 16, 32, 16]
-                self.convs = nn.ModuleList([
-                    nn.Conv1d(ch[i], ch[i+1], 3, padding="same", padding_mode="circular")
-                    for i in range(5)
-                ])
-                self.pools = nn.ModuleList([nn.MaxPool1d(2, 2) for _ in range(5)])
-                self.fc1, self.fc2, self.out = nn.Linear(18, 32), nn.Linear(32, 16), nn.Linear(16, 1)
-
-            def forward(self, x, s):
-                x = x.transpose(1, 2)
-                for conv, pool in zip(self.convs, self.pools):
-                    x = pool(torch.relu(conv(x)))
-                return self.out(torch.relu(self.fc2(torch.relu(self.fc1(torch.cat([x.mean(-1), s], -1))))))
-
-        torch.manual_seed(42)
-        np.random.seed(42)
-        model = CyclicNet().eval()
-        sd = model.state_dict()
-
-        w = {}
-        for i in range(5):
-            w[f"conv_layers.{i}.weight"] = jnp.array(sd[f"convs.{i}.weight"].numpy())
-            w[f"conv_layers.{i}.bias"] = jnp.array(sd[f"convs.{i}.bias"].numpy())
-        w["fc_layers.0.weight"], w["fc_layers.0.bias"] = jnp.array(sd["fc1.weight"].numpy()), jnp.array(sd["fc1.bias"].numpy())
-        w["fc_layers.1.weight"], w["fc_layers.1.bias"] = jnp.array(sd["fc2.weight"].numpy()), jnp.array(sd["fc2.bias"].numpy())
-        w["output_layer.weight"], w["output_layer.bias"] = jnp.array(sd["out.weight"].numpy()), jnp.array(sd["out.bias"].numpy())
-
-        sig, sca = np.random.randn(2, 96, 7).astype(np.float32), np.random.randn(2, 2).astype(np.float32)
-        with torch.no_grad():
-            y_pt = model(torch.from_numpy(sig), torch.from_numpy(sca)).numpy()
-        y_jax = np.array(_cyclic_invariant_forward(jnp.array(sig.transpose(0,2,1)), jnp.array(sca), w))
-        assert np.allclose(y_jax, y_pt, rtol=1e-4, atol=1e-4), f"max_diff={np.max(np.abs(y_jax-y_pt))}"
-    """)
-
-    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, timeout=60)
-    if result.returncode != 0:
-        pytest.fail(f"JAX vs PyTorch mismatch:\n{result.stdout}\n{result.stderr}")
-
-
 @pytest.mark.unit
 def test_ensemble_forward():
     """Test ensemble forward pass averages predictions correctly."""
@@ -470,17 +429,21 @@ def test_ensemble_forward():
             weights[f"conv_layers.{i}.bias"] = jnp.array(
                 np.random.randn(conv_channels[i + 1])
             ).astype(jnp.float32)
-        weights["fc_layers.0.weight"] = jnp.array(np.random.randn(fc_dims[1], fc_dims[0])).astype(
+        weights["fc_layers.0.weight"] = jnp.array(
+            np.random.randn(fc_dims[1], fc_dims[0])
+        ).astype(jnp.float32)
+        weights["fc_layers.0.bias"] = jnp.array(np.random.randn(fc_dims[1])).astype(
             jnp.float32
         )
-        weights["fc_layers.0.bias"] = jnp.array(np.random.randn(fc_dims[1])).astype(jnp.float32)
-        weights["fc_layers.1.weight"] = jnp.array(np.random.randn(fc_dims[2], fc_dims[1])).astype(
+        weights["fc_layers.1.weight"] = jnp.array(
+            np.random.randn(fc_dims[2], fc_dims[1])
+        ).astype(jnp.float32)
+        weights["fc_layers.1.bias"] = jnp.array(np.random.randn(fc_dims[2])).astype(
             jnp.float32
         )
-        weights["fc_layers.1.bias"] = jnp.array(np.random.randn(fc_dims[2])).astype(jnp.float32)
-        weights["output_layer.weight"] = jnp.array(np.random.randn(1, fc_dims[2])).astype(
-            jnp.float32
-        )
+        weights["output_layer.weight"] = jnp.array(
+            np.random.randn(1, fc_dims[2])
+        ).astype(jnp.float32)
         weights["output_layer.bias"] = jnp.array(np.random.randn(1)).astype(jnp.float32)
         return weights
 
@@ -517,10 +480,7 @@ def test_ensemble_forward():
 def test_jit_forward_matches_original():
     """Test JIT-compiled forward matches non-JIT version."""
     from desc.backend import jnp
-    from desc.compute._turbulence import (
-        _cyclic_invariant_forward,
-        _make_jit_forward,
-    )
+    from desc.compute._turbulence import _cyclic_invariant_forward, _make_jit_forward
 
     np.random.seed(42)
 
@@ -548,9 +508,9 @@ def test_jit_forward_matches_original():
     weights["fc_layers.1.bias"] = jnp.array(np.random.randn(fc_dims[2])).astype(
         jnp.float32
     )
-    weights["output_layer.weight"] = jnp.array(
-        np.random.randn(1, fc_dims[2])
-    ).astype(jnp.float32)
+    weights["output_layer.weight"] = jnp.array(np.random.randn(1, fc_dims[2])).astype(
+        jnp.float32
+    )
     weights["output_layer.bias"] = jnp.array(np.random.randn(1)).astype(jnp.float32)
 
     # Create JIT-compiled forward function
@@ -588,9 +548,12 @@ def _make_mock_weights():
     weights = {}
     for i in range(5):
         weights[f"conv_layers.{i}.weight"] = jnp.array(
-            np.random.randn(conv_channels[i + 1], conv_channels[i], kernel_sizes[i]) * 0.1
+            np.random.randn(conv_channels[i + 1], conv_channels[i], kernel_sizes[i])
+            * 0.1
         ).astype(jnp.float32)
-        weights[f"conv_layers.{i}.bias"] = jnp.zeros(conv_channels[i + 1], dtype=jnp.float32)
+        weights[f"conv_layers.{i}.bias"] = jnp.zeros(
+            conv_channels[i + 1], dtype=jnp.float32
+        )
 
     weights["fc_layers.0.weight"] = jnp.array(
         np.random.randn(fc_dims[1], fc_dims[0]) * 0.1
@@ -636,8 +599,11 @@ def single_model_obj(dshape_eq):
         return_value=mock_weights_tuple,
     ):
         obj = NNITGProxy(
-            dshape_eq, rho=[0.4, 0.6], alpha=[0, np.pi / 2],
-            model_path="/fake/path.pt", nz_internal=_TEST_NZ_INTERNAL,
+            dshape_eq,
+            rho=[0.4, 0.6],
+            alpha=[0, np.pi / 2],
+            model_path="/fake/path.pt",
+            nz_internal=_TEST_NZ_INTERNAL,
         )
         obj.build(use_jit=False, verbose=0)
     return obj
@@ -663,8 +629,11 @@ def ensemble_obj(dshape_eq):
         return_value=([mock_weights, mock_weights2], [jit_forward1, jit_forward2]),
     ):
         obj = NNITGProxy(
-            dshape_eq, rho=[0.4, 0.6], alpha=[0, np.pi / 2],
-            ensemble_dir="/fake/dir", ensemble_csv="/fake/results.csv",
+            dshape_eq,
+            rho=[0.4, 0.6],
+            alpha=[0, np.pi / 2],
+            ensemble_dir="/fake/dir",
+            ensemble_csv="/fake/results.csv",
             nz_internal=_TEST_NZ_INTERNAL,
         )
         obj.build(use_jit=False, verbose=0)
@@ -725,7 +694,9 @@ def test_nnitgproxy_build(dshape_eq):
         return_value=(mock_weights, mock_jit_forward),
     ):
         obj = NNITGProxy(
-            dshape_eq, rho=0.5, model_path="/fake/path.pt",
+            dshape_eq,
+            rho=0.5,
+            model_path="/fake/path.pt",
             nz_internal=_TEST_NZ_INTERNAL,
         )
         obj.build(use_jit=False, verbose=0)
@@ -790,9 +761,7 @@ def test_nnitgproxy_compute(single_model_obj):
     np.testing.assert_allclose(np.mean(Q_pa, axis=-1), Q, rtol=1e-5)
 
     # --- return_per_alpha + return_signals ---
-    Q_both, sig_both = obj.compute(
-        params, return_signals=True, return_per_alpha=True
-    )
+    Q_both, sig_both = obj.compute(params, return_signals=True, return_per_alpha=True)
     assert Q_both.shape == (num_rho, num_alpha)
     assert sig_both["signals"].shape == (num_rho, num_alpha, 7, 96)
     assert np.isfinite(sig_both["signals"]).all()
@@ -813,8 +782,12 @@ def test_nnitgproxy_solve_length(dshape_eq):
         return_value=mock_weights_tuple,
     ):
         obj = NNITGProxy(
-            dshape_eq, rho=[0.5], alpha=[0], model_path="/fake/path.pt",
-            solve_length_at_compute=True, nz_internal=_TEST_NZ_INTERNAL,
+            dshape_eq,
+            rho=[0.5],
+            alpha=[0],
+            model_path="/fake/path.pt",
+            solve_length_at_compute=True,
+            nz_internal=_TEST_NZ_INTERNAL,
         )
         obj.build(use_jit=False, verbose=0)
 

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -558,6 +558,7 @@ def _make_mock_weights():
 @pytest.mark.unit
 def test_nnitgproxy_init():
     """Test NNITGProxy construction and parameter validation."""
+    pytest.importorskip("torch")
     from desc.objectives._turbulence import NNITGProxy
 
     eq = get("DSHAPE")
@@ -596,6 +597,7 @@ def test_nnitgproxy_init():
 @pytest.mark.unit
 def test_nnitgproxy_build():
     """Test NNITGProxy build method with mock weights."""
+    pytest.importorskip("torch")
     from unittest.mock import patch
 
     from desc.objectives._turbulence import NNITGProxy
@@ -634,6 +636,7 @@ def test_nnitgproxy_build():
 @pytest.mark.unit
 def test_nnitgproxy_compute():
     """Test NNITGProxy compute method produces valid output."""
+    pytest.importorskip("torch")
     from unittest.mock import patch
 
     from desc.objectives._turbulence import NNITGProxy
@@ -659,6 +662,7 @@ def test_nnitgproxy_compute():
 @pytest.mark.unit
 def test_nnitgproxy_compute_return_signals():
     """Test NNITGProxy compute with return_signals=True."""
+    pytest.importorskip("torch")
     from unittest.mock import patch
 
     from desc.objectives._turbulence import NNITGProxy

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -91,3 +91,21 @@ def test_gx_coefficients_stellarator():
     assert np.all(data["gx_bmag"] > 0)
     assert np.all(data["gx_gds2"] > 0)
     assert np.all(data["gx_gds22_over_shat_squared"] > 0)
+
+
+@pytest.mark.unit
+def test_itg_proxy():
+    """Test ITG proxy compute functions."""
+    for eq_name in ["DSHAPE", "HELIOTRON"]:
+        eq = get(eq_name)
+        rho = np.linspace(0.2, 0.8, 3)
+        grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
+        data = eq.compute(["ITG proxy integrand", "ITG proxy"], grid=grid)
+
+        # Integrand should be finite and positive (sigmoid + 0.2 >= 0.2)
+        assert np.isfinite(data["ITG proxy integrand"]).all(), f"Non-finite for {eq_name}"
+        assert np.all(data["ITG proxy integrand"] >= 0), f"Negative integrand for {eq_name}"
+
+        # Scalar proxy should be finite and positive
+        assert np.isfinite(data["ITG proxy"]), f"Non-finite proxy for {eq_name}"
+        assert data["ITG proxy"] > 0, f"Non-positive proxy for {eq_name}"

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -109,3 +109,14 @@ def test_itg_proxy():
         # Scalar proxy should be finite and positive
         assert np.isfinite(data["ITG proxy"]), f"Non-finite proxy for {eq_name}"
         assert data["ITG proxy"] > 0, f"Non-positive proxy for {eq_name}"
+
+
+@pytest.mark.unit
+def test_itg_proxy_objective_import():
+    """Test that ITGProxy objective can be imported."""
+    from desc.objectives import ITGProxy
+
+    eq = get("DSHAPE")
+    obj = ITGProxy(eq, rho=0.5, nturns=1, nzetaperturn=20)
+    assert obj._nturns == 1
+    assert obj._nzetaperturn == 20

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -615,7 +615,7 @@ def test_nnitgproxy_build():
     # Check constants are populated
     assert "rho" in obj.constants
     assert "alpha" in obj.constants
-    assert "poloidal_turns" in obj.constants
+    assert "toroidal_turns" in obj.constants
     assert "target_length" in obj.constants
     assert "a" in obj.constants
     assert "nn_weights" in obj.constants
@@ -623,7 +623,7 @@ def test_nnitgproxy_build():
     assert "a_over_Ln" in obj.constants
 
     # Check values are reasonable
-    assert obj.constants["poloidal_turns"] > 0
+    assert obj.constants["toroidal_turns"] > 0
     assert obj.constants["target_length"] > 0
     assert obj.constants["a"] > 0
     assert obj.constants["nn_weights"] is not None

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -6,7 +6,6 @@ import pytest
 from desc.examples import get
 from desc.grid import LinearGrid
 
-
 @pytest.mark.unit
 def test_gx_B_reference():
     """Test GX reference magnetic field B_ref = 2|ψ_b|/a²."""
@@ -19,7 +18,6 @@ def test_gx_B_reference():
     assert np.isfinite(data["gx_B_reference"])
     np.testing.assert_allclose(data["gx_B_reference"], expected, rtol=1e-10)
 
-
 @pytest.mark.unit
 def test_gx_L_reference():
     """Test GX reference length L_ref = a."""
@@ -28,7 +26,6 @@ def test_gx_L_reference():
 
     assert np.isfinite(data["gx_L_reference"])
     np.testing.assert_allclose(data["gx_L_reference"], data["a"], rtol=1e-10)
-
 
 @pytest.mark.unit
 def test_gx_bmag():
@@ -46,7 +43,6 @@ def test_gx_bmag():
     assert np.all(data["gx_bmag"] > 0.1)
     assert np.all(data["gx_bmag"] < 10)
 
-
 @pytest.mark.unit
 def test_gx_bmag_stellarator():
     """Test bmag on 3D stellarator equilibrium."""
@@ -57,3 +53,78 @@ def test_gx_bmag_stellarator():
 
     assert np.isfinite(data["gx_bmag"]).all()
     assert np.all(data["gx_bmag"] > 0)
+
+@pytest.mark.unit
+def test_gx_gds2():
+    """Test gds2 = |∇α|² × L_ref² × s."""
+    eq = get("DSHAPE")
+    rho = np.linspace(0.2, 0.8, 3)
+    grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
+    data = eq.compute(["gx_gds2", "grad(alpha)", "a", "rho"], grid=grid)
+
+    # Manual calculation
+    from desc.utils import dot
+    grad_alpha_sq = dot(data["grad(alpha)"], data["grad(alpha)"])
+    L_ref = data["a"]
+    s = data["rho"] ** 2
+    expected = grad_alpha_sq * L_ref**2 * s
+
+    assert np.isfinite(data["gx_gds2"]).all()
+    np.testing.assert_allclose(data["gx_gds2"], expected, rtol=1e-10)
+    assert np.all(data["gx_gds2"] > 0)  # Should be positive (squared quantity)
+
+@pytest.mark.unit
+def test_gx_gds21_over_shat():
+    """Test gds21/shat = σ_Bxy × (∇α·∇ψ) / B_ref."""
+    eq = get("DSHAPE")
+    rho = np.linspace(0.2, 0.8, 3)
+    grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
+    data = eq.compute(
+        ["gx_gds21_over_shat", "grad(alpha)", "grad(psi)", "a"], grid=grid
+    )
+
+    # Manual calculation
+    from desc.utils import dot
+    sigma_Bxy = -1
+    psi_b = eq.Psi / (2 * np.pi)
+    B_ref = 2 * psi_b / data["a"] ** 2
+    grad_alpha_dot_grad_psi = dot(data["grad(alpha)"], data["grad(psi)"])
+    expected = sigma_Bxy * grad_alpha_dot_grad_psi / B_ref
+
+    assert np.isfinite(data["gx_gds21_over_shat"]).all()
+    np.testing.assert_allclose(data["gx_gds21_over_shat"], expected, rtol=1e-10)
+
+@pytest.mark.unit
+def test_gx_gds22_over_shat_squared():
+    """Test gds22/shat² = |∇ψ|² / (L_ref² × B_ref² × s)."""
+    eq = get("DSHAPE")
+    rho = np.linspace(0.2, 0.8, 3)
+    grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
+    data = eq.compute(["gx_gds22_over_shat_squared", "|grad(psi)|^2", "a", "rho"], grid=grid)
+
+    # Manual calculation
+    psi_b = eq.Psi / (2 * np.pi)
+    B_ref = 2 * psi_b / data["a"] ** 2
+    L_ref = data["a"]
+    s = data["rho"] ** 2
+    expected = data["|grad(psi)|^2"] / (L_ref**2 * B_ref**2 * s)
+
+    assert np.isfinite(data["gx_gds22_over_shat_squared"]).all()
+    np.testing.assert_allclose(data["gx_gds22_over_shat_squared"], expected, rtol=1e-10)
+    assert np.all(data["gx_gds22_over_shat_squared"] > 0)  # Should be positive
+
+@pytest.mark.unit
+def test_gx_gradient_coefficients_stellarator():
+    """Test gradient coefficients on 3D stellarator equilibrium."""
+    eq = get("HELIOTRON")
+    rho = np.linspace(0.2, 0.8, 3)
+    grid = LinearGrid(rho=rho, M=eq.M_grid, N=eq.N_grid, NFP=eq.NFP, sym=eq.sym)
+    data = eq.compute(
+        ["gx_gds2", "gx_gds21_over_shat", "gx_gds22_over_shat_squared"], grid=grid
+    )
+
+    assert np.isfinite(data["gx_gds2"]).all()
+    assert np.isfinite(data["gx_gds21_over_shat"]).all()
+    assert np.isfinite(data["gx_gds22_over_shat_squared"]).all()
+    assert np.all(data["gx_gds2"] > 0)
+    assert np.all(data["gx_gds22_over_shat_squared"] > 0)

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -52,6 +52,7 @@ def test_gx_coefficients_tokamak():
         "gx_gbdrift",
         "gx_cvdrift",
         "gx_gbdrift0_over_shat",
+        "gx_gradpar",
     ]
     data = eq.compute(quantities, grid=grid)
 
@@ -79,6 +80,7 @@ def test_gx_coefficients_stellarator():
         "gx_gbdrift",
         "gx_cvdrift",
         "gx_gbdrift0_over_shat",
+        "gx_gradpar",
     ]
     data = eq.compute(quantities, grid=grid)
 

--- a/tests/test_turbulence.py
+++ b/tests/test_turbulence.py
@@ -736,7 +736,7 @@ def test_nnitgproxy_build(dshape_eq):
     assert "toroidal_turns" in obj.constants
     assert "target_length" in obj.constants
     assert "a" in obj.constants
-    assert "models" in obj.constants
+    assert hasattr(obj, "_models") and len(obj._models) > 0
     assert "a_over_LT" in obj.constants
     assert "a_over_Ln" in obj.constants
 
@@ -744,8 +744,8 @@ def test_nnitgproxy_build(dshape_eq):
     assert obj.constants["toroidal_turns"] > 0
     assert obj.constants["target_length"] > 0
     assert obj.constants["a"] > 0
-    assert len(obj.constants["models"]) == 1
-    assert callable(obj.constants["models"][0])
+    assert len(obj._models) == 1
+    assert callable(obj._models[0])
 
     # Check dimension
     assert obj._dim_f == 1  # Single rho value


### PR DESCRIPTION
Related to #1196

Adds two new objective functions for ITG turbulence optimization: an analytical proxy (`ITGProxy`) and a neural network ensemble proxy (`NNITGProxy`), based on Landreman et al. 2025 ("How does ITG turbulence depend on magnetic geometry?").

### GX Geometric Features
- Reference quantities (`gx_B_reference`, `gx_L_reference`), magnetic field strength (`gx_bmag`), gradient features (`gx_gds2`, `gx_gds21_over_shat`, `gx_gds22_over_shat_squared`), drift features (`gx_gbdrift`, `gx_cvdrift`, `gx_gbdrift0_over_shat`), and parallel gradient (`gx_gradpar`)
- Sign convention corrections for toroidal flux direction and pressure gradient terms

### ITGProxy Objective
- Analytical proxy: `f_Q = mean([Theta(cvdrift) + 0.2] * |grad(x)|^3 / B)`
- Uses smooth sigmoid approximation for differentiability during optimization

### Flux Tube Geometry Utilities
- Arclength computation via `gradpar` with uniform resampling to `z in [-pi, pi)`
- Brent's method solver for poloidal turns matching a target flux tube length (I tried making it differentiable via desc.backend.root_scalar within .compute())
- Dynamic `poloidal_turns`(fixed toroidal turns) that adapts as iota changes during optimization

### NNITGProxy Objective
- Pure-JAX re-implementation of the CyclicInvariantNet CNN architecture (circular convolutions, BatchNorm inference, max/global-avg pooling)
- Loads pre-trained PyTorch `.pth` weights and converts to JAX arrays (TODO: will have to make this not Torch dependent.
- Ensemble inference with configurable `top_k` model selection from DeepHyper results
- JIT-compiled forward pass
- Batched grid processing: single `map_coordinates` + `compute` call for all `(rho, alpha, zeta)` points
- Optional features: `return_per_alpha` for per-field-line analysis, `return_std` for ensemble uncertainty, `return_signals` for intermediate GX feature debugging

### Known Limitations/TODO
- The quantities calculated here are the same as in _stability with normalization / sign factors, so this can be consolidated. But for debugging purposes, I have created a separate compute() quantities for now.
- PyTorch dependency for weight loading: Currently requires `torch` to deserialize `.pth` files. Plan is to serialize weights to a torch-free format (e.g. `.npz`) in a separate conversion repo, so DESC only needs JAX at runtime.
- TEM metrics (Proll 2015, Mackenbach 2022/2023) are not included in this PR — they depend on bounce integral infrastructure and will be addressed separately under #1196.