### PR TITLE
Change to `CoilSetLinkingNumber`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Performance Improvements
 Bug Fixes
 
 - Fixes bug in ``auglag`` optimizers which prevented them from accepting solver hyperparameters.
+- Fixes computation of ``CoilSetLinkingNumber`` to exclude coil writhe.
 
 v0.17.3
 -------

--- a/desc/coils.py
+++ b/desc/coils.py
@@ -1732,6 +1732,8 @@ class CoilSet(OptimizableCollection, _Coil, MutableSequence):
         link : ndarray, shape(num_coils, num_coils)
             Linking number of each coil with each other coil. link=0 means they are not
             linked, +/- 1 means the coils link each other in one direction or another.
+            Diagonal entries represent the writhe of a coil, and can be non-zero for
+            non-planar coils.
 
         """
         if grid is None:

--- a/desc/objectives/_coils.py
+++ b/desc/objectives/_coils.py
@@ -2634,7 +2634,9 @@ class CoilSetLinkingNumber(_Objective):
             params=params, grid=constants["grid"]
         )
 
-        return jnp.abs(link).sum(axis=0)
+        # the diagonal entries of "link" should be excluded
+        mask = ~jnp.eye(self._dim_f, dtype=bool)
+        return jnp.abs(link).sum(axis=0, where=mask)
 
 
 class SurfaceCurrentRegularization(_Objective):

--- a/tests/test_coils.py
+++ b/tests/test_coils.py
@@ -1459,9 +1459,12 @@ def test_linking_number():
     link = coilset2._compute_linking_number(grid=grid)
 
     # modular coils don't link each other
+    # note we remove diagonal entries explicitly, as they do not
+    # represent linking numbers (they are zero here anyway).
+    mask = ~jnp.eye(link.shape[0], dtype=bool)
+    link = jnp.where(mask, link, 0)
     np.testing.assert_allclose(link[:-1, :-1], 0, atol=1e-14)
-    # axis coil doesn't link itself
-    np.testing.assert_allclose(link[-1, -1], 0, atol=1e-14)
+
     # we expect the axis coil to link all the modular coils, with alternating sign
     # due to alternating orientation of the coils due to symmetry.
     expected = [1, -1] * 5

--- a/tests/test_objective_funs.py
+++ b/tests/test_objective_funs.py
@@ -1758,6 +1758,7 @@ class TestObjectiveFunction:
         # one way and half going the other way
         coilset = CoilSet.from_symmetry(coil, NFP=5, sym=True, check_intersection=False)
         coil2 = FourierRZCoil()
+
         # add a coil along the axis that links all the other coils
         coilset2 = MixedCoilSet(coilset, coil2, check_intersection=False)
 
@@ -1768,6 +1769,17 @@ class TestObjectiveFunction:
         # while the axis links all 10 modular coils
         expected = np.array([1] * 10 + [10])
         np.testing.assert_allclose(out, expected, rtol=1e-3)
+
+        # produce a coilset of non-planar coils with nonzero writhe
+        coil3 = FourierXYZCoil(
+            X_n=[0, 0.5, 5, 1, 0], Y_n=[0, 0, 0, 0, 0.5], Z_n=[0, -1, 0, 0, 1]
+        )
+        coilset3 = CoilSet.from_symmetry(coil3, NFP=5, check_intersection=False)
+        obj = CoilSetLinkingNumber(coilset3)
+        obj.build()
+        out = obj.compute_scaled_error(coilset3.params_dict)
+        expected = np.array([0] * 5)
+        np.testing.assert_allclose(out, expected, atol=1e-12)
 
     @pytest.mark.unit
     def test_signed_plasma_vessel_distance(self):


### PR DESCRIPTION
The current linking number objective returns, for each coil, the sum of Gauss integrals with respect to every coil. This includes a coil's integral with itself, which can be nonzero even if there is no linking. One of the changed tests has such a coilset. This PR removes those terms from the objective.

The stage 2 notebook uses this objective, so I can rerun it and see if the results change.

