### PR TITLE
Keep `solve_options` from being mutated in `ProximalProjection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Bug Fixes
   (e.g. a Hessian with an all-zero row), producing NaN steps in ``fmintr`` and
   ``fmin-auglag`` with the default ``tr_method="exact"``, and in
   ``lsq-exact``/``lsq-auglag`` with ``tr_method="cho"``.
-
+- Stops `ProximalProjection` from mutating `solve_options` during iterations.
 
 v0.17.3
 -------

--- a/desc/optimize/optimizer.py
+++ b/desc/optimize/optimizer.py
@@ -192,7 +192,7 @@ class Optimizer(IOAble):
             and constraints in the ``Objective values`` key.
 
         """
-        options = {} if options is None else options
+        options = {} if options is None else options.copy()
         is_linear_proj = isinstance(objective, LinearConstraintProjection)
         if not isinstance(constraints, (tuple, list)) and not is_linear_proj:
             constraints = (constraints,)


### PR DESCRIPTION
Addresses issue #2312. The only change is to have Optimizer.optimize() work with a copy of the input options. 