### PR TITLE
Adding support for umbilic curves

### DIFF
--- a/desc/basis.py
+++ b/desc/basis.py
@@ -479,8 +479,9 @@ class FourierSeries(_Basis):
     NFP : int
         number of field periods
     n_umbilic : int
-        Prefactor of the form 1/NFP_umbilic_fac.
+        Prefactor of the form 1/n_umbilic.
         This is needed for the umbilic torus design.
+    sym:
         * ``'cos'`` for cos(n*z) symmetry
         * ``'sin'`` for sin(n*z) symmetry
         * ``'no n=0'`` for no n=0 mode

--- a/desc/basis.py
+++ b/desc/basis.py
@@ -31,7 +31,6 @@ class _Basis(IOAble, ABC):
         "_M",
         "_N",
         "_NFP",
-        "_N_scaling",
         "_modes",
         "_sym",
         "_spectral_indexing",
@@ -44,7 +43,6 @@ class _Basis(IOAble, ABC):
         "_M",
         "_N",
         "_NFP",
-        "_N_scaling",
         "_sym",
         "_spectral_indexing",
     ]
@@ -80,6 +78,7 @@ class _Basis(IOAble, ABC):
         self._M = int(self._M)
         self._N = int(self._N)
         self._NFP = int(self._NFP)
+        self._N_scaling = int(self.__dict__.setdefault("_N_scaling", 1))
         self._modes = self._modes.astype(int)
         (
             self._unique_L_idx,
@@ -231,11 +230,6 @@ class _Basis(IOAble, ABC):
     def NFP(self):
         """int: Number of field periods."""
         return self.__dict__.setdefault("_NFP", 1)
-
-    @property
-    def N_scaling(self):
-        """int: Factor multiplying toroidal period."""
-        return self.__dict__.setdefault("_N_scaling", 1)
 
     @property
     def sym(self):
@@ -489,6 +483,7 @@ class FourierSeries(_Basis):
 
     """
 
+    _static_attrs = _Basis._static_attrs + ["N_scaling"]
     _fft_poloidal = True
     _fft_toroidal = True
 
@@ -505,6 +500,11 @@ class FourierSeries(_Basis):
         self._modes = self._get_modes(N=self.N)
 
         super().__init__()
+
+    @property
+    def N_scaling(self):
+        """int: Factor multiplying toroidal period."""
+        return self.__dict__.setdefault("_N_scaling", 1)
 
     def _get_modes(self, N):
         """Get mode numbers for Fourier series.
@@ -943,7 +943,6 @@ class ZernikePolynomial(_Basis):
         radial = zernike_radial(r[:, np.newaxis], lm[:, 0], lm[:, 1], dr=derivatives[0])
         poloidal = fourier(t[:, np.newaxis], m, 1, 1, derivatives[1])
 
-        poloidal = fourier(t[:, np.newaxis], m, 1, derivatives[1])
         radial = radial[routidx][:, lmoutidx]
         poloidal = poloidal[toutidx][:, moutidx]
 
@@ -1360,9 +1359,6 @@ class FourierZernikeBasis(_Basis):
             N_scaling=1,
             dt=derivatives[2],
         )
-
-        poloidal = fourier(t[:, np.newaxis], m, dt=derivatives[1])
-        toroidal = fourier(z[:, np.newaxis], n, NFP=self.NFP, dt=derivatives[2])
 
         radial = radial[routidx][:, lmoutidx]
         poloidal = poloidal[toutidx][:, moutidx]

--- a/desc/basis.py
+++ b/desc/basis.py
@@ -31,7 +31,7 @@ class _Basis(IOAble, ABC):
         "_M",
         "_N",
         "_NFP",
-        # --no-verify "_N_scaling",
+        "_N_scaling",
         "_modes",
         "_sym",
         "_spectral_indexing",
@@ -44,6 +44,7 @@ class _Basis(IOAble, ABC):
         "_M",
         "_N",
         "_NFP",
+        "_N_scaling",
         "_sym",
         "_spectral_indexing",
     ]

--- a/desc/compute/__init__.py
+++ b/desc/compute/__init__.py
@@ -35,6 +35,7 @@ from . import (
     _equil,
     _fast_ion,
     _field,
+    _fluxsurfacecurve,
     _geometry,
     _metric,
     _neoclassical,
@@ -43,7 +44,6 @@ from . import (
     _profiles,
     _stability,
     _surface,
-    _umbiliccurve,
 )
 from .data_index import all_kwargs, allowed_kwargs, data_index
 from .utils import (

--- a/desc/compute/_fluxsurfacecurve.py
+++ b/desc/compute/_fluxsurfacecurve.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 from .data_index import register_compute_fun
 
 
@@ -16,7 +14,7 @@ from .data_index import register_compute_fun
     profiles=[],
     coordinates="",
     data=[],
-    parameterization="desc.geometry.umbiliccurve.FourierUmbilicCurve",
+    parameterization="desc.geometry.fluxsurfacecurve.FourierUmbilicCurve",
 )
 def _UC_FourierUmbilicCurve(params, transforms, profiles, data, **kwargs):
     # If the grid is non-uniform, the transform has to be modified
@@ -36,7 +34,7 @@ def _UC_FourierUmbilicCurve(params, transforms, profiles, data, **kwargs):
     profiles=[],
     coordinates="phi",
     data=[],
-    parameterization="desc.geometry.umbiliccurve.FourierUmbilicCurve",
+    parameterization="desc.geometry.fluxsurfacecurve.FourierUmbilicCurve",
 )
 def _phi(params, transforms, profiles, data, **kwargs):
     data["phi"] = transforms["grid"].nodes[:, 2]
@@ -55,7 +53,7 @@ def _phi(params, transforms, profiles, data, **kwargs):
     profiles=[],
     coordinates="phi",
     data=["UC", "phi"],
-    parameterization="desc.geometry.umbiliccurve.FourierUmbilicCurve",
+    parameterization="desc.geometry.fluxsurfacecurve.FourierUmbilicCurve",
 )
 def _theta(params, transforms, profiles, data, **kwargs):
     data["theta"] = (

--- a/desc/compute/_fluxsurfacecurve.py
+++ b/desc/compute/_fluxsurfacecurve.py
@@ -1,5 +1,21 @@
 from .data_index import register_compute_fun
 
+kwargs_FourierUmbilicCurve = {
+    "n_umbilic": """int:
+        Prefactor of the form 1/n_umbilic modifying NFP.
+        Curve closes after n_umbilic/gcd(n_umbilic, NFP) transits.
+        Default is n_umbilic = 1.
+        """,
+    "m_umbilic": """int:
+        Parameter arising from umbilic torus parameterization, determining
+        the average slope of the curve in the (theta,zeta) plane.
+        Should satisfy gcd(n_umbilic, m_umbilic)=1.
+        Default is m_umbilic = 1.
+        """,
+    "NFP": """int:
+        Number of field periods.""",
+}
+
 
 @register_compute_fun(
     name="UC",
@@ -12,7 +28,7 @@ from .data_index import register_compute_fun
     params=["a_n"],
     transforms={"UC": [[0, 0, 0]], "grid": []},
     profiles=[],
-    coordinates="",
+    coordinates="phi",
     data=[],
     parameterization="desc.geometry.fluxsurfacecurve.FourierUmbilicCurve",
 )
@@ -48,17 +64,18 @@ def _phi(params, transforms, profiles, data, **kwargs):
     units_long="Radians",
     description="Values of poloidal angle theta along curve",
     dim=1,
-    params=["n_umbilic", "m_umbilic", "NFP"],
+    params=[],
     transforms={"grid": []},
     profiles=[],
     coordinates="phi",
     data=["UC", "phi"],
     parameterization="desc.geometry.fluxsurfacecurve.FourierUmbilicCurve",
+    **kwargs_FourierUmbilicCurve
 )
 def _theta(params, transforms, profiles, data, **kwargs):
     data["theta"] = (
         1
-        / params["n_umbilic"]
-        * (params["m_umbilic"] * params["NFP"] * data["phi"] + data["UC"])
+        / kwargs.get("n_umbilic")
+        * (kwargs.get("m_umbilic") * kwargs.get("NFP") * data["phi"] + data["UC"])
     )
     return data

--- a/desc/compute/_umbiliccurve.py
+++ b/desc/compute/_umbiliccurve.py
@@ -9,9 +9,9 @@ from .data_index import register_compute_fun
     units="~",
     units_long="None",
     description="angular difference between theta and phi on a surface"
-    + "determines the shape of an umbilic curve",
+    + r", equal to n_umbilic \theta - m_umbilic NFP \zeta",
     dim=1,
-    params=["UC_n"],
+    params=["a_n"],
     transforms={"UC": [[0, 0, 0]], "grid": []},
     profiles=[],
     coordinates="",
@@ -20,7 +20,7 @@ from .data_index import register_compute_fun
 )
 def _UC_FourierUmbilicCurve(params, transforms, profiles, data, **kwargs):
     # If the grid is non-uniform, the transform has to be modified
-    data["UC"] = transforms["UC"].transform(params["UC_n"], dz=0)
+    data["UC"] = transforms["UC"].transform(params["a_n"], dz=0)
     return data
 
 
@@ -29,7 +29,7 @@ def _UC_FourierUmbilicCurve(params, transforms, profiles, data, **kwargs):
     label="phi",
     units="~",
     units_long="Radians",
-    description="Toroidal phi position along curve",
+    description="Values of toroidal angle phi along curve",
     dim=1,
     params=[],
     transforms={"grid": []},
@@ -40,4 +40,27 @@ def _UC_FourierUmbilicCurve(params, transforms, profiles, data, **kwargs):
 )
 def _phi(params, transforms, profiles, data, **kwargs):
     data["phi"] = transforms["grid"].nodes[:, 2]
+    return data
+
+
+@register_compute_fun(
+    name="theta",
+    label="theta",
+    units="~",
+    units_long="Radians",
+    description="Values of poloidal angle theta along curve",
+    dim=1,
+    params=["n_umbilic", "m_umbilic", "NFP"],
+    transforms={"grid": []},
+    profiles=[],
+    coordinates="phi",
+    data=["UC", "phi"],
+    parameterization="desc.geometry.umbiliccurve.FourierUmbilicCurve",
+)
+def _theta(params, transforms, profiles, data, **kwargs):
+    data["theta"] = (
+        1
+        / params["n_umbilic"]
+        * (params["m_umbilic"] * params["NFP"] * data["phi"] + data["UC"])
+    )
     return data

