### PR TITLE
fix NFP bug in `to_FourierRZ`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 Changelog
 =========
 
-
 Performance Improvements
 
 - Speeds up the ``"qr"`` trust-region subproblem and Newton-step solves in the least-squares optimizers by reusing the Jacobian QR factorization across the Levenberg-Marquardt parameter sweep. On ``jax >= 0.10.0`` this uses ``qr_multiply`` to additionally avoid forming ``Q`` explicitly; on older versions a fallback preserves the same results.
+
+Bug Fixes
+
+- Fixes bug that was always setting NFP=1 in ``to_FourierRZ`` methods.
 
 
 v0.17.2

--- a/desc/coils.py
+++ b/desc/coils.py
@@ -654,7 +654,7 @@ class _Coil(_MagneticField, Optimizable, ABC):
             New representation of the coil parameterized by Fourier series for R,Z.
 
         """
-        NFP = 1 or NFP
+        NFP = 1 if NFP is None else NFP
         if grid is None:
             grid = LinearGrid(N=2 * N + 1)
         coords = self.compute("x", grid=grid, basis="xyz")["x"]

--- a/desc/geometry/core.py
+++ b/desc/geometry/core.py
@@ -312,7 +312,7 @@ class Curve(IOAble, Optimizable, ABC):
         """
         from .curve import FourierRZCurve
 
-        NFP = 1 or NFP
+        NFP = 1 if NFP is None else NFP
         if grid is None:
             grid = LinearGrid(N=2 * N + 1)
         coords = self.compute("x", grid=grid, basis="xyz")["x"]


### PR DESCRIPTION
Fixes a bug in the `to_FourierRZ` methods that was always setting NFP=1 even when a different value was input. 