### PR TITLE
Update the pytest-mpl version

### DIFF
--- a/devtools/dev-requirements.txt
+++ b/devtools/dev-requirements.txt
@@ -32,7 +32,7 @@ pytest ~= 9.0
 pytest-benchmark <= 5.2.3
 pytest-cov >= 2.6.0, <= 7.1.0
 pytest-monitor <= 1.6.6
-pytest-mpl == 0.16.1
+pytest-mpl >= 0.16.1, <= 0.19.0
 pytest-split >= 0.8.2, <= 0.11.0
 qicna @ git+https://github.com/rogeriojorge/pyQIC/
 qsc <= 0.1.3


### PR DESCRIPTION
Recent CI failures were caused by the incompatibility with the new `pytest` release.