### PR TITLE
Add warning for batched mode when a sub objective has rev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 Changelog
 =========
 
+New Features
+
+- Added warning for when ``deriv_mode="batched"`` is used in an ``ObjectiveFunction`` where one or more sub-objectives is using ``rev`` mode differentiation. Also adds more info about the derivative mode and Jacobian chunk sizes when building the objective with ``verbose>1``.
+
 Performance Improvements
 
 - Improves memory management to reduce the base memory used during optimization while using `lsq-exact`, `lsq-auglag` and `fmin-auglag` optimizers.
 
-
 Bug Fixes
 
 - Fixes bug in ``auglag`` optimizers which prevented them from accepting solver hyperparameters.
+
 
 v0.17.3
 -------
@@ -18,7 +22,6 @@ New Features
 - Adds ``eq_fixed`` argument to ``BoundaryError`` to remove the equilibrium from the optimization. This can be used instead of adding a ``FixParameter(eq)`` constraint.
 - Adds `check_intersection` argument to `initialize_modular_coils`, `initialize_helical_coils` and `initialize_saddle_coils`
 - Default value of `check_intersection` for coil related functions now defaults to False (no check). Previously, the default was True, and this was causing redundant checks.
-- Added warning for when ``deriv_mode="batched"`` is used in an ``ObjectiveFunction`` where one or more sub-objectives is using ``rev`` mode differentiation. Also adds more info about the derivative mode and Jacobian chunk sizes when building the objective with ``verbose>1``.
 
 Performance Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ New Features
 - Adds ``eq_fixed`` argument to ``BoundaryError`` to remove the equilibrium from the optimization. This can be used instead of adding a ``FixParameter(eq)`` constraint.
 - Adds `check_intersection` argument to `initialize_modular_coils`, `initialize_helical_coils` and `initialize_saddle_coils`
 - Default value of `check_intersection` for coil related functions now defaults to False (no check). Previously, the default was True, and this was causing redundant checks.
+- Added warning for when ``deriv_mode="batched"`` is used in an ``ObjectiveFunction`` where one or more sub-objectives is using ``rev`` mode differentiation. Also adds more info about the derivative mode and Jacobian chunk sizes when building the objective with ``verbose>1``.
 
 Performance Improvements
 

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -511,6 +511,17 @@ class ObjectiveFunction(IOAble):
             else:
                 self._deriv_mode = "blocked"
 
