### PR TITLE
Handle zero Gershgorin bound in modified Cholesky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Performance Improvements
 Bug Fixes
 
 - Fixes bug in ``auglag`` optimizers which prevented them from accepting solver hyperparameters.
+- Fixes bug in modified Cholesky factorization used by the trust-region
+  subproblems when the Gershgorin lower bound of the Hessian was exactly zero
+  (e.g. a Hessian with an all-zero row), producing NaN steps in ``fmintr`` and
+  ``fmin-auglag`` with the default ``tr_method="exact"``, and in
+  ``lsq-exact``/``lsq-auglag`` with ``tr_method="cho"``.
 
 v0.17.3
 -------

--- a/desc/optimize/utils.py
+++ b/desc/optimize/utils.py
@@ -187,8 +187,9 @@ def _cholmod(A, maxiter=4):
     Attempts to find smallest alpha to the nearest order of magnitude,
     in maxiter steps (so 2**maxiter values of alpha will be scanned over).
     Scans over values of -log(abs(lb))< log(alpha) < log(abs(lb)). If the
-    Gershgorin lower bound is zero, a matrix-scaled machine epsilon supplies
-    the positive reference value for the logarithmic search.
+    Gershgorin lower bound is zero, a matrix-scaled machine epsilon, floored
+    at the dtype's smallest normal value, supplies the positive reference
+    value for the logarithmic search.
 
     Cost is approximately maxiter times the cost of a single cholesky
     factorization.
@@ -217,10 +218,14 @@ def _cholmod(A, maxiter=4):
     abs_lb = jnp.abs(lb)
     scale = jnp.max(jnp.abs(A))
     scale = jnp.where(scale > 0, scale, jnp.ones_like(scale))
+    fallback_scale = jnp.maximum(
+        jnp.finfo(scale.dtype).eps * scale,
+        jnp.finfo(scale.dtype).tiny,
+    )
     alpha_scale = jnp.where(
         abs_lb > 0,
         abs_lb,
-        jnp.finfo(scale.dtype).eps * scale,
+        fallback_scale,
     )
     # upper bound on log(alpha) such that A + alpha*I > 0, ie we know alpha < ub
     # lower bound on eig(A) = upper bound on alpha, +1 in log scale to make sure

--- a/desc/optimize/utils.py
+++ b/desc/optimize/utils.py
@@ -186,7 +186,7 @@ def _cholmod(A, maxiter=4):
 
     Attempts to find smallest alpha to the nearest order of magnitude,
     in maxiter steps (so 2**maxiter values of alpha will be scanned over).
-    Scans over values of -log(abs(lb))< log(alpha) < log(abs(lb)). If the
+    Scans over values of -log(abs(lb)) < log(alpha) < log(abs(lb)). If the
     Gershgorin lower bound is zero, a matrix-scaled machine epsilon, floored
     at the dtype's smallest normal value, supplies the positive reference
     value for the logarithmic search.

--- a/desc/optimize/utils.py
+++ b/desc/optimize/utils.py
@@ -186,7 +186,9 @@ def _cholmod(A, maxiter=4):
 
     Attempts to find smallest alpha to the nearest order of magnitude,
     in maxiter steps (so 2**maxiter values of alpha will be scanned over).
-    Scans over values of -log(abs(lb))< log(alpha) < log(abs(lb))
+    Scans over values of -log(abs(lb))< log(alpha) < log(abs(lb)). If the
+    Gershgorin lower bound is zero, a matrix-scaled machine epsilon supplies
+    the positive reference value for the logarithmic search.
 
     Cost is approximately maxiter times the cost of a single cholesky
     factorization.
@@ -211,15 +213,24 @@ def _cholmod(A, maxiter=4):
     n = A.shape[0]
     eye = jnp.eye(n)
     # upper and lower bounds on eig(A)
-    lb, ub = gershgorin_bounds(A)
+    lb, _ = gershgorin_bounds(A)
+    abs_lb = jnp.abs(lb)
+    scale = jnp.max(jnp.abs(A))
+    scale = jnp.where(scale > 0, scale, jnp.ones_like(scale))
+    alpha_scale = jnp.where(
+        abs_lb > 0,
+        abs_lb,
+        jnp.finfo(scale.dtype).eps * scale,
+    )
     # upper bound on log(alpha) such that A + alpha*I > 0, ie we know alpha < ub
     # lower bound on eig(A) = upper bound on alpha, +1 in log scale to make sure
     # that it's actually greater than the maximum alpha
