### PR TITLE
Fix benchmarks for forks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,6 +21,9 @@ jobs:
   benchmark:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'run_benchmarks') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # allows posting the benchmark comment on the PR
+      contents: read        # allows checkout; prevents the token from pushing code or modifying workflows if exfiltrated by fork code
     env:
       GH_TOKEN: ${{ github.token }}
     strategy:
@@ -38,6 +41,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Filter changes
         id: changes

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       pull-requests: write  # allows posting the benchmark comment on the PR
       contents: read        # allows checkout; prevents the token from pushing code or modifying workflows if exfiltrated by fork code
+      actions: read         # allows `gh cache list`; all other scopes default to none
     env:
       GH_TOKEN: ${{ github.token }}
     strategy:

--- a/.github/workflows/memory_benchmark.yml
+++ b/.github/workflows/memory_benchmark.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   memory-benchmark:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # allows posting the benchmark comment on the PR
+      contents: read        # allows checkout; prevents the token from pushing code or modifying workflows if exfiltrated by fork code
     env:
       GH_TOKEN: ${{ github.token }}
     strategy:
@@ -20,6 +23,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Filter changes
         id: changes

--- a/.github/workflows/memory_benchmark.yml
+++ b/.github/workflows/memory_benchmark.yml
@@ -36,7 +36,7 @@ jobs:
               - 'requirements.txt'
               - 'devtools/dev-requirements.txt'
               - 'setup.cfg'
-              - '.github/workflows/memory_benchmarks.yml'
+              - '.github/workflows/memory_benchmark.yml'
 
       - name: Check for relevant changes
         id: check_changes

--- a/.github/workflows/memory_benchmark.yml
+++ b/.github/workflows/memory_benchmark.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       pull-requests: write  # allows posting the benchmark comment on the PR
       contents: read        # allows checkout; prevents the token from pushing code or modifying workflows if exfiltrated by fork code
+      actions: read         # allows `gh cache list`; all other scopes default to none
     env:
       GH_TOKEN: ${{ github.token }}
     strategy:


### PR DESCRIPTION
Looks like after #2250, fork PRs are no longer able to run benchmarks workflows (see  [example failing action](https://github.com/PlasmaControl/DESC/actions/runs/28606777291/job/84828939317?pr=2221)).

These changes make sure that all CI jobs run for forks. Also, added `permissions` prevents the use of `GITHUB_TOKEN` for any other purpose than posting the benchmark results as comment. See [permission docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idpermissions) for details.