### PR TITLE
Support building from sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
 include versioneer.py
 include desc/_version.py
 include desc/examples/*.h5
+
+include LICENSE README.rst pyproject.toml setup.py setup.cfg requirements.txt
+global-exclude __pycache__ *.py[cod] .venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
 # These are the assumed default build requirements from pip:
 # https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-requires = ["setuptools>=40.8.0", "wheel", "versioneer-518"]
+requires = ["setuptools>=42", "versioneer-518"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,6 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as f:
 with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as f:
     requirements = f.read().splitlines()
 
-with open(os.path.join(here, "devtools/dev-requirements.txt"), encoding="utf-8") as f:
-    dev_requirements = f.read().splitlines()
-dev_requirements = [
-    foo for foo in dev_requirements if not (foo.startswith("#") or foo.startswith("-r"))
-]
-
 setup(
     name="desc-opt",
     version=versioneer.get_version(),


### PR DESCRIPTION
Current building from `sdists` are broken as `desc-opt`'s requirements are read in from a requirements file

https://github.com/PlasmaControl/DESC/blob/03637dda549c9227d6513071bfdb881367cca1de/setup.py#L14-L15

and that `requirements.txt` file is not packaged

https://github.com/PlasmaControl/DESC/blob/03637dda549c9227d6513071bfdb881367cca1de/MANIFEST.in#L1-L3

```console
$ docker run --rm -ti ghcr.io/prefix-dev/pixi:latest 
root@01c631f2ee1c:/# pixi global install uv
└── uv: 0.11.6 (installed)
    └─ exposes: uv, uvx
root@01c631f2ee1c:/# uv venv
Using CPython 3.14.4
Creating virtual environment at: .venv
Activate with: source .venv/bin/activate
root@01c631f2ee1c:/# . .venv/bin/activate
(.venv) root@01c631f2ee1c:/# uv pip install --no-binary desc-opt desc-opt
Resolved 73 packages in 2.56s
      Built pylatexenc==2.10
      Built nvgpu==0.10.0
  x Failed to build `desc-opt==0.17.1`
  |-> The build backend returned an error
  `-> Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 14, in <module>
          requires = get_requires_for_build({})
        File "/root/.cache/uv/builds-v0/.tmpf5EHdi/lib/python3.14/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/root/.cache/uv/builds-v0/.tmpf5EHdi/lib/python3.14/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "/root/.cache/uv/builds-v0/.tmpf5EHdi/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 14, in <module>
          requires = get_requires_for_build({})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      FileNotFoundError: [Errno 2] No such file or directory: '/root/.cache/uv/sdists-v9/pypi/desc-opt/0.17.1/_C0PgcgtxBLzcxbueY_K1/src/requirements.txt'

      hint: This usually indicates a problem with the package or the build environment.
(.venv) root@01c631f2ee1c:/#
```

In addition to noticing `requirements.txt` absence from `MANIFEST.in` we can also manually check

```console
$ curl -sLO https://files.pythonhosted.org/packages/88/86/1057bcddd2648f492b2820b1eca06ed9e77626ab8b7fcfede06b2c4b8ec1/desc_opt-0.17.1.tar.gz
$ tar -ztvf ./desc_opt-0.17.1.tar.gz | grep requirements.txt  # no output
```

We can see that this works now as expected by building the sdist and wheel distributions and then inspecting the sdist

```console
$ rm -rf dist/* *.egg* && uvx --from build pyproject-build
$ python -m tarfile --list dist/*.tar.gz | grep requirements
desc_opt-0.17.1+14.gfebd4184c/requirements.txt
```

This PR fixes that by ensuring the required packages are include in `setuptools` manifest.

---

* `requirements-dev.txt` is not used anywhere in the `setuptools` build system implementation and is not packaged so it should not be used in `setup.py`.
* Remove wheel from `build-system.requires` as that is now redundant.
   - c.f. https://learn.scientific-python.org/development/guides/packaging-classic/
* Update `setuptools` to `v42` to conform with modern standards.
* Add requirements.txt to setuptools manifest.

Note, this is effectively the same PR as https://github.com/f0uriest/orthax/pull/92.