-    ub = jnp.log10(jnp.abs(lb)) + 1
+    ub = jnp.log10(alpha_scale) + 1
     # we know alpha > 0 because otherwise initial factorization would have succeeded
     # but we'd like to be a bit better (in log scaling). This is just a heuristic but
     # seems ok in practice
     m = jnp.mean(jnp.abs(A))
+    m = jnp.where(m > 0, m, alpha_scale)
     lb = ub - 2 * abs(ub) - abs(jnp.log10(m))
     # values to try
     alphas = jnp.logspace(lb, ub, k)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -123,6 +123,26 @@ def test_chol_zero_gershgorin_lower_bound(matrix):
 
 
 @pytest.mark.unit
+def test_chol_extreme_small_zero_gershgorin_lower_bound():
+    """The zero-bound fallback remains positive below eps-scaled normal range."""
+    matrix = np.diag(np.array([1e-300, 0.0], dtype=np.float64))
+
+    factor = np.asarray(chol(jnp.asarray(matrix)))
+    reconstructed = factor @ factor.T
+    correction = reconstructed - matrix
+
+    assert np.isfinite(factor).all()
+    assert np.linalg.eigvalsh(reconstructed).min() > 0.0
+    np.testing.assert_allclose(
+        correction,
+        np.eye(2) * correction[0, 0],
+        rtol=0.0,
+        atol=np.finfo(np.float64).tiny,
+    )
+    assert 0.0 < correction[0, 0] < matrix[0, 0]
+
+
+@pytest.mark.unit
 def test_chol_positive_definite_path_unchanged():
     """Positive-definite input agrees with the unmodified Cholesky oracle."""
     matrix = np.array([[2.0, 0.2], [0.2, 1.0]])

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -73,6 +73,7 @@ from desc.optimize import (
     sgd,
 )
 from desc.optimize.optimizer import _parse_x_scale
+from desc.optimize.utils import chol, gershgorin_bounds
 from desc.utils import get_all_instances
 
 
@@ -101,6 +102,36 @@ SCALAR_FUN_SOLN = np.array(
         (-B1 + np.sqrt(B1**2 - 4 * A1 * C1)) / (2 * A1),
     ]
 )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("matrix", [np.zeros((2, 2)), np.diag([1.0, 0.0])])
+def test_chol_zero_gershgorin_lower_bound(matrix):
+    """A zero lower bound gets a finite, small positive diagonal correction."""
+    lower_bound, _ = gershgorin_bounds(jnp.asarray(matrix))
+    assert float(lower_bound) == 0.0
+
+    factor = np.asarray(chol(jnp.asarray(matrix)))
+    reconstructed = factor @ factor.T
+    scale = max(np.linalg.norm(matrix, ord=2), 1.0)
+
+    assert np.isfinite(factor).all()
+    assert np.linalg.eigvalsh(reconstructed).min() > 0.0
+    assert np.linalg.norm(reconstructed - matrix, ord=2) < (
+        100 * np.finfo(matrix.dtype).eps * scale
+    )
+
+
+@pytest.mark.unit
+def test_chol_positive_definite_path_unchanged():
+    """Positive-definite input agrees with the unmodified Cholesky oracle."""
+    matrix = np.array([[2.0, 0.2], [0.2, 1.0]])
+    np.testing.assert_allclose(
+        chol(jnp.asarray(matrix)),
+        np.linalg.cholesky(matrix),
+        rtol=1e-14,
+        atol=1e-14,
+    )
 
 
 @jit


### PR DESCRIPTION
Fixes #2296

Use a scale-aware positive fallback when the Gershgorin lower bound is exactly zero, including matrices at extreme subnormal scale. The positive-definite path remains unchanged.

Validation:
- optimizer test module: 93 passed
- focused zero, singular, extreme-scale, and positive-definite oracles passed
- pre-commit hooks on changed files passed