--- a/desc/compute/_umbiliccurve.py
+++ b/desc/compute/_umbiliccurve.py
@@ -39,5 +39,5 @@ def _UC_FourierUmbilicCurve(params, transforms, profiles, data, **kwargs):
     parameterization="desc.geometry.umbiliccurve.FourierUmbilicCurve",
 )
 def _phi(params, transforms, profiles, data, **kwargs):
-    data["phi"] = transforms["grid"].nodes[:]
+    data["phi"] = transforms["grid"].nodes[:, 2]
     return data

--- a/desc/compute/data_index.py
+++ b/desc/compute/data_index.py
@@ -237,8 +237,8 @@ _class_inheritance = {
     "desc.geometry.curve.FourierRZCurve": [
         "desc.geometry.core.Curve",
     ],
-    "desc.geometry.umbiliccurve.FourierUmbilicCurve": [
-        "desc.geometry.core.UmbilicCurve",
+    "desc.geometry.fluxsurfacecurve.FourierUmbilicCurve": [
+        "desc.geometry.core.FluxSurfaceCurve",
     ],
     "desc.geometry.curve.FourierXYZCurve": [
         "desc.geometry.core.Curve",

--- a/desc/geometry/__init__.py
+++ b/desc/geometry/__init__.py
@@ -8,5 +8,5 @@ from .curve import (
     FourierXYZCurve,
     SplineXYZCurve,
 )
+from .fluxsurfacecurve import FourierUmbilicCurve
 from .surface import FourierRZToroidalSurface, ZernikeRZToroidalSection
-from .umbiliccurve import FourierUmbilicCurve

--- a/desc/geometry/__init__.py
+++ b/desc/geometry/__init__.py
@@ -1,6 +1,6 @@
 """Classes for representing geometric objects like curves and surfaces."""
 
-from .core import Curve, Surface, UmbilicCurve
+from .core import Curve, FluxSurfaceCurve, Surface
 from .curve import (
     FourierPlanarCurve,
     FourierRZCurve,

--- a/desc/geometry/core.py
+++ b/desc/geometry/core.py
@@ -157,7 +157,7 @@ class UmbilicCurve(IOAble, Optimizable, ABC):
             if (data_index[p][dep]["coordinates"] == "") and (dep not in data)
         ]
         calc0d = bool(len(dep0d))
-        # see if the grid we're already using will work for desired qtys
+        # see if the grid we're already using will work for desired quantities
         if calc0d and (grid.N >= 2 * self.N + 5) and isinstance(grid, LinearGrid):
             calc0d = False
 

--- a/desc/geometry/core.py
+++ b/desc/geometry/core.py
@@ -115,26 +115,19 @@ class UmbilicCurve(IOAble, Optimizable, ABC):
         if isinstance(names, str):
             names = [names]
         if grid is None:
-            NFP_umbilic_factor = (
-                self.NFP_umbilic_factor
-                if (
-                    hasattr(self, "NFP_umbilic_factor")
-                    and self.NFP_umbilic_factor is not None
-                )
+            n_umbilic = (
+                self.n_umbilic
+                if (hasattr(self, "n_umbilic") and self.n_umbilic is not None)
                 else 1
             )
             grid = LinearGrid(
                 N=2 * self.N * getattr(self, "NFP", 1) + 5,
-                NFP_umbilic_factor=int(NFP_umbilic_factor),
+                n_umbilic=int(n_umbilic),
             )
         elif isinstance(grid, numbers.Integral):
             NFP = self.NFP if hasattr(self, "NFP") else 1
-            NFP_umbilic_factor = (
-                self.NFP_umbilic_factor if hasattr(self, "NFP_umbilic_factor") else 1
-            )
-            grid = LinearGrid(
-                N=grid, NFP=NFP, NFP_umbilic_factor=NFP_umbilic_factor, endpoint=False
-            )
+            n_umbilic = self.n_umbilic if hasattr(self, "n_umbilic") else 1
+            grid = LinearGrid(N=grid, NFP=NFP, n_umbilic=n_umbilic, endpoint=False)
         elif hasattr(grid, "NFP"):
             NFP = grid.NFP
         else:
@@ -220,7 +213,7 @@ class UmbilicCurve(IOAble, Optimizable, ABC):
         )
 
     def to_FourierUmbilic(
-        self, N=10, grid=None, NFP=None, NFP_umbilic_factor=1, sym=False, name=""
+        self, N=10, grid=None, NFP=None, n_umbilic=1, sym=False, name=""
     ):
         """Convert Curve to FourierRZCurve representation.
 
@@ -257,7 +250,7 @@ class UmbilicCurve(IOAble, Optimizable, ABC):
             coords,
             N=N,
             NFP=NFP,
-            NFP_umbilic_factor=NFP_umbilic_factor,
+            n_umbilic=n_umbilic,
             basis="rtz",
             name=name,
             sym=sym,
@@ -362,26 +355,19 @@ class Curve(IOAble, Optimizable, ABC):
         if isinstance(names, str):
             names = [names]
         if grid is None:
-            NFP_umbilic_factor = (
-                self.NFP_umbilic_factor
-                if (
-                    hasattr(self, "NFP_umbilic_factor")
-                    and self.NFP_umbilic_factor is not None
-                )
+            n_umbilic = (
+                self.n_umbilic
+                if (hasattr(self, "n_umbilic") and self.n_umbilic is not None)
                 else 1
             )
             grid = LinearGrid(
                 N=2 * self.N * getattr(self, "NFP", 1) + 5,
-                NFP_umbilic_factor=int(NFP_umbilic_factor),
+                n_umbilic=int(n_umbilic),
             )
         elif isinstance(grid, numbers.Integral):
             NFP = self.NFP if hasattr(self, "NFP") else 1
-            NFP_umbilic_factor = (
-                self.NFP_umbilic_factor if hasattr(self, "NFP_umbilic_factor") else 1
-            )
-            grid = LinearGrid(
-                N=grid, NFP=NFP, NFP_umbilic_factor=NFP_umbilic_factor, endpoint=False
-            )
+            n_umbilic = self.n_umbilic if hasattr(self, "n_umbilic") else 1
+            grid = LinearGrid(N=grid, NFP=NFP, n_umbilic=n_umbilic, endpoint=False)
         elif hasattr(grid, "NFP"):
             NFP = grid.NFP
         else:

--- a/desc/geometry/core.py
+++ b/desc/geometry/core.py
@@ -212,6 +212,7 @@ class UmbilicCurve(IOAble, Optimizable, ABC):
             + " (name={})".format(self.name)
         )
 
+    # TO DO: Determine if this function is necessary
     def to_FourierUmbilic(
         self, N=10, grid=None, NFP=None, n_umbilic=1, sym=False, name=""
     ):

--- a/desc/geometry/core.py
+++ b/desc/geometry/core.py
@@ -118,19 +118,19 @@ class Curve(IOAble, Optimizable, ABC):
         if isinstance(names, str):
             names = [names]
         if grid is None:
-            n_umbilic = (
-                self.n_umbilic
-                if (hasattr(self, "n_umbilic") and self.n_umbilic is not None)
+            N_scaling = (
+                self.N_scaling
+                if (hasattr(self, "N_scaling") and self.N_scaling is not None)
                 else 1
             )
             grid = LinearGrid(
                 N=2 * self.N * getattr(self, "NFP", 1) + 5,
-                n_umbilic=int(n_umbilic),
+                N_scaling=int(N_scaling),
             )
         elif isinstance(grid, numbers.Integral):
             NFP = self.NFP if hasattr(self, "NFP") else 1
-            n_umbilic = self.n_umbilic if hasattr(self, "n_umbilic") else 1
-            grid = LinearGrid(N=grid, NFP=NFP, n_umbilic=n_umbilic, endpoint=False)
+            N_scaling = self.N_scaling if hasattr(self, "N_scaling") else 1
+            grid = LinearGrid(N=grid, NFP=NFP, N_scaling=N_scaling, endpoint=False)
         elif hasattr(grid, "NFP"):
             NFP = grid.NFP
         else:
@@ -726,6 +726,7 @@ class FluxSurfaceCurve(IOAble, Optimizable, ABC):
             grid = LinearGrid(N=grid, NFP=NFP, N_scaling=N_scaling, endpoint=False)
         elif hasattr(grid, "NFP"):
             NFP = grid.NFP
+            N_scaling = self.N_scaling if hasattr(self, "N_scaling") else 1
         else:
             raise TypeError(
                 "must pass in a Grid object or an integer for argument grid!"
@@ -758,7 +759,9 @@ class FluxSurfaceCurve(IOAble, Optimizable, ABC):
             calc0d = False
 
         if calc0d and override_grid:
-            grid0d = LinearGrid(N=2 * self.N * getattr(self, "NFP", 1) + 5)
+            grid0d = LinearGrid(
+                N=2 * self.N * getattr(self, "NFP", 1) + 5, N_scaling=N_scaling
+            )
             data0d = compute_fun(
                 self,
                 dep0d,

--- a/desc/geometry/core.py
+++ b/desc/geometry/core.py
@@ -20,199 +20,6 @@ from desc.optimizable import Optimizable, optimizable_parameter
 from desc.utils import reflection_matrix, rotation_matrix
 
 
-class UmbilicCurve(IOAble, Optimizable, ABC):
-    """Abstract base class for 1D umbilic curves in 3D space."""
-
-    _io_attrs_ = ["_name"]
-
-    def __init__(self, name=""):
-        self._name = name
-
-    def _set_up(self):
-        """Set things after loading."""
-        if hasattr(self, "_NFP"):
-            self._NFP = int(self._NFP)
-        if not hasattr(self, "_shift"):
-            self.shift
-        if not hasattr(self, "_rotmat"):
-            self.rotmat
-
-    @optimizable_parameter
-    @property
-    def shift(self):
-        """Displacement of curve in X, Y, Z."""
-        return self.__dict__.setdefault("_shift", jnp.array([0, 0, 0], dtype=float))
-
-    @shift.setter
-    def shift(self, new):
-        if len(new) == 3:
-            self._shift = jnp.asarray(new)
-        else:
-            raise ValueError("shift should be a 3 element vector, got {}".format(new))
-
-    @optimizable_parameter
-    @property
-    def rotmat(self):
-        """Rotation matrix of curve in X, Y, Z."""
-        return self.__dict__.setdefault("_rotmat", jnp.eye(3, dtype=float).flatten())
-
-    @rotmat.setter
-    def rotmat(self, new):
-        if len(new) == 9:
-            self._rotmat = jnp.asarray(new)
-        else:
-            self._rotmat = jnp.asarray(new.flatten())
-
-    @property
-    def name(self):
-        """Name of the curve."""
-        return self.__dict__.setdefault("_name", "")
-
-    @name.setter
-    def name(self, new):
-        self._name = str(new)
-
-    def compute(
-        self,
-        names,
-        grid=None,
-        params=None,
-        transforms=None,
-        data=None,
-        override_grid=True,
-        **kwargs,
-    ):
-        """Compute the quantity given by name on grid.
-
-        Parameters
-        ----------
-        names : str or array-like of str
-            Name(s) of the quantity(s) to compute.
-        grid : Grid or int, optional
-            Grid of coordinates to evaluate at. Defaults to a Linear grid.
-            If an integer, uses that many equally spaced points.
-        params : dict of ndarray
-            Parameters from the equilibrium. Defaults to attributes of self.
-        transforms : dict of Transform
-            Transforms for R, Z, lambda, etc. Default is to build from grid
-        data : dict of ndarray
-            Data computed so far, generally output from other compute functions.
-            Any vector v = v¹ R̂ + v² ϕ̂ + v³ Ẑ should be given in components
-            v = [v¹, v², v³] where R̂, ϕ̂, Ẑ are the normalized basis vectors
-            of the cylindrical coordinates R, ϕ, Z.
-        override_grid : bool
-            If True, override the user supplied grid if necessary and use a full
-            resolution grid to compute quantities and then downsample to user requested
-            grid. If False, uses only the user specified grid, which may lead to
-            inaccurate values for surface or volume averages.
-
-        Returns
-        -------
-        data : dict of ndarray
-            Computed quantity and intermediate variables.
-
-        """
-        if isinstance(names, str):
-            names = [names]
-        if grid is None:
-            n_umbilic = (
-                self.n_umbilic
-                if (hasattr(self, "n_umbilic") and self.n_umbilic is not None)
-                else 1
-            )
-            grid = LinearGrid(
-                N=2 * self.N * getattr(self, "NFP", 1) + 5,
-                n_umbilic=int(n_umbilic),
-            )
-        elif isinstance(grid, numbers.Integral):
-            NFP = self.NFP if hasattr(self, "NFP") else 1
-            n_umbilic = self.n_umbilic if hasattr(self, "n_umbilic") else 1
-            grid = LinearGrid(N=grid, NFP=NFP, n_umbilic=n_umbilic, endpoint=False)
-        elif hasattr(grid, "NFP"):
-            NFP = grid.NFP
-        else:
-            raise TypeError(
-                "must pass in a Grid object or an integer for argument grid!"
-                f"instead got type {type(grid)}",
-            )
-
-        if params is None:
-            params = get_params(names, obj=self, basis=kwargs.get("basis", "rpz"))
-        if transforms is None:
-            transforms = get_transforms(
-                names,
-                obj=self,
-                grid=grid,
-                jitable=True,
-            )
-        if data is None:
-            data = {}
-        profiles = {}
-
-        p = _parse_parameterization(self)
-        deps = list(set(get_data_deps(names, obj=p) + names))
-        dep0d = [
-            dep
-            for dep in deps
-            if (data_index[p][dep]["coordinates"] == "") and (dep not in data)
-        ]
-        calc0d = bool(len(dep0d))
-        # see if the grid we're already using will work for desired quantities
-        if calc0d and (grid.N >= 2 * self.N + 5) and isinstance(grid, LinearGrid):
-            calc0d = False
-
-        if calc0d and override_grid:
-            grid0d = LinearGrid(N=2 * self.N * getattr(self, "NFP", 1) + 5)
-            data0d = compute_fun(
-                self,
-                dep0d,
-                params=params,
-                transforms=get_transforms(
-                    dep0d,
-                    obj=self,
-                    grid=grid0d,
-                    jitable=True,
-                    **kwargs,
-                ),
-                profiles={},
-                data=None,
-                **kwargs,
-            )
-            # these should all be 0d quantities so don't need to compress/expand
-            data0d = {key: val for key, val in data0d.items() if key in dep0d}
-            data.update(data0d)
-
-        data = compute_fun(
-            self,
-            names,
-            params=params,
-            transforms=transforms,
-            profiles=profiles,
-            data=data,
-            **kwargs,
-        )
-        return data
-
-    def translate(self, displacement=[0, 0, 0]):
-        """Translate the curve by a rigid displacement in X,Y,Z coordinates."""
-        self.shift = self.shift + jnp.asarray(displacement)
-
-    def flip(self, normal=[0, 0, 1]):
-        """Flip the curve about the plane with specified normal in X,Y,Z coordinates."""
-        F = reflection_matrix(normal)
-        self.rotmat = (F @ self.rotmat.reshape(3, 3)).flatten()
-        self.shift = self.shift @ F.T
-
-    def __repr__(self):
-        """Get the string form of the object."""
-        return (
-            type(self).__name__
-            + " at "
-            + str(hex(id(self)))
-            + " (name={})".format(self.name)
-        )
-
-
 class Curve(IOAble, Optimizable, ABC):
     """Abstract base class for 1D curves in 3D space."""
 
@@ -457,7 +264,7 @@ class Curve(IOAble, Optimizable, ABC):
             should be an 1D ndarray of same length as the input.
             (input length in this case is determined by grid argument, since
             the input coordinates come from Curve.compute("x",grid=grid))
-            If None, defaults to using an linearly spaced points in [0, 2pi) as the
+            If None, defaults to using linearly spaced points in [0, 2pi) as the
             knots. If supplied, should lie in [0,2pi].
             Alternatively, the string "arclength" can be supplied to use the normalized
             distance between points.
@@ -822,6 +629,199 @@ class Surface(IOAble, Optimizable, ABC):
             **kwargs,
         )
         return data
+
+    def __repr__(self):
+        """Get the string form of the object."""
+        return (
+            type(self).__name__
+            + " at "
+            + str(hex(id(self)))
+            + " (name={})".format(self.name)
+        )
+
+
+class UmbilicCurve(IOAble, Optimizable, ABC):
+    """Abstract base class for 1D umbilic curves in 3D space."""
+
+    _io_attrs_ = ["_name"]
+
+    def __init__(self, name=""):
+        self._name = name
+
+    def _set_up(self):
+        """Set things after loading."""
+        if hasattr(self, "_NFP"):
+            self._NFP = int(self._NFP)
+        if not hasattr(self, "_shift"):
+            self.shift
+        if not hasattr(self, "_rotmat"):
+            self.rotmat
+
+    @optimizable_parameter
+    @property
+    def shift(self):
+        """Displacement of curve in X, Y, Z."""
+        return self.__dict__.setdefault("_shift", jnp.array([0, 0, 0], dtype=float))
+
+    @shift.setter
+    def shift(self, new):
+        if len(new) == 3:
+            self._shift = jnp.asarray(new)
+        else:
+            raise ValueError("shift should be a 3 element vector, got {}".format(new))
+
+    @optimizable_parameter
+    @property
+    def rotmat(self):
+        """Rotation matrix of curve in X, Y, Z."""
+        return self.__dict__.setdefault("_rotmat", jnp.eye(3, dtype=float).flatten())
+
+    @rotmat.setter
+    def rotmat(self, new):
+        if len(new) == 9:
+            self._rotmat = jnp.asarray(new)
+        else:
+            self._rotmat = jnp.asarray(new.flatten())
+
+    @property
+    def name(self):
+        """Name of the curve."""
+        return self.__dict__.setdefault("_name", "")
+
+    @name.setter
+    def name(self, new):
+        self._name = str(new)
+
+    def compute(
+        self,
+        names,
+        grid=None,
+        params=None,
+        transforms=None,
+        data=None,
+        override_grid=True,
+        **kwargs,
+    ):
+        """Compute the quantity given by name on grid.
+
+        Parameters
+        ----------
+        names : str or array-like of str
+            Name(s) of the quantity(s) to compute.
+        grid : Grid or int, optional
+            Grid of coordinates to evaluate at. Defaults to a Linear grid.
+            If an integer, uses that many equally spaced points.
+        params : dict of ndarray
+            Parameters from the equilibrium. Defaults to attributes of self.
+        transforms : dict of Transform
+            Transforms for R, Z, lambda, etc. Default is to build from grid
+        data : dict of ndarray
+            Data computed so far, generally output from other compute functions.
+            Any vector v = v¹ R̂ + v² ϕ̂ + v³ Ẑ should be given in components
+            v = [v¹, v², v³] where R̂, ϕ̂, Ẑ are the normalized basis vectors
+            of the cylindrical coordinates R, ϕ, Z.
+        override_grid : bool
+            If True, override the user supplied grid if necessary and use a full
+            resolution grid to compute quantities and then downsample to user requested
+            grid. If False, uses only the user specified grid, which may lead to
+            inaccurate values for surface or volume averages.
+
+        Returns
+        -------
+        data : dict of ndarray
+            Computed quantity and intermediate variables.
+
+        """
+        if isinstance(names, str):
+            names = [names]
+        if grid is None:
+            n_umbilic = (
+                self.n_umbilic
+                if (hasattr(self, "n_umbilic") and self.n_umbilic is not None)
+                else 1
+            )
+            grid = LinearGrid(
+                N=2 * self.N * getattr(self, "NFP", 1) + 5,
+                n_umbilic=int(n_umbilic),
+            )
+        elif isinstance(grid, numbers.Integral):
+            NFP = self.NFP if hasattr(self, "NFP") else 1
+            n_umbilic = self.n_umbilic if hasattr(self, "n_umbilic") else 1
+            grid = LinearGrid(N=grid, NFP=NFP, n_umbilic=n_umbilic, endpoint=False)
+        elif hasattr(grid, "NFP"):
+            NFP = grid.NFP
+        else:
+            raise TypeError(
+                "must pass in a Grid object or an integer for argument grid!"
+                f"instead got type {type(grid)}",
+            )
+
+        if params is None:
+            params = get_params(names, obj=self, basis=kwargs.get("basis", "rpz"))
+        if transforms is None:
+            transforms = get_transforms(
+                names,
+                obj=self,
+                grid=grid,
+                jitable=True,
+            )
+        if data is None:
+            data = {}
+        profiles = {}
+
+        p = _parse_parameterization(self)
+        deps = list(set(get_data_deps(names, obj=p) + names))
+        dep0d = [
+            dep
+            for dep in deps
+            if (data_index[p][dep]["coordinates"] == "") and (dep not in data)
+        ]
+        calc0d = bool(len(dep0d))
+        # see if the grid we're already using will work for desired quantities
+        if calc0d and (grid.N >= 2 * self.N + 5) and isinstance(grid, LinearGrid):
+            calc0d = False
+
+        if calc0d and override_grid:
+            grid0d = LinearGrid(N=2 * self.N * getattr(self, "NFP", 1) + 5)
+            data0d = compute_fun(
+                self,
+                dep0d,
+                params=params,
+                transforms=get_transforms(
+                    dep0d,
+                    obj=self,
+                    grid=grid0d,
+                    jitable=True,
+                    **kwargs,
+                ),
+                profiles={},
+                data=None,
+                **kwargs,
+            )
+            # these should all be 0d quantities so don't need to compress/expand
+            data0d = {key: val for key, val in data0d.items() if key in dep0d}
+            data.update(data0d)
+
+        data = compute_fun(
+            self,
+            names,
+            params=params,
+            transforms=transforms,
+            profiles=profiles,
+            data=data,
+            **kwargs,
+        )
+        return data
+
+    def translate(self, displacement=[0, 0, 0]):
+        """Translate the curve by a rigid displacement in X,Y,Z coordinates."""
+        self.shift = self.shift + jnp.asarray(displacement)
+
+    def flip(self, normal=[0, 0, 1]):
+        """Flip the curve about the plane with specified normal in X,Y,Z coordinates."""
+        F = reflection_matrix(normal)
+        self.rotmat = (F @ self.rotmat.reshape(3, 3)).flatten()
+        self.shift = self.shift @ F.T
 
     def __repr__(self):
         """Get the string form of the object."""

--- a/desc/geometry/core.py
+++ b/desc/geometry/core.py
@@ -212,51 +212,6 @@ class UmbilicCurve(IOAble, Optimizable, ABC):
             + " (name={})".format(self.name)
         )
 
-    # TO DO: Determine if this function is necessary
-    def to_FourierUmbilic(
-        self, N=10, grid=None, NFP=None, n_umbilic=1, sym=False, name=""
-    ):
-        """Convert Curve to FourierRZCurve representation.
-
-        Note that some types of curves may not be representable in this basis.
-
-        Parameters
-        ----------
-        N : int
-            Fourier resolution of the new A representation.
-        grid : Grid, int or None
-            Grid used to evaluate curve coordinates on to fit with FourierRZCurve.
-            If an integer, uses that many equally spaced points.
-        NFP : int
-            Number of field periods, the curve will have a discrete toroidal symmetry
-            according to NFP.
-        sym : bool, optional
-            Whether the curve is stellarator-symmetric or not. Default is False.
-        name : str
-            name for this curve
-
-        Returns
-        -------
-        curve : FourierRZCurve
-            New representation of the curve parameterized by Fourier series for R,Z.
-
-        """
-        from .umbiliccurve import FourierUmbilicCurve
-
-        NFP = 1 or NFP
-        if grid is None:
-            grid = LinearGrid(N=2 * N + 1)
-        coords = self.compute("A", grid=grid, basis="rtz")["A"]
-        return FourierUmbilicCurve.from_values(
-            coords,
-            N=N,
-            NFP=NFP,
-            n_umbilic=n_umbilic,
-            basis="rtz",
-            name=name,
-            sym=sym,
-        )
-
 
 class Curve(IOAble, Optimizable, ABC):
     """Abstract base class for 1D curves in 3D space."""

--- a/desc/geometry/curve.py
+++ b/desc/geometry/curve.py
@@ -46,7 +46,7 @@ class FourierRZCurve(Curve):
     modes_R : array-like, optional
         Mode numbers associated with R_n. If not given defaults to [-n:n].
     modes_Z : array-like, optional
-        Mode numbers associated with Z_n, If not given defaults to [-n:n]].
+        Mode numbers associated with Z_n. If not given defaults to [-n:n].
     NFP : int
         Number of field periods.
     sym : bool
@@ -111,13 +111,13 @@ class FourierRZCurve(Curve):
         self._R_basis = FourierSeries(
             N,
             int(NFP),
-            NFP_umbilic_factor=int(1),
+            n_umbilic=int(1),
             sym="cos" if sym else False,
         )
         self._Z_basis = FourierSeries(
             N,
             int(NFP),
-            NFP_umbilic_factor=int(1),
+            n_umbilic=int(1),
             sym="sin" if sym else False,
         )
 
@@ -166,13 +166,13 @@ class FourierRZCurve(Curve):
             self.R_basis.change_resolution(
                 N=N,
                 NFP=self.NFP,
-                NFP_umbilic_factor=1,
+                n_umbilic=1,
                 sym="cos" if self.sym else self.sym,
             )
             self.Z_basis.change_resolution(
                 N=N,
                 NFP=self.NFP,
-                NFP_umbilic_factor=1,
+                n_umbilic=1,
                 sym="sin" if self.sym else self.sym,
             )
             self.R_n = copy_coeffs(self.R_n, R_modes_old, self.R_basis.modes)
@@ -286,7 +286,7 @@ class FourierRZCurve(Curve):
         sym : bool
             Whether to enforce stellarator symmetry.
         basis : {"rpz", "xyz"}
-            basis for input coordinates. Defaults to "rpz"
+            basis for input coordinates. Defaults to "rpz".
         name : str
             Name for this curve.
 
@@ -445,9 +445,9 @@ class FourierXYZCurve(Curve):
         assert Z_n.size == modes.size, "Z_n and modes must be the same size"
 
         N = np.max(abs(modes))
-        self._X_basis = FourierSeries(N, NFP=1, NFP_umbilic_factor=1, sym=False)
-        self._Y_basis = FourierSeries(N, NFP=1, NFP_umbilic_factor=1, sym=False)
-        self._Z_basis = FourierSeries(N, NFP=1, NFP_umbilic_factor=1, sym=False)
+        self._X_basis = FourierSeries(N, NFP=1, n_umbilic=1, sym=False)
+        self._Y_basis = FourierSeries(N, NFP=1, n_umbilic=1, sym=False)
+        self._Z_basis = FourierSeries(N, NFP=1, n_umbilic=1, sym=False)
         self._X_n = copy_coeffs(X_n, modes, self.X_basis.modes[:, 2])
         self._Y_n = copy_coeffs(Y_n, modes, self.Y_basis.modes[:, 2])
         self._Z_n = copy_coeffs(Z_n, modes, self.Z_basis.modes[:, 2])
@@ -731,7 +731,7 @@ class FourierPlanarCurve(Curve):
         assert basis.lower() in ["xyz", "rpz"]
 
         N = np.max(abs(modes))
-        self._r_basis = FourierSeries(N, NFP=1, NFP_umbilic_factor=1, sym=False)
+        self._r_basis = FourierSeries(N, NFP=1, n_umbilic=1, sym=False)
         self._r_n = copy_coeffs(r_n, modes, self.r_basis.modes[:, 2])
 
         self._basis = basis

--- a/desc/geometry/curve.py
+++ b/desc/geometry/curve.py
@@ -111,13 +111,13 @@ class FourierRZCurve(Curve):
         self._R_basis = FourierSeries(
             N,
             int(NFP),
-            n_umbilic=int(1),
+            N_scaling=int(1),
             sym="cos" if sym else False,
         )
         self._Z_basis = FourierSeries(
             N,
             int(NFP),
-            n_umbilic=int(1),
+            N_scaling=int(1),
             sym="sin" if sym else False,
         )
 
@@ -166,13 +166,13 @@ class FourierRZCurve(Curve):
             self.R_basis.change_resolution(
                 N=N,
                 NFP=self.NFP,
-                n_umbilic=1,
+                N_scaling=1,
                 sym="cos" if self.sym else self.sym,
             )
             self.Z_basis.change_resolution(
                 N=N,
                 NFP=self.NFP,
-                n_umbilic=1,
+                N_scaling=1,
                 sym="sin" if self.sym else self.sym,
             )
             self.R_n = copy_coeffs(self.R_n, R_modes_old, self.R_basis.modes)
@@ -445,9 +445,9 @@ class FourierXYZCurve(Curve):
         assert Z_n.size == modes.size, "Z_n and modes must be the same size"
 
         N = np.max(abs(modes))
-        self._X_basis = FourierSeries(N, NFP=1, n_umbilic=1, sym=False)
-        self._Y_basis = FourierSeries(N, NFP=1, n_umbilic=1, sym=False)
-        self._Z_basis = FourierSeries(N, NFP=1, n_umbilic=1, sym=False)
+        self._X_basis = FourierSeries(N, NFP=1, N_scaling=1, sym=False)
+        self._Y_basis = FourierSeries(N, NFP=1, N_scaling=1, sym=False)
+        self._Z_basis = FourierSeries(N, NFP=1, N_scaling=1, sym=False)
         self._X_n = copy_coeffs(X_n, modes, self.X_basis.modes[:, 2])
         self._Y_n = copy_coeffs(Y_n, modes, self.Y_basis.modes[:, 2])
         self._Z_n = copy_coeffs(Z_n, modes, self.Z_basis.modes[:, 2])
@@ -731,7 +731,7 @@ class FourierPlanarCurve(Curve):
         assert basis.lower() in ["xyz", "rpz"]
 
         N = np.max(abs(modes))
-        self._r_basis = FourierSeries(N, NFP=1, n_umbilic=1, sym=False)
+        self._r_basis = FourierSeries(N, NFP=1, N_scaling=1, sym=False)
         self._r_n = copy_coeffs(r_n, modes, self.r_basis.modes[:, 2])
 
         self._basis = basis

--- a/desc/geometry/fluxsurfacecurve.py
+++ b/desc/geometry/fluxsurfacecurve.py
@@ -15,13 +15,13 @@ __all__ = ["FourierUmbilicCurve"]
 
 
 class FourierUmbilicCurve(FluxSurfaceCurve):
-    r"""Curve parameterized by Fourier series in terms of toroidal angle zeta.
+    r"""Curve parameterized by Fourier series in terms of toroidal angle phi.
 
     Specific parameterization introduced for study of umbilic curves in [1].
     Given in DESC coordinates by
-    \theta = (m_umbilic/n_umbilic*NFP)\\zeta
-                    + (1/n_umbilic)\\sum_{n=0}^{N} a_n cos( (n*NFP/n_umbilic) zeta)
-                    + (1/n_umbilic)\\sum_{n=-N}^{-1} a_n sin( (|n|*NFP/n_umbilic) zeta)
+    \theta = (m_umbilic/n_umbilic*NFP)\\phi
+                    + (1/n_umbilic)\\sum_{n=0}^{N} a_n cos( (n*NFP/n_umbilic) phi)
+                    + (1/n_umbilic)\\sum_{n=-N}^{-1} a_n sin( (|n|*NFP/n_umbilic) phi)
 
     References
     ----------
@@ -46,7 +46,7 @@ class FourierUmbilicCurve(FluxSurfaceCurve):
         Default is n_umbilic = 1.
     m_umbilic : int
         Parameter arising from umbilic torus parameterization, determining
-        the average slope of the curve in the (theta,zeta) plane.
+        the average slope of the curve in the (theta,phi) plane.
         Should satisfy gcd(n_umbilic, m_umbilic)=1.
         Default is m_umbilic = 1.
     sym : bool
@@ -74,7 +74,7 @@ class FourierUmbilicCurve(FluxSurfaceCurve):
 
     def __init__(
         self,
-        a_n=0,
+        a_n=None,
         modes_UC=None,
         NFP=1,
         n_umbilic=1,
@@ -83,13 +83,14 @@ class FourierUmbilicCurve(FluxSurfaceCurve):
         name="",
     ):
         super().__init__(name)
+
+        if a_n is None:
+            a_n = np.array([0.0, 0.0, 0.0])
+            modes_UC = np.array([-1, 0, 1])
         a_n = np.atleast_1d(a_n)
+
         if modes_UC is None:
             modes_UC = np.arange(-(a_n.size // 2), a_n.size // 2 + 1)
-
-        if a_n.size == 0:
-            a_n = np.array([0.0])
-            modes_UC = np.array([0])
 
         modes_UC = np.asarray(modes_UC)
 
@@ -123,6 +124,56 @@ class FourierUmbilicCurve(FluxSurfaceCurve):
         self._a_n = jnp.atleast_1d(self._a_n)
         self._n_umbilic = int(self._n_umbilic)
         self._m_umbilic = int(self._m_umbilic)
+        self._UC_basis._N_scaling = self._n_umbilic
+
+    def compute(
+        self,
+        names,
+        grid=None,
+        params=None,
+        transforms=None,
+        data=None,
+        override_grid=True,
+        **kwargs,
+    ):
+        """Compute the quantity given by name on grid.
+
+        Parameters
+        ----------
+        names : str or array-like of str
+            Name(s) of the quantity(s) to compute.
+        grid : Grid or int, optional
+            Grid of coordinates to evaluate at. Defaults to a Linear grid.
+            If an integer, uses that many equally spaced points.
+        params : dict of ndarray
+            Parameters from the equilibrium. Defaults to attributes of self.
+        transforms : dict of Transform
+            Transforms for R, Z, lambda, etc. Default is to build from grid
+        data : dict of ndarray
+            Data computed so far, generally output from other compute functions.
+            Any vector v = v¹ R̂ + v² ϕ̂ + v³ Ẑ should be given in components
+            v = [v¹, v², v³] where R̂, ϕ̂, Ẑ are the normalized basis vectors
+            of the cylindrical coordinates R, ϕ, Z.
+        override_grid : bool
+            If True, override the user supplied grid if necessary and use a full
+            resolution grid to compute quantities and then downsample to user requested
+            grid. If False, uses only the user specified grid, which may lead to
+            inaccurate values for surface or volume averages.
+
+        Returns
+        -------
+        data : dict of ndarray
+            Computed quantity and intermediate variables.
+
+        """
+        kwargs["n_umbilic"] = self._n_umbilic
+        kwargs["m_umbilic"] = self._m_umbilic
+        kwargs["NFP"] = self._NFP
+
+        data = super().compute(
+            names, grid, params, transforms, data, override_grid, **kwargs
+        )
+        return data
 
     @property
     def sym(self):
@@ -151,13 +202,51 @@ class FourierUmbilicCurve(FluxSurfaceCurve):
 
     @property
     def m_umbilic(self):
-        """Slope parameter for curve in (theta,zeta) plane."""
+        """Slope parameter for curve in (theta,phi) plane."""
         return self.__dict__.setdefault("_m_umbilic", 1)
 
     @property
     def N(self):
         """Maximum mode number."""
         return self.UC_basis.N
+
+    def change_resolution(
+        self, N=None, NFP=None, n_umbilic=None, m_umbilic=None, sym=None
+    ):
+        """Change the maximum toroidal resolution."""
+        N = check_posint(N, "N")
+        NFP = check_posint(NFP, "NFP")
+        n_umbilic = check_posint(n_umbilic, "n_umbilic")
+        m_umbilic = check_posint(m_umbilic, "m_umbilic")
+        if (
+            ((N is not None) and (N != self.N))
+            or ((NFP is not None) and (NFP != self.NFP))
+            or ((n_umbilic is not None) and (n_umbilic != self.n_umbilic))
+            or ((m_umbilic is not None) and (m_umbilic != self.m_umbilic))
+            or ((sym is not None) and (sym != self.sym))
+        ):
+            self._NFP = int(NFP if NFP is not None else self.NFP)
+            self._n_umbilic = int(
+                n_umbilic if n_umbilic is not None else self.n_umbilic
+            )
+            self._m_umbilic = int(
+                m_umbilic if m_umbilic is not None else self.m_umbilic
+            )
+            assert (
+                jnp.gcd(self.n_umbilic, self.m_umbilic) == 1
+            ), "n_umbilic and m_umbilic should have gcd = 1"
+
+            self._sym = bool(sym) if sym is not None else self.sym
+            N = int(N if N is not None else self.N)
+
+            UC_modes_old = self.UC_basis.modes
+            self.UC_basis.change_resolution(
+                N=N,
+                NFP=self.NFP,
+                N_scaling=self.n_umbilic,
+                sym="cos" if self.sym else self.sym,
+            )
+            self.a_n = copy_coeffs(self.a_n, UC_modes_old, self.UC_basis.modes)
 
     def get_coeffs(self, n):
         """Get Fourier coefficients for given mode number(s)."""
@@ -198,14 +287,15 @@ class FourierUmbilicCurve(FluxSurfaceCurve):
     def from_values(
         cls, coords, N=10, NFP=1, n_umbilic=1, m_umbilic=1, name="", sym=False
     ):
-        """Fit a FourierUmbilicCurve to given (theta,zeta) values.
+        """Fit a FourierUmbilicCurve to given (theta,phi) values.
 
         Parameters
         ----------
         coords: ndarray, shape (num_coords,2)
-            Coordinates theta, zeta along the curve.
+            Coordinates theta, phi along the curve.
         N : int
-            Fourier resolution of the curve parameterization.
+            Fourier resolution of the curve parameterization. Resulting curve will have
+            modes UC_modes = [-N:N] populated.
         NFP : int
             Number of field periods, the curve will have a discrete toroidal symmetry
             according to NFP.
@@ -213,7 +303,7 @@ class FourierUmbilicCurve(FluxSurfaceCurve):
             Umbilic factor to fit curves that go around multiple times toroidally before
             closing on themselves.
         m_umbilic : int
-            Umbilic factor to set the average slope of curve in the (theta,zeta) plane.
+            Umbilic factor to set the average slope of curve in the (theta,phi) plane.
         sym : bool
             Whether to enforce stellarator symmetry.
         name : str
@@ -222,14 +312,23 @@ class FourierUmbilicCurve(FluxSurfaceCurve):
         Returns
         -------
         curve : FourierUmbilicCurve
-            New representation of the curve parameterized by Fourier series for zeta.
+            New representation of the curve parameterized by Fourier series for phi.
 
         """
         theta = coords[:, 0]
-        zeta = coords[:, 1]
-        UC = n_umbilic * theta - m_umbilic * NFP * zeta
+        phi = coords[:, 1]
+        UC = n_umbilic * theta - m_umbilic * NFP * phi
 
-        grid = LinearGrid(zeta=zeta, NFP=NFP, N_scaling=n_umbilic, sym=sym)
+        # Will fit a basis with period n_umbilic/NFP*2pi,
+        # so mod input phi values by this
+        period = n_umbilic / NFP * 2 * np.pi
+        phi = phi % period
+
+        # Sort and remove duplicate values of phi
+        phi, idx = np.unique(phi, return_index=True)
+        UC = UC[idx]
+
+        grid = LinearGrid(zeta=phi, NFP=NFP, N_scaling=n_umbilic, sym=sym)
         basis = FourierSeries(N=N, NFP=NFP, N_scaling=n_umbilic, sym=sym)
         transform = Transform(grid, basis, build_pinv=True)
         a_n = transform.fit(UC)

--- a/desc/geometry/fluxsurfacecurve.py
+++ b/desc/geometry/fluxsurfacecurve.py
@@ -1,4 +1,4 @@
-"""Classes for parameterized 3D umbilic space curves."""
+"""Classes for parameterized 3D space curves constrained to lie in flux surfaces."""
 
 import numpy as np
 
@@ -64,6 +64,14 @@ class FourierUmbilicCurve(FluxSurfaceCurve):
         "_m_umbilic",
     ]
 
+    _static_attrs = FluxSurfaceCurve._static_attrs + [
+        "_UC_basis",
+        "_sym",
+        "_NFP",
+        "_n_umbilic",
+        "_m_umbilic",
+    ]
+
     def __init__(
         self,
         a_n=0,
@@ -105,10 +113,16 @@ class FourierUmbilicCurve(FluxSurfaceCurve):
         self._UC_basis = FourierSeries(
             N,
             int(NFP),
-            n_umbilic=int(n_umbilic),
+            N_scaling=int(n_umbilic),
             sym="sin" if sym else False,
         )
         self._a_n = copy_coeffs(a_n, modes_UC, self.UC_basis.modes[:, 2])
+
+    def _set_up(self):
+        super()._set_up()
+        self._a_n = jnp.atleast_1d(self._a_n)
+        self._n_umbilic = int(self._n_umbilic)
+        self._m_umbilic = int(self._m_umbilic)
 
     @property
     def sym(self):
@@ -130,18 +144,15 @@ class FourierUmbilicCurve(FluxSurfaceCurve):
         """NFP umbilic factor. Effective NFP -> NFP/n_umbilic."""
         return self.__dict__.setdefault("_n_umbilic", 1)
 
-    def _n_umbilic(self):
-        """NFP umbilic factor. Effective NFP -> NFP/n_umbilic."""
-        self._n_umbilic = self.n_umbilic
+    @property
+    def N_scaling(self):
+        """Alias for n_umbilic."""
+        return self.__dict__.setdefault("_n_umbilic", 1)
 
     @property
     def m_umbilic(self):
         """Slope parameter for curve in (theta,zeta) plane."""
         return self.__dict__.setdefault("_m_umbilic", 1)
-
-    def _m_umbilic(self):
-        """Slope parameter for curve in (theta,zeta) plane."""
-        self._m_umbilic = self.m_umbilic
 
     @property
     def N(self):

--- a/desc/geometry/fluxsurfacecurve.py
+++ b/desc/geometry/fluxsurfacecurve.py
@@ -9,22 +9,23 @@ from desc.optimizable import optimizable_parameter
 from desc.transform import Transform
 from desc.utils import check_posint, copy_coeffs
 
-from .core import UmbilicCurve
+from .core import FluxSurfaceCurve
 
 __all__ = ["FourierUmbilicCurve"]
 
 
-class FourierUmbilicCurve(UmbilicCurve):
-    r"""Umbilic curve parameterized by Fourier series in terms of toroidal angle zeta.
+class FourierUmbilicCurve(FluxSurfaceCurve):
+    r"""Curve parameterized by Fourier series in terms of toroidal angle zeta.
 
-    Curve parameterized in DESC coordinates via
+    Specific parameterization introduced for study of umbilic curves in [1].
+    Given in DESC coordinates by
     \theta = (m_umbilic/n_umbilic*NFP)\\zeta
                     + (1/n_umbilic)\\sum_{n=0}^{N} a_n cos( (n*NFP/n_umbilic) zeta)
                     + (1/n_umbilic)\\sum_{n=-N}^{-1} a_n sin( (|n|*NFP/n_umbilic) zeta)
 
     References
     ----------
-    https://arxiv.org/abs/2505.04211.
+    [1] https://arxiv.org/abs/2505.04211.
     Omnigenous Umbilic Stellarators.
     R. Gaur, D. Panici, T.M. Elder, M. Landreman, K.E. Unalmis,
     Y. Elmacioglu. D. Dudt, R. Conlin, E. Kolemen.
@@ -54,7 +55,7 @@ class FourierUmbilicCurve(UmbilicCurve):
         Name for this curve.
     """
 
-    _io_attrs_ = UmbilicCurve._io_attrs_ + [
+    _io_attrs_ = FluxSurfaceCurve._io_attrs_ + [
         "_a_n",
         "_UC_basis",
         "_sym",
@@ -100,6 +101,7 @@ class FourierUmbilicCurve(UmbilicCurve):
         self._NFP = check_posint(NFP, "NFP", False)
         self._n_umbilic = check_posint(n_umbilic, "n_umbilic", False)
         self._m_umbilic = check_posint(m_umbilic, "m_umbilic", False)
+        self._N_scaling = self._n_umbilic
         self._UC_basis = FourierSeries(
             N,
             int(NFP),
@@ -216,8 +218,8 @@ class FourierUmbilicCurve(UmbilicCurve):
         zeta = coords[:, 1]
         UC = n_umbilic * theta - m_umbilic * NFP * zeta
 
-        grid = LinearGrid(zeta=zeta, NFP=1, n_umbilic=1, sym=sym)
-        basis = FourierSeries(N=N, NFP=1, sym=sym)
+        grid = LinearGrid(zeta=zeta, NFP=NFP, N_scaling=n_umbilic, sym=sym)
+        basis = FourierSeries(N=N, NFP=NFP, N_scaling=n_umbilic, sym=sym)
         transform = Transform(grid, basis, build_pinv=True)
         a_n = transform.fit(UC)
 

--- a/desc/geometry/umbiliccurve.py
+++ b/desc/geometry/umbiliccurve.py
@@ -22,7 +22,7 @@ class FourierUmbilicCurve(UmbilicCurve):
     UC_n: array-like
         Fourier coefficients of Z.
     modes_UC : array-like, optional
-        Mode numbers associated with Z_n, If not given defaults to [-n:n].
+        Mode numbers associated with Z_n. If not given defaults to [-n:n].
     NFP : int
         Number of field periods.
     n_umbilic : int
@@ -118,9 +118,6 @@ class FourierUmbilicCurve(UmbilicCurve):
 
     def get_coeffs(self, n):
         """Get Fourier coefficients for given mode number(s)."""
-        ## TO DO: understand this
-        ## CURRENTLY ONLY OUTPUTS COEFFICIENTS FOR NEGATIVE n
-        ## values
         n = np.atleast_1d(n).astype(int)
         UC = np.zeros_like(n).astype(float)
 
@@ -156,13 +153,12 @@ class FourierUmbilicCurve(UmbilicCurve):
 
     @classmethod
     def from_values(cls, coords, N=10, NFP=1, n_umbilic=1, name="", sym=False):
-        """Fit coordinates to FourierRZCurve representation.
+        """Fit a FourierUmbilicCurve to given (theta,zeta) values.
 
         Parameters
         ----------
         coords: ndarray, shape (num_coords,2)
-            ## TO DO
-            coordinates theta, zeta, the different of which is fit with a FourierSeries
+            Coordinates theta, zeta along the curve.
         N : int
             Fourier resolution of the new R,Z representation.
         NFP : int

--- a/desc/geometry/umbiliccurve.py
+++ b/desc/geometry/umbiliccurve.py
@@ -225,6 +225,7 @@ class FourierUmbilicCurve(UmbilicCurve):
             a_n=a_n,
             NFP=NFP,
             n_umbilic=n_umbilic,
+            m_umbilic=m_umbilic,
             modes_UC=basis.modes[:, 2],
             sym=sym,
             name=name,

--- a/desc/grid.py
+++ b/desc/grid.py
@@ -27,7 +27,6 @@ class _Grid(IOAble, ABC):
         "_M",
         "_N",
         "_NFP",
-        "_N_scaling",
         "_sym",
         "_nodes",
         "_spacing",
@@ -60,6 +59,7 @@ class _Grid(IOAble, ABC):
         "_M",
         "_N",
         "_NFP",
+        "_N_scaling",
         "_node_pattern",
         "_sym",
     ]
@@ -76,6 +76,7 @@ class _Grid(IOAble, ABC):
         self._M = int(self._M)
         self._N = int(self._N)
         self._NFP = int(self._NFP)
+        self._N_scaling = int(self.__dict__.setdefault("_N_scaling", 1))
         if hasattr(self, "_inverse_theta_idx"):
             self._inverse_poloidal_idx = self._inverse_theta_idx
             del self._inverse_theta_idx
@@ -843,7 +844,6 @@ class Grid(_Grid):
         # Python 3.3 (PEP 412) introduced key-sharing dictionaries.
         # This change measurably reduces memory usage of objects that
         # define all attributes in their __init__ method.
-        self._N_scaling = 1
         self._NFP = check_posint(NFP, "NFP", False)
         self._sym = False
         self._node_pattern = "custom"
@@ -856,6 +856,8 @@ class Grid(_Grid):
                 else (np.inf, np.inf, np.inf)
             ),
         )
+        # N_scaling only implemented for LinearGrid
+        self._N_scaling = 1
         self._source_grid = source_grid
         self._is_meshgrid = bool(is_meshgrid)
         self._nodes = self._create_nodes(nodes)

--- a/desc/grid.py
+++ b/desc/grid.py
@@ -27,7 +27,7 @@ class _Grid(IOAble, ABC):
         "_M",
         "_N",
         "_NFP",
-        "_NFP_umbilic_factor",
+        "_n_umbilic",
         "_sym",
         "_nodes",
         "_spacing",
@@ -178,7 +178,7 @@ class _Grid(IOAble, ABC):
         nodes = put(
             nodes,
             Index[:, 2],
-            nodes[:, 2] % (2 * np.pi / self.NFP * self.NFP_umbilic_factor),
+            nodes[:, 2] % (2 * np.pi / self.NFP * self.n_umbilic),
         )
         # reduce weights for duplicated nodes
         _, inverse, counts = np.unique(
@@ -239,9 +239,9 @@ class _Grid(IOAble, ABC):
         return self.__dict__.setdefault("_NFP", 1)
 
     @property
-    def NFP_umbilic_factor(self):
+    def n_umbilic(self):
         """float: Umbilic factor for (toroidal) field periods."""
-        return self.__dict__.setdefault("_NFP_umbilic_factor", 1)
+        return self.__dict__.setdefault("_n_umbilic", 1)
 
     @property
     def sym(self):
@@ -521,14 +521,14 @@ class _Grid(IOAble, ABC):
             type(self).__name__
             + " at "
             + str(hex(id(self)))
-            + " (L={}, M={}, N={}, NFP={}, NFP_umbilic_factor = {},\
+            + " (L={}, M={}, N={}, NFP={}, n_umbilic = {},\
                sym={}, node_pattern={}, coordinates={})"
         ).format(
             self.L,
             self.M,
             self.N,
             self.NFP,
-            self.NFP_umbilic_factor,
+            self.n_umbilic,
             self.sym,
             self.node_pattern,
             self.coordinates,
@@ -843,7 +843,7 @@ class Grid(_Grid):
         # Python 3.3 (PEP 412) introduced key-sharing dictionaries.
         # This change measurably reduces memory usage of objects that
         # define all attributes in their __init__ method.
-        self._NFP_umbilic_factor = 1
+        self._n_umbilic = 1
         self._NFP = check_posint(NFP, "NFP", False)
         self._sym = False
         self._node_pattern = "custom"
@@ -1072,7 +1072,7 @@ class LinearGrid(_Grid):
         Toroidal grid resolution.
     NFP : int
         Number of field periods (Default = 1).
-    NFP_umbilic_factor : int
+    n_umbilic : int
         Integer>=1.
         This is needed for the umbilic torus design.
         Change this only if your nodes are placed within one field period
@@ -1116,7 +1116,7 @@ class LinearGrid(_Grid):
         M=None,
         N=None,
         NFP=1,
-        NFP_umbilic_factor=int(1),
+        n_umbilic=int(1),
         sym=False,
         axis=True,
         endpoint=False,
@@ -1131,9 +1131,7 @@ class LinearGrid(_Grid):
         self._M = check_nonnegint(M, "M")
         self._N = check_nonnegint(N, "N")
         self._NFP = check_posint(NFP, "NFP", False)
-        self._NFP_umbilic_factor = check_posint(
-            NFP_umbilic_factor, "NFP_umbilic_factor", False
-        )
+        self._n_umbilic = check_posint(n_umbilic, "n_umbilic", False)
         self._sym = sym
         self._endpoint = bool(endpoint)
         # these are just default values that may get overwritten in _create_nodes
@@ -1150,7 +1148,7 @@ class LinearGrid(_Grid):
         self._period = (
             np.inf,
             2 * np.pi,
-            2 * np.pi / self._NFP * self._NFP_umbilic_factor,
+            2 * np.pi / self._NFP * self._n_umbilic,
         )
 
         self._nodes, self._spacing = self._create_nodes(
@@ -1158,7 +1156,7 @@ class LinearGrid(_Grid):
             M=M,
             N=N,
             NFP=NFP,
-            NFP_umbilic_factor=NFP_umbilic_factor,
+            n_umbilic=n_umbilic,
             axis=axis,
             endpoint=endpoint,
             rho=rho,
@@ -1184,7 +1182,7 @@ class LinearGrid(_Grid):
         M=None,
         N=None,
         NFP=1,
-        NFP_umbilic_factor=int(1),
+        n_umbilic=int(1),
         axis=True,
         endpoint=False,
         rho=1.0,
@@ -1203,7 +1201,7 @@ class LinearGrid(_Grid):
             Toroidal grid resolution.
         NFP : int
             Number of field periods (Default = 1).
-        NFP_umbilic_factor : float
+        n_umbilic : float
             Rational number of the form 1/integer with integer>=1.
             This is needed for the umbilic torus design.
             Only change this if your nodes are placed within one field period
@@ -1233,13 +1231,11 @@ class LinearGrid(_Grid):
 
         """
         self._NFP = check_posint(NFP, "NFP", False)
-        self._NFP_umbilic_factor = check_posint(
-            NFP_umbilic_factor, "NFP_umbilic_factor", False
-        )
+        self._n_umbilic = check_posint(n_umbilic, "n_umbilic", False)
         self._period = (
             np.inf,
             2 * np.pi,
-            2 * np.pi / self._NFP * self._NFP_umbilic_factor,
+            2 * np.pi / self._NFP * self._n_umbilic,
         )
         # TODO:
         #  https://github.com/PlasmaControl/DESC/pull/1204#pullrequestreview-2246771337
@@ -1412,7 +1408,7 @@ class LinearGrid(_Grid):
 
         return nodes, spacing
 
-    def change_resolution(self, L, M, N, NFP=None, NFP_umbilic_factor=None):
+    def change_resolution(self, L, M, N, NFP=None, n_umbilic=None):
         """Change the resolution of the grid.
 
         Parameters
@@ -1425,28 +1421,28 @@ class LinearGrid(_Grid):
             new toroidal grid resolution (N toroidal nodes)
         NFP : int
             Number of field periods.
-        NFP_umbilic_factor : float
+        n_umbilic : float
             Rational number of the form 1/integer.
             This is needed for the umbilic torus design.
 
         """
         if NFP is None:
             NFP = self.NFP
-        if NFP_umbilic_factor is None:
-            NFP_umbilic_factor = self.NFP_umbilic_factor
+        if n_umbilic is None:
+            n_umbilic = self.n_umbilic
         if (
             L != self.L
             or M != self.M
             or N != self.N
             or NFP != self.NFP
-            or NFP_umbilic_factor != self.NFP_umbilic_factor
+            or n_umbilic != self.n_umbilic
         ):
             self._nodes, self._spacing = self._create_nodes(
                 L=L,
                 M=M,
                 N=N,
                 NFP=NFP,
-                NFP_umbilic_factor=NFP_umbilic_factor,
+                n_umbilic=n_umbilic,
                 axis=self.axis.size > 0,
                 endpoint=self.endpoint,
             )

--- a/desc/objectives/_geometry.py
+++ b/desc/objectives/_geometry.py
@@ -1481,14 +1481,12 @@ class UmbilicHighCurvature(_Objective):
 
         if self._curve_grid is None:
             phi_arr = jnp.linspace(0, 2 * jnp.pi, 3 * curve.N)
-            phi_arr = jnp.tile(phi_arr, curve.NFP_umbilic_factor) + jnp.repeat(
-                2 * np.pi * np.arange(curve.NFP_umbilic_factor), len(phi_arr)
+            phi_arr = jnp.tile(phi_arr, curve.n_umbilic) + jnp.repeat(
+                2 * np.pi * np.arange(curve.n_umbilic), len(phi_arr)
             )
             phi_arr = phi_arr.ravel()
 
-            curve_grid = LinearGrid(
-                zeta=phi_arr, NFP_umbilic_factor=curve.NFP_umbilic_factor
-            )
+            curve_grid = LinearGrid(zeta=phi_arr, n_umbilic=curve.n_umbilic)
         else:
             curve_grid = self._curve_grid
 
@@ -1566,9 +1564,7 @@ class UmbilicHighCurvature(_Objective):
         curve_UC = curve_data["UC"]
         curve_phi = curve_grid.nodes[:, 2]
 
-        theta_points = (
-            -self._curve.NFP * curve_phi + curve_UC
-        ) / self._curve.NFP_umbilic_factor
+        theta_points = (-self._curve.NFP * curve_phi + curve_UC) / self._curve.n_umbilic
 
         umbilic_edge_grid = Grid(
             jnp.array([jnp.ones_like(theta_points), theta_points, curve_phi]).T,

--- a/desc/transform.py
+++ b/desc/transform.py
@@ -86,14 +86,6 @@ class Transform(IOAble):
             msg=f"Unequal number of field periods for grid {self.grid.NFP} and "
             f"basis {self.basis.NFP}.",
         )
-        # The integer N_scaling multiplies the total zeta domain by 2pi, so
-        # basis.N_scaling must equal grid.N_scaling
-        warnif(
-            np.any(self.grid.nodes[:, 2] != 0)
-            and self.grid.N_scaling != self.basis.N_scaling,
-            msg=f"Unequal toroidal scaling for grid {self.grid.N_scaling} and "
-            f"basis {self.basis.N_scaling}.",
-        )
 
         self._built = False
         self._built_pinv = False

--- a/desc/transform.py
+++ b/desc/transform.py
@@ -83,7 +83,7 @@ class Transform(IOAble):
             and self.basis.N != 0
             and grid.node_pattern != "custom"
             and np.any(self.grid.nodes[:, 2] != 0)
-            or self.grid.NFP_umbilic_factor != self.basis.NFP_umbilic_factor,
+            or self.grid.n_umbilic != self.basis.n_umbilic,
             msg=f"Unequal number of field periods for grid {self.grid.NFP} and "
             f"basis {self.basis.NFP}.",
         )

--- a/desc/transform.py
+++ b/desc/transform.py
@@ -82,10 +82,17 @@ class Transform(IOAble):
             and self.grid.NFP != self.basis.NFP
             and self.basis.N != 0
             and grid.node_pattern != "custom"
-            and np.any(self.grid.nodes[:, 2] != 0)
-            or self.grid.n_umbilic != self.basis.n_umbilic,
+            and np.any(self.grid.nodes[:, 2] != 0),
             msg=f"Unequal number of field periods for grid {self.grid.NFP} and "
             f"basis {self.basis.NFP}.",
+        )
+        # The integer N_scaling multiplies the total zeta domain by 2pi, so
+        # basis.N_scaling must equal grid.N_scaling
+        warnif(
+            np.any(self.grid.nodes[:, 2] != 0)
+            and self.grid.N_scaling != self.basis.N_scaling,
+            msg=f"Unequal toroidal scaling for grid {self.grid.N_scaling} and "
+            f"basis {self.basis.N_scaling}.",
         )
 
         self._built = False

--- a/tests/test_compute_everything.py
+++ b/tests/test_compute_everything.py
@@ -135,8 +135,8 @@ def test_compute_everything():
             X_n=[5, 10, 2], Y_n=[1, 2, 3], Z_n=[-4, -5, -6]
         ).to_SplineXYZ(grid=LinearGrid(N=50)),
         # umbilic curve
-        "desc.geometry.umbiliccurve.FourierUmbilicCurve": FourierUmbilicCurve(
-            a_n=[10, 1, 0.2], modes_UC=[0, 1, 2], NFP=1, n_umbilic=3, m_umbilic=2
+        "desc.geometry.fluxsurfacecurve.FourierUmbilicCurve": FourierUmbilicCurve(
+            a_n=[10, 1, 0.2], modes_UC=[0, 1, 2], NFP=2, n_umbilic=3, m_umbilic=2
         ),
         # surfaces
         "desc.geometry.surface.FourierRZToroidalSurface": FourierRZToroidalSurface(
@@ -215,6 +215,7 @@ def test_compute_everything():
     )
     curvegrid1 = LinearGrid(N=10)
     curvegrid2 = LinearGrid(N=10, NFP=2)
+    curvegrid3 = LinearGrid(N=10, NFP=2, N_scaling=3)
     fieldgrid = LinearGrid(
         L=2,
         M=4,
@@ -230,6 +231,7 @@ def test_compute_everything():
         "desc.geometry.curve.FourierPlanarCurve": {"grid": curvegrid1},
         "desc.geometry.curve.FourierXYCurve": {"grid": curvegrid1},
         "desc.geometry.curve.SplineXYZCurve": {"grid": curvegrid1},
+        "desc.geometry.fluxsurfacecurve.FourierUmbilicCurve": {"grid": curvegrid3},
         "desc.magnetic_fields._core.OmnigenousField": {"grid": fieldgrid},
     }
 

--- a/tests/test_compute_everything.py
+++ b/tests/test_compute_everything.py
@@ -139,7 +139,7 @@ def test_compute_everything():
             UC_n=[10, 1, 0.2],
             modes_UC=[0, 1, 2],
             NFP=1,
-            NFP_umbilic_factor=3,
+            n_umbilic=3,
         ),
         # surfaces
         "desc.geometry.surface.FourierRZToroidalSurface": FourierRZToroidalSurface(

--- a/tests/test_compute_everything.py
+++ b/tests/test_compute_everything.py
@@ -136,10 +136,7 @@ def test_compute_everything():
         ).to_SplineXYZ(grid=LinearGrid(N=50)),
         # umbilic curve
         "desc.geometry.umbiliccurve.FourierUmbilicCurve": FourierUmbilicCurve(
-            UC_n=[10, 1, 0.2],
-            modes_UC=[0, 1, 2],
-            NFP=1,
-            n_umbilic=3,
+            a_n=[10, 1, 0.2], modes_UC=[0, 1, 2], NFP=1, n_umbilic=3, m_umbilic=2
         ),
         # surfaces
         "desc.geometry.surface.FourierRZToroidalSurface": FourierRZToroidalSurface(

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -1270,3 +1270,12 @@ class TestSplineXYZCurve:
         c = SplineXYZCurve(X=R * np.cos(phi), Y=R * np.sin(phi), Z=np.zeros_like(phi))
         with pytest.raises(TypeError):
             c.compute("length", grid=np.linspace(0, 1, 10))
+
+
+class TestFourierUmbilicCurve:
+    """Tests for FourierUmbilicCurve class."""
+
+    @pytest.mark.unit
+    def test_parameterization(self):
+        """Verify the parameterization of curves in DESC coordinates."""
+        pass

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -1278,4 +1278,26 @@ class TestFourierUmbilicCurve:
     @pytest.mark.unit
     def test_parameterization(self):
         """Verify the parameterization of curves in DESC coordinates."""
+        # TODO
+        # Define simple umbilic curve with n_umbilic=3,m_umbilic=2,
+        # a_n= 0, nfp = 5.
+
+        # Assert it has slope 2/3*5=10/3 in the sense
+        # that after zeta = 2pi, phi has changed 10/3*2pi
+
+        # Create now a curve with general a_n. It should close
+        # after delta theta = p 2pi = 10/3 2 pi k
+        # -> want smallest k such that 10/3 k is an integer.
+        # -> k=3. So compute curve theta for zeta=[0,2pi,4pi,6pi],
+        # verify theta-theta[0]=0 is nonzero for 2pi, 4pi but is zero
+        # for 6pi.
+        pass
+
+    @pytest.mark.unit
+    def test_from_values(self):
+        """Verify FourierUmbilicCurve can be created from input values."""
+        # TODO
+        # take a curve corresponding to n_umbilic=3, m_umbilic=2, etc.
+        # evaluate the theta and phi grid, pass it in to constructor and
+        # assert various things about the modes, check modes are correct.
         pass

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -7,6 +7,7 @@ from desc.equilibrium import Equilibrium
 from desc.geometry import (
     FourierPlanarCurve,
     FourierRZCurve,
+    FourierUmbilicCurve,
     FourierXYCurve,
     FourierXYZCurve,
     SplineXYZCurve,
@@ -1278,26 +1279,26 @@ class TestFourierUmbilicCurve:
     @pytest.mark.unit
     def test_parameterization(self):
         """Verify the parameterization of curves in DESC coordinates."""
-        # TODO
-        # Define simple umbilic curve with n_umbilic=3,m_umbilic=2,
-        # a_n= 0, nfp = 5.
+        curve = FourierUmbilicCurve(NFP=5, n_umbilic=3, m_umbilic=2)
+        grid = LinearGrid(zeta=4, N_scaling=3, endpoint=True)
+        reference = np.array([0.0, 2 / 3 * np.pi, 4 / 3 * np.pi, 2 * np.pi])
 
-        # Assert it has slope 2/3*5=10/3 in the sense
-        # that after zeta = 2pi, phi has changed 10/3*2pi
-
-        # Create now a curve with general a_n. It should close
-        # after delta theta = p 2pi = 10/3 2 pi k
-        # -> want smallest k such that 10/3 k is an integer.
-        # -> k=3. So compute curve theta for zeta=[0,2pi,4pi,6pi],
-        # verify theta-theta[0]=0 is nonzero for 2pi, 4pi but is zero
-        # for 6pi.
-        pass
+        theta = curve.compute("theta", grid=grid)["theta"]
+        UC = curve.compute("UC", grid=grid)["UC"]
+        np.testing.assert_allclose(theta % (2 * np.pi), reference, atol=1e-12)
+        np.testing.assert_allclose(UC, np.zeros_like(reference), atol=1e-12)
 
     @pytest.mark.unit
     def test_from_values(self):
         """Verify FourierUmbilicCurve can be created from input values."""
-        # TODO
-        # take a curve corresponding to n_umbilic=3, m_umbilic=2, etc.
-        # evaluate the theta and phi grid, pass it in to constructor and
-        # assert various things about the modes, check modes are correct.
-        pass
+        a_n = [0, -2, 1, 2, 0]
+        curveUC = FourierUmbilicCurve(a_n=a_n, n_umbilic=3, m_umbilic=2, NFP=2)
+        grid = LinearGrid(zeta=20, N_scaling=3, NFP=2, endpoint=False)
+        data = curveUC.compute("theta", grid=grid)
+        theta = data["theta"]
+        phi = data["phi"]
+        vals = np.stack([theta, phi], axis=1)
+
+        curveUC_reconstructed = FourierUmbilicCurve.from_values(vals, 2, 2, 3, 2)
+        a_n_reconstructed = curveUC_reconstructed._a_n
+        np.testing.assert_allclose(a_n_reconstructed, a_n, atol=1e-12)

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -847,9 +847,13 @@ class TestGrid:
 
     @pytest.mark.unit
     def test_N_scaling(self):
-        """Test that toroidal scaling parameter works correctly."""
-        # TODO
-        pass
+        """Test that toroidal scaling parameter works correctly for LinearGrid."""
+        grid = LinearGrid(zeta=5, N_scaling=5, NFP=2, endpoint=True)
+        zeta_coords = grid.nodes[:, 2]
+        zeta_reference = np.array(
+            [0.0, 5 / 4 * np.pi, 2 * 5 / 4 * np.pi, 3 * 5 / 4 * np.pi, 5 * np.pi]
+        )
+        np.testing.assert_allclose(zeta_coords, zeta_reference, atol=1e-8)
 
 
 @pytest.mark.unit

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -845,6 +845,12 @@ class TestGrid:
             z = grid.meshgrid_flatten(y, order)
             np.testing.assert_allclose(x, z)
 
+    @pytest.mark.unit
+    def test_N_scaling(self):
+        """Test that toroidal scaling parameter works correctly."""
+        # TODO
+        pass
+
 
 @pytest.mark.unit
 def test_find_most_rational_surfaces():

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -28,7 +28,12 @@ from desc.coils import (
 from desc.compute import get_transforms
 from desc.equilibrium import Equilibrium
 from desc.examples import get
-from desc.geometry import FourierPlanarCurve, FourierRZToroidalSurface, FourierXYZCurve
+from desc.geometry import (
+    FourierPlanarCurve,
+    FourierRZToroidalSurface,
+    FourierUmbilicCurve,
+    FourierXYZCurve,
+)
 from desc.grid import ConcentricGrid, Grid, LinearGrid, QuadratureGrid
 from desc.integrals import Bounce2D
 from desc.io import load
@@ -1930,6 +1935,25 @@ class TestObjectiveFunction:
         )
 
     @pytest.mark.unit
+    def test_umbilic_high_curvature(self):
+        """Test umbilic high curvature."""
+        # Default equilibrium with minor radius a=1
+        eq = Equilibrium(L=2, M=2, N=2, NFP=2)
+        curve = FourierUmbilicCurve(a_n=[-2, 0, 2], NFP=2, n_umbilic=3, m_umbilic=2)
+        num_nodes = 10
+        curve_grid = LinearGrid(zeta=num_nodes, NFP=2, N_scaling=3)
+        obj = UmbilicHighCurvature(eq, curve, curve_grid=curve_grid)
+        obj.build()
+        lowest_curvature = obj.compute()
+
+        assert len(lowest_curvature) == num_nodes
+
+        # lowest principal curvature is -1/a = -1
+        np.testing.assert_allclose(
+            lowest_curvature, -1 * np.ones_like(lowest_curvature), atol=1e-14
+        )
+
+    @pytest.mark.unit
     def test_surface_current_regularization(self):
         """Test SurfaceCurrentRegularization Calculation."""
 
@@ -3556,12 +3580,6 @@ class TestComputeScalarResolution:
         np.testing.assert_allclose(f, f[-1], rtol=2e-2)
 
     @pytest.mark.regression
-    def test_compute_scalar_resolution_umbilic_high_curv(self):
-        """Umbilic High Curvature."""
-        # TODO
-        pass
-
-    @pytest.mark.regression
     def test_compute_scalar_resolution_omnigenity(self):
         """Omnigenity."""
         surf = FourierRZToroidalSurface.from_qp_model(
@@ -3944,8 +3962,12 @@ class TestObjectiveNaNGrad:
     @pytest.mark.unit
     def test_objective_no_nangrad_umbilic_high_curv(self):
         """Umbilic High Curvature."""
-        # TODO
-        pass
+        eq = Equilibrium(L=2, M=2, N=2)
+        curve = FourierUmbilicCurve()
+        obj = ObjectiveFunction(UmbilicHighCurvature(eq, curve), use_jit=False)
+        obj.build()
+        g = obj.grad(obj.x())
+        assert not np.any(np.isnan(g)), "umbilic high curvature"
 
     @pytest.mark.unit
     @pytest.mark.parametrize(

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -3556,6 +3556,12 @@ class TestComputeScalarResolution:
         np.testing.assert_allclose(f, f[-1], rtol=2e-2)
 
     @pytest.mark.regression
+    def test_compute_scalar_resolution_umbilic_high_curv(self):
+        """Umbilic High Curvature."""
+        # TODO
+        pass
+
+    @pytest.mark.regression
     def test_compute_scalar_resolution_omnigenity(self):
         """Omnigenity."""
         surf = FourierRZToroidalSurface.from_qp_model(
@@ -3934,6 +3940,12 @@ class TestObjectiveNaNGrad:
         obj.build()
         g = obj.grad(obj.x(field))
         assert not np.any(np.isnan(g)), "surface current regularization"
+
+    @pytest.mark.unit
+    def test_objective_no_nangrad_umbilic_high_curv(self):
+        """Umbilic High Curvature."""
+        # TODO
+        pass
 
     @pytest.mark.unit
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR is meant to update the [umbilic curve PR](https://github.com/PlasmaControl/DESC/pull/819) and address some of the TODOs listed there. The changes are based on my understanding of the paper/original PR, so if anything isn't quite right I can revert it.

Overview:
- Cosmetic changes (update docstrings, make variables uniform, removing some unused functions)
- Rename base `UmbilicCurve` class to `FluxSurfaceCurve`, allowing for future representations of curves which by construction lie in a flux surface. Subclasses include `FourierUmbilicCurve`, which is the particular parameterization of umbilic curves used in the original paper.
- Add a parameter `m_umbilic` to `FourierUmbilicCurve`, so that the class can represent all curves in the original paper.
- Rename `NFP_umbilic_factor` to `n_umbilic` when used internally in `FourierUmbilicCurve`, and to `N_scaling` when used externally in basis and grid classes. Wanted a name which doesn't require knowing about umbilic curves when just working with bases or grids. 
- Separate compute functions for some of the operations happening in the `UmbilicHighCurvature` objective.
- Add tests for the curve class and objective.



Notes:
- when we update an i/o attribute, is there a way to regenerate the test examples so it doesn't throw warnings when I run the tests? To avoid those warnings I didn't include `N_scaling` in i/o attributes for grid and basis, and left if for the curve itself to update these in its `_set_up()`. 
