### PR TITLE
Minor bug fix in augmented lagrangian solvers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Bug Fixes
 - Fixes bug in ``reactor_QA.py`` script where the current profile was allowed to have a nonzero rho^1 component, which resulted in an unphysical profile near-axis.
     - Updates ``"reactor_QA"`` in ``desc.examples`` to fix this. Note that if using ``"reactor_QA"`` example from ``v0.16.0`` until this fix, the current profile in that example has this issue.
 - Fixes bug in `CoilSet.from_symmetry` that ignored the passed in `check_intersection` value. This caused redundant checks in various other functions such as `plot_coils`.
-- Fixes bug in ``auglag`` optimizers which prevented it from accepting solver hyperparameters.
+- Fixes bug in ``auglag`` optimizers which prevented them from accepting solver hyperparameters.
 
 
 Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Bug Fixes
 
 - Fixes bug in ``auglag`` optimizers which prevented them from accepting solver hyperparameters.
 
-v0.17.2
+v0.17.3
 -------
 
 New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Bug Fixes
 - Fixes bug in ``reactor_QA.py`` script where the current profile was allowed to have a nonzero rho^1 component, which resulted in an unphysical profile near-axis.
     - Updates ``"reactor_QA"`` in ``desc.examples`` to fix this. Note that if using ``"reactor_QA"`` example from ``v0.16.0`` until this fix, the current profile in that example has this issue.
 - Fixes bug in `CoilSet.from_symmetry` that ignored the passed in `check_intersection` value. This caused redundant checks in various other functions such as `plot_coils`.
+- Fixes bug in ``auglag`` optimizers which prevented it from accepting solver hyperparameters.
+
 
 Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Performance Improvements
 - Improves memory management to reduce the base memory used during optimization while using `lsq-exact`, `lsq-auglag` and `fmin-auglag` optimizers.
 
 
+Bug Fixes
+
+- Fixes bug in ``auglag`` optimizers which prevented them from accepting solver hyperparameters.
+
 v0.17.2
 -------
 
@@ -33,7 +37,6 @@ Bug Fixes
 - Fixes bug in ``reactor_QA.py`` script where the current profile was allowed to have a nonzero rho^1 component, which resulted in an unphysical profile near-axis.
     - Updates ``"reactor_QA"`` in ``desc.examples`` to fix this. Note that if using ``"reactor_QA"`` example from ``v0.16.0`` until this fix, the current profile in that example has this issue.
 - Fixes bug in `CoilSet.from_symmetry` that ignored the passed in `check_intersection` value. This caused redundant checks in various other functions such as `plot_coils`.
-- Fixes bug in ``auglag`` optimizers which prevented them from accepting solver hyperparameters.
 
 
 Breaking Changes

--- a/desc/optimize/aug_lagrangian.py
+++ b/desc/optimize/aug_lagrangian.py
@@ -384,12 +384,6 @@ def fmin_auglag(  # noqa: C901
     tr_decrease_ratio = options.pop("tr_decrease_ratio", 0.25)
     tr_method = options.pop("tr_method", "exact")
 
-    errorif(
-        len(options) > 0,
-        ValueError,
-        "Unknown options: {}".format([key for key in options]),
-    )
-
     callback = setdefault(callback, lambda *args: False)
 
     methods = {
@@ -425,6 +419,12 @@ def fmin_auglag(  # noqa: C901
     alpha_eta = options.pop("alpha_eta", 0.1)
     beta_eta = options.pop("beta_eta", 0.9)
     tau = options.pop("tau", 10)
+
+    errorif(
+        len(options) > 0,
+        ValueError,
+        "Unknown options: {}".format([key for key in options]),
+    )
 
     gtolk = max(omega / jnp.mean(mu) ** alpha_omega, gtol)
     ctolk = max(eta / jnp.mean(mu) ** alpha_eta, ctol)

--- a/desc/optimize/aug_lagrangian_ls.py
+++ b/desc/optimize/aug_lagrangian_ls.py
@@ -319,11 +319,6 @@ def lsq_auglag(  # noqa: C901
     tr_method = options.pop("tr_method", "qr")
 
     errorif(
-        len(options) > 0,
-        ValueError,
-        "Unknown options: {}".format([key for key in options]),
-    )
-    errorif(
         tr_method not in ["cho", "svd", "qr"],
         ValueError,
         "tr_method should be one of 'cho', 'svd', 'qr', got {}".format(tr_method),
@@ -352,6 +347,12 @@ def lsq_auglag(  # noqa: C901
     alpha_eta = options.pop("alpha_eta", 0.1)
     beta_eta = options.pop("beta_eta", 0.9)
     tau = options.pop("tau", 10)
+
+    errorif(
+        len(options) > 0,
+        ValueError,
+        "Unknown options: {}".format([key for key in options]),
+    )
 
     gtolk = max(omega / jnp.mean(mu) ** alpha_omega, gtol)
     ctolk = max(eta / jnp.mean(mu) ** alpha_eta, ctol)


### PR DESCRIPTION
`Auglag` solvers are not accepting hyperparameters like `omega`, `eta`, ..., `tau`, due to an error check that comes before all options have been popped. This just moves the error check later in the function. 