+        warnif(
+            any((obj._deriv_mode == "rev") for obj in self.objectives)
+            and self._deriv_mode == "batched",
+            UserWarning,
+            "Using batched derivative mode, which performs fwd mode "
+            "differentiation of the entire objective, but one or more of the"
+            ' sub-objectives have deriv_mode="rev". It is recommended to use '
+            'deriv_mode="blocked", as these objective performances may suffer '
+            "in fwd mode.",
+        )
+
         errorif(
             isposint(self._jac_chunk_size) and self._deriv_mode in ["blocked"],
             ValueError,

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -511,9 +511,7 @@ class ObjectiveFunction(IOAble):
             else:
                 self._deriv_mode = "blocked"
 
-        rev_objs = [
-            o.__name__ for o in self.objectives if o._deriv_mode == "rev"
-        ]
+        rev_objs = [o.name for o in self.objectives if o._deriv_mode == "rev"]
         warnif(
             len(rev_objs) > 0 and self._deriv_mode == "batched",
             UserWarning,

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -512,7 +512,7 @@ class ObjectiveFunction(IOAble):
                 self._deriv_mode = "blocked"
 
         rev_objs = [
-            o.__class__.__name__ for o in self.objectives if o._deriv_mode == "rev"
+            o.__name__ for o in self.objectives if o._deriv_mode == "rev"
         ]
         warnif(
             len(rev_objs) > 0 and self._deriv_mode == "batched",

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -519,7 +519,7 @@ class ObjectiveFunction(IOAble):
             "differentiation of the entire objective, but one or more of the"
             ' sub-objectives have deriv_mode="rev". It is recommended to use '
             'deriv_mode="blocked", as these objective performances may suffer '
-            "in fwd mode.",
+            "in fwd mode, or may not even support reverse mode at all.",
         )
 
         errorif(

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -435,7 +435,7 @@ class ObjectiveFunction(IOAble):
                 pass
 
     @execute_on_cpu
-    def build(self, use_jit=None, verbose=1):
+    def build(self, use_jit=None, verbose=1):  # noqa: C901
         """Build the objective.
 
         Parameters
@@ -511,15 +511,18 @@ class ObjectiveFunction(IOAble):
             else:
                 self._deriv_mode = "blocked"
 
+        rev_objs = [
+            o.__class__.__name__ for o in self.objectives if o._deriv_mode == "rev"
+        ]
         warnif(
-            any((obj._deriv_mode == "rev") for obj in self.objectives)
-            and self._deriv_mode == "batched",
+            len(rev_objs) > 0 and self._deriv_mode == "batched",
             UserWarning,
-            "Using batched derivative mode, which performs fwd mode "
-            "differentiation of the entire objective, but one or more of the"
-            ' sub-objectives have deriv_mode="rev". It is recommended to use '
-            'deriv_mode="blocked", as these objective performances may suffer '
-            "in fwd mode, or may not even support reverse mode at all.",
+            "'batched' deriv_mode differentiates the whole ObjectiveFunction in "
+            "forward mode, but these sub-objectives are set to use reverse mode "
+            "(either automatically, from their input/output sizes, or by user): "
+            f"{rev_objs}. In forward mode these may under-perform, or may not "
+            "work at all. Consider 'blocked' deriv_mode. See the sub-objective "
+            "docstrings for details.",
         )
 
         errorif(
@@ -557,6 +560,12 @@ class ObjectiveFunction(IOAble):
 
         timer.stop("Objective build")
         if verbose > 1:
+            print(f"{self.name} deriv_mode : {self._deriv_mode}")
+            if self._deriv_mode == "batched":
+                print(f"{self.name} jac_chunk_size: {self._jac_chunk_size}")
+            else:
+                for o in self.objectives:
+                    print(f"{o.name} jac_chunk_size: {o._jac_chunk_size}")
             timer.disp("Objective build")
 
     def _set_things(self, things=None):

--- a/desc/objectives/objective_funs.py
+++ b/desc/objectives/objective_funs.py
@@ -520,9 +520,10 @@ class ObjectiveFunction(IOAble):
             "'batched' deriv_mode differentiates the whole ObjectiveFunction in "
             "forward mode, but these sub-objectives are set to use reverse mode "
             "(either automatically, from their input/output sizes, or by user): "
-            f"{rev_objs}. In forward mode these may under-perform, or may not "
-            "work at all. Consider 'blocked' deriv_mode. See the sub-objective "
-            "docstrings for details.",
+            f"{rev_objs}. \n"
+            "In forward mode these may under-perform, or they may not "
+            "support forward mode. Consider 'blocked' deriv_mode. See the "
+            "sub-objective docstrings for details.",
         )
 
         errorif(

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -2346,7 +2346,8 @@ def test_derivative_modes():
         jac_chunk_size="auto",
         use_jit=False,
     )
-    obj1.build()
+    with pytest.warns(UserWarning, match="batched"):
+        obj1.build()
     obj2.build()
     # check that default size works for blocked
     assert obj2.objectives[0]._jac_chunk_size == 2
@@ -2354,7 +2355,8 @@ def test_derivative_modes():
     assert obj2.objectives[2]._jac_chunk_size is None
     # hard to say what size auto will give, just check it is >0
     assert obj1._jac_chunk_size > 0
-    obj3.build()
+    with pytest.warns(UserWarning, match="batched"):
+        obj3.build()
     x = obj1.x(eq, surf)
     v = jnp.ones_like(x)
     g1 = obj1.grad(x)


### PR DESCRIPTION
Does not resolve #2243 but at least warns users of the situation occuring

I am not sure if we can do batched as not fwd mode: maybe we can do it as like batched all at once but in reverse mode if all sub-objectives are rev mode.
Either way this will just throw a warning in the case that batched is set as ObjectiveFunction deriv_mode but any sub objective has rev mode, since that indicates a probable inefficiency. 