### PR TITLE
correct CGL nodes in `OmnigenousField.change_resolution`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ New Features
 Bug Fixes
 
 - Fixes SyntaxError thrown when loading hdf5 data from file-like objects.
+- Fixes a bug in `OmnigenousField.change_resolution` when changing `L_B`.
 
 Performance Improvements
 

--- a/desc/magnetic_fields/_core.py
+++ b/desc/magnetic_fields/_core.py
@@ -2992,15 +2992,15 @@ class OmnigenousField(Optimizable, IOAble):
         self._N_x = setdefault(N_x, self.N_x)
 
         # change well parameters and basis
-        rho = (  # Chebyshev-Gauss-Lobatto nodes
-            1 - np.cos(np.arange(old_L_B // 2, old_L_B + 1, 1) * np.pi / old_L_B)
-        ) / 2
+        # Chebyshev-Gauss-Lobatto nodes for radial interpolation
+        rho = (1 - np.cos(np.arange(old_L_B + 1) * np.pi / old_L_B)) / 2
         nodes = np.array([rho, np.zeros_like(rho), np.zeros_like(rho)]).T
 
         transform_fwd = self.B_basis.evaluate(nodes)
         transform_rev = jnp.linalg.pinv(transform_fwd)
         B_old = transform_fwd @ self.B_lm.reshape((old_L_B + 1, -1))
 
+        # linearly spaced nodes for eta interpolation
         eta_old = np.linspace(0, jnp.pi / 2, num=B_old.shape[-1])
         eta_new = np.linspace(0, jnp.pi / 2, num=self.M_B)
 

--- a/tests/test_magnetic_fields.py
+++ b/tests/test_magnetic_fields.py
@@ -1504,7 +1504,7 @@ class TestMagneticFields:
     def test_omnigenous_field_change_resolution_B(self):
         """Test OmnigenousField.change_resolution() of the B_lm parameters."""
         L_B_old = 1
-        L_B_new = 2
+        L_B_new = 3
         M_B_old = 3
         M_B_new = 6
         NFP = 4
@@ -1531,6 +1531,7 @@ class TestMagneticFields:
         np.testing.assert_allclose(B_axis_lowres, B_axis_highres, rtol=6e-3)
         np.testing.assert_allclose(B_half_lowres, B_half_highres, rtol=3e-3)
         np.testing.assert_allclose(B_lcfs_lowres, B_lcfs_highres, rtol=4e-3)
+        field.change_resolution(L_B=L_B_new, M_B=M_B_new)  # Issue #2189
 
     @pytest.mark.unit
     def test_solve_current_potential_warnings_and_errors(self):


### PR DESCRIPTION
Resolves #2189. 

The Chebyshev-Gauss-Lobatto nodes used for changing the resolution were incorrect, but besides the linked issue this shouldn't have caused any problems besides less accurate interpolation. 