### PR TITLE
Fix VMEC current output metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Performance Improvements
 Bug Fixes
 
 - Fixes bug that was always setting NFP=1 in ``to_FourierRZ`` methods.
+- Fixes ``VMECIO.save`` metadata for current-density variables and corrects the
+  asymmetric ``currvmns`` magnetic-axis extrapolation.
 
 
 v0.17.2

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -56,7 +56,9 @@ class VMECIO:
         NOTE: This is only a fit, so the DESC Equilibrium returned is not
         expected to be in force balance. It is recommended to solve the
         Equilibrium once loaded before using the Equilibrium for any
-        analysis.
+        analysis. Current-density quantities computed from the loaded fit may
+        not reproduce the VMEC current harmonics until the equilibrium is
+        solved or otherwise refined.
 
         Parameters
         ----------
@@ -734,7 +736,7 @@ class VMECIO:
         jcuru[0] = 0
 
         jcurv = file.createVariable("jcurv", np.float64, ("radius",))
-        jcuru.long_name = "flux surface average of sqrt(g)*J^zeta, on full mesh"
+        jcurv.long_name = "flux surface average of sqrt(g)*J^zeta, on full mesh"
         jcurv.units = "A/m^3"
         jcurv[:] = surface_averages(
             grid_full,
@@ -1331,7 +1333,7 @@ class VMECIO:
         # TODO (#1379): evaluate current at rho=0 nodes instead of extrapolation
         if not eq.sym:
             currvmns[:, :] = -s
-            currumns[0, :] = -(
+            currvmns[0, :] = -(
                 s[1, :] - (s[2, :] - s[1, :]) / (s_full[2] - s_full[1]) * s_full[1]
             )
         timer.stop("J^zeta*sqrt(g)")

--- a/desc/vmec.py
+++ b/desc/vmec.py
@@ -53,12 +53,11 @@ class VMECIO:
         boundary is loaded and the DESC Equilibrium R,Z are constrained to
         match the given VMEC boundary.
 
-        NOTE: This is only a fit, so the DESC Equilibrium returned is not
-        expected to be in force balance. It is recommended to solve the
-        Equilibrium once loaded before using the Equilibrium for any
-        analysis. Current-density quantities computed from the loaded fit may
-        not reproduce the VMEC current harmonics until the equilibrium is
-        solved or otherwise refined.
+        NOTE: This is only a fit of the VMEC R, Z and lambda, so the DESC
+        Equilibrium returned is not expected to be in force balance. It is
+        recommended to solve the Equilibrium once loaded before using the
+        Equilibrium for any analysis or computing any derived quantities in
+        DESC (e.g. anything that is not just R, Z or lambda).
 
         Parameters
         ----------

--- a/tests/test_vmec.py
+++ b/tests/test_vmec.py
@@ -1027,6 +1027,25 @@ def test_vmec_save_asym(VMEC_save_asym):
     np.testing.assert_allclose(
         vmec.variables["jcurv"][20:100], desc.variables["jcurv"][20:100], rtol=2
     )
+    assert desc.variables["jcuru"].long_name == (
+        "flux surface average of sqrt(g)*J^theta, on full mesh"
+    )
+    assert desc.variables["jcurv"].long_name == (
+        "flux surface average of sqrt(g)*J^zeta, on full mesh"
+    )
+    s_full = np.linspace(0, 1, desc.dimensions["radius"].size)
+    expected_currumns_axis = desc.variables["currumns"][1, :] - (
+        (desc.variables["currumns"][2, :] - desc.variables["currumns"][1, :])
+        / (s_full[2] - s_full[1])
+        * s_full[1]
+    )
+    expected_currvmns_axis = desc.variables["currvmns"][1, :] - (
+        (desc.variables["currvmns"][2, :] - desc.variables["currvmns"][1, :])
+        / (s_full[2] - s_full[1])
+        * s_full[1]
+    )
+    np.testing.assert_allclose(desc.variables["currumns"][0, :], expected_currumns_axis)
+    np.testing.assert_allclose(desc.variables["currvmns"][0, :], expected_currvmns_axis)
     np.testing.assert_allclose(
         vmec.variables["DShear"][20:100], desc.variables["DShear"][20:100], rtol=6e-2
     )


### PR DESCRIPTION
## Summary

This PR fixes two deterministic VMEC netCDF output issues in `VMECIO.save` and adds regression coverage for them:

1. `jcurv.long_name` was accidentally assigned to `jcuru.long_name`, so the saved `jcuru` metadata could be overwritten and `jcurv` did not get its intended long name.
2. In the non-stellarator-symmetric current harmonic output path, the magnetic-axis extrapolation for `currvmns[0, :]` was accidentally written into `currumns[0, :]`. This overwrote the already-computed `J^theta` sine-axis coefficients and left the `J^zeta` sine-axis coefficients without their intended axis extrapolation.

I also added a note to `VMECIO.load` documenting that it returns a Fourier-Zernike fit to the VMEC state, not necessarily a force-balanced DESC equilibrium. Current-density quantities computed from that fitted state can therefore differ from the original VMEC current harmonics until the equilibrium is solved or otherwise refined.

## Why I looked at this

While comparing VMEC/DESC current-line diagnostics downstream, I was checking whether VMEC current harmonics and DESC-derived current-density quantities were being interpreted consistently. During that audit I noticed these two clear write-side issues in `desc/vmec.py`. The PR intentionally keeps the code change narrow: it does not change the VMEC-to-DESC fitting algorithm or equilibrium solve behavior.

## Downstream diagnostic context

The figures below use a public W7-X finite-beta VMEC benchmark from the SIMSOPT test data. They are included only as context for why I audited the VMEC current output path; they are not private data and they are not the primary regression test for this PR.

In this downstream current-line diagnostic, using local current density computed from the fitted DESC `curl(B)` representation produces excessive toroidal drift for the W7-X case. Reconstructing the streamline direction from the VMEC current harmonics (`currumn/currvmn`) instead gives the expected near-poloidal closure. The empirical W7-X gate used here is a total toroidal span of `1/15` turn.

Static PNG preview of the interactive 3D Plotly diagnostic:

![3D Plotly preview: public W7-X current-line comparison](https://raw.githubusercontent.com/WenyinWei/DESC/pr-assets/desc-2258/pr-2258/w7x_current_line_3d_before_after.png)

Interactive 3D Plotly version: [download `w7x_current_line_3d_before_after.html` from this gist](https://gist.github.com/WenyinWei/0fa009550aaac47112d0e197be9820cd). GitHub does not execute Plotly HTML inline, so the intended workflow is to download the HTML file and open it locally in a browser. The direct raw HTML URL is also available [here](https://gist.githubusercontent.com/WenyinWei/0fa009550aaac47112d0e197be9820cd/raw/5516860a7ec3405a696aadb1fc9b566f2608fb20/w7x_current_line_3d_before_after.html).

A compact 2D toroidal-drift summary is also included for quick comparison:

![Public W7-X current-line diagnostic: DESC-local current has excessive toroidal drift, VMEC current harmonics close poloidally](https://gist.githubusercontent.com/WenyinWei/0fa009550aaac47112d0e197be9820cd/raw/a442fbc1ada147c55fbb006e45c1d6fba3fabe27/w7x_current_line_toroidal_drift_before_after.svg)

Figure-generation details:

- public input file: `simsopt/tests/test_files/wout_W7-X_without_coil_ripple_beta0p05_d23p4_tm_reference.nc`
- plotted surface: `rho = 0.75`
- four toroidal seed sections
- before/source diagnostic: DESC-local current from the fitted `curl(B)` representation, `phi_span_max = 0.1494` toroidal turns, gate failed
- after/source diagnostic: VMEC current harmonics mapped to the same PEST surface, `phi_span_max = 0.0221` toroidal turns, gate passed

## Reproduction

The two write-side issues fixed in this PR can be reproduced with the public asymmetric HELIOTRON fixture already present in the DESC test suite.

```python
from pathlib import Path
import tempfile

import numpy as np
from netCDF4 import Dataset

from desc.equilibrium import Equilibrium
from desc.vmec import VMECIO

root = Path("/path/to/DESC")
with tempfile.TemporaryDirectory() as tmp:
    out = Path(tmp) / "wout_HELIO_asym_desc.nc"
    vmec = Dataset(root / "tests/inputs/wout_HELIOTRON_asym_NTHETA50_NZETA100.nc", mode="r")
    eq = Equilibrium.load(root / "tests/inputs/HELIO_asym.h5")

    VMECIO.save(
        eq,
        str(out),
        surfs=vmec.variables["ns"][:],
        verbose=0,
        M_nyq=round(np.max(vmec.variables["xm_nyq"][:])),
        N_nyq=round(np.max(vmec.variables["xn_nyq"][:]) / eq.NFP),
        M_grid=round(np.max(vmec.variables["xm_nyq"][:])),
        N_grid=round(np.max(vmec.variables["xn_nyq"][:]) / eq.NFP),
    )

    desc = Dataset(out, mode="r")

    # Metadata check.
    assert desc.variables["jcuru"].long_name == (
        "flux surface average of sqrt(g)*J^theta, on full mesh"
    )
    assert desc.variables["jcurv"].long_name == (
        "flux surface average of sqrt(g)*J^zeta, on full mesh"
    )

    # Axis extrapolation check for the asymmetric sine current harmonics.
    s_full = np.linspace(0, 1, desc.dimensions["radius"].size)
    currumns = np.asarray(np.ma.filled(desc.variables["currumns"][:], np.nan), dtype=float)
    currvmns = np.asarray(np.ma.filled(desc.variables["currvmns"][:], np.nan), dtype=float)

    expected_currumns_axis = currumns[1, :] - (
        (currumns[2, :] - currumns[1, :]) / (s_full[2] - s_full[1]) * s_full[1]
    )
    expected_currvmns_axis = currvmns[1, :] - (
        (currvmns[2, :] - currvmns[1, :]) / (s_full[2] - s_full[1]) * s_full[1]
    )

    np.testing.assert_allclose(currumns[0, :], expected_currumns_axis)
    np.testing.assert_allclose(currvmns[0, :], expected_currvmns_axis)
```

On the current code, the first check exposes the `jcurv.long_name` assignment mistake, and the second check exposes the `currvmns[0, :]` typo in the asymmetric branch. This PR adds the same checks to `tests/test_vmec.py::test_vmec_save_asym`.

## Verification run locally

```bash
python3 -m py_compile desc/vmec.py tests/test_vmec.py
```

I also ran the standalone asymmetric HELIOTRON script above against this branch, and it passed the metadata and axis-extrapolation checks.

I did not run the full DESC pytest suite locally. The available environment in this checkout had the DESC runtime dependencies needed for the direct `VMECIO.save` check, but did not have `pytest` installed in that same environment. I expect CI to run the full test matrix, including the updated `test_vmec_save_asym` regression